### PR TITLE
feat: ship Sounding v0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,36 @@
 
 Sounding is a testing framework for Sails applications and The Boring JavaScript Stack.
 
-This repository currently starts with research and product design work for an elegant testing story built on:
-- the native Node.js test runner
-- Playwright for browser testing
-- Captain Vane for factories and scenarios
+It is designed to be:
+- a Sails hook first
+- a CLI second
+- powered by the native Node.js test runner
+- integrated with Playwright for browser testing
+- elegant for helper, endpoint, JSON API, Inertia, mail, and browser trials
+
+The canonical Sails-native surface is:
+- optional `config/sounding.js` when you need overrides
+- `sails.sounding`
+- `sails.helpers.user.signupWithTeam(...)` inside trials
+- `get('/api/issues')` or `sails.sounding.request.get('/api/issues')` inside endpoint-style trials
+- request helpers default to Sails virtual requests powered by `sails.request()`
+- Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
+- a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`
+- any trial can also scope a request client with `sails.sounding.request.using('http')`
+
+Sounding also owns its own built-in world engine, so the same package can:
+- define factories under `tests/factories`
+- define scenarios under `tests/scenarios`
+- load named worlds for endpoint and browser trials
+- capture outgoing mail by wrapping `sails.helpers.mail.send` and storing normalized messages in `sails.sounding.mailbox`
+
+The default configuration story is intentionally calm:
+- Sounding manages a temporary `sails-sqlite` datastore by default
+- managed SQLite artifacts live under `.tmp/db`
+- the default datastore identity is `default`
+- browser projects start with `desktop`
+- `inherit` remains available when an app already has a serious test datastore story
+
+This repository starts with docs-driven product research and the first hook/runtime scaffolding for that vision.
 
 See `RESEARCH.md`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,104 @@
+# Sounding 0.0.1
+
+Sounding `0.0.1` is the first public release of a Sails-native testing framework for Sails applications and The Boring JavaScript Stack.
+
+This release establishes the core shape of Sounding:
+
+- one `test()` API
+- a Sails-centered trial context
+- request-level trials through `get()`, `post()`, and friends
+- Inertia-aware trials through `visit()`
+- browser-capable trials when `{ browser: true }` is present
+- managed SQLite test datastores under `.tmp/db` by default
+- real mail capture through the Sails mail path
+- worlds, factories, scenarios, and actors as first-class testing concepts
+
+## Highlights
+
+### One testing story
+
+Sounding keeps the native Node test runner feel, but gives Sails apps one coherent runtime:
+
+- `sails` at the center of every trial
+- `sails.helpers`, `sails.models`, `sails.config`, and `sails.hooks` where you expect them
+- `sails.sounding` for Sounding-specific capabilities
+
+### Native request and Inertia support
+
+Sounding supports both fast virtual requests and real HTTP, while preserving one request API.
+
+- `get()`, `post()`, `put()`, `patch()`, `del()`
+- `visit()` for Inertia responses and page contracts
+- transport switching when true HTTP parity matters
+
+### Browser-capable trials
+
+When the browser actually matters, Sounding can furnish browser context directly inside `test()`:
+
+- `page`
+- `browser`
+- `browserContext`
+- auth helpers and browser flows on the same test surface
+
+### Built for Sails conventions
+
+Sounding embraces Sails concepts instead of asking Sails apps to translate into a different testing mental model:
+
+- trials
+- trial context
+- worlds
+- actors
+- scenarios
+- datastores
+
+### Convention over configuration
+
+Most apps do not need a `config/sounding.js` file at all.
+
+By default, Sounding will:
+
+- manage a `sails-sqlite` datastore
+- keep artifacts under `.tmp/db`
+- clean up managed test artifacts automatically
+- capture mail in-memory through the real mail flow
+
+## Included in 0.0.1
+
+- Sounding Sails hook runtime
+- `test()` API
+- request transport layer with virtual and HTTP support
+- Inertia-oriented `visit()` API
+- default managed datastore orchestration
+- mail capture
+- world engine foundations
+- docs on Sailscasts
+- Boring Stack testing skill and template alignment
+- first real dogfood usage in The African Engineer
+
+## Notes
+
+- `0.0.1` is intentionally small, but real
+- the API is coherent enough to dogfood in production apps
+- some areas will keep evolving quickly as more apps adopt Sounding
+
+## Install
+
+```bash
+npm install -D sounding
+```
+
+Then write trials with:
+
+```js
+const { test } = require('sounding')
+```
+
+And run:
+
+```bash
+npm run test
+```
+
+## Thanks
+
+This release exists because we pushed beyond a pile of disconnected testing tools and insisted on one elegant story for Sails apps.

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -6,16 +6,16 @@ Sounding is a testing framework for Sails applications and The Boring JavaScript
 
 It should make it feel natural to test:
 - helpers and business logic
-- actions and endpoints
+- actions, endpoints, and JSON APIs
 - Inertia responses
 - authentication flows
 - email flows
 - browser journeys
-- sockets, jobs, payments, and webhooks over time
+- sockets, jobs, payments, uploads, and webhooks over time
 
 The key idea is simple:
 
-**Use the native Node.js test runner, use Playwright for browser work, and wrap both in a Sails-aware runtime that makes realistic tests easy to write and easy to trust.**
+**Use the native Node.js test runner, use Playwright for browser work, and wrap both in a Sails-native runtime that makes realistic tests easy to write and easy to trust.**
 
 This should feel less like "yet another framework" and more like the missing test home for everything TBJS already does.
 
@@ -27,7 +27,7 @@ It is how mariners probe unknown waters, verify what is safe, and learn what lie
 
 That maps naturally to testing.
 
-Sounding gives us a name that suggests:
+Sounding suggests:
 - probing the system
 - measuring the unknown
 - learning before committing
@@ -37,7 +37,7 @@ It is also:
 - one word
 - maritime without being too cute
 - broad enough for unit, integration, endpoint, and browser testing
-- distinct from Captain Vane, which can remain the data/scenario engine underneath
+- broad enough to grow into the full Sails-native testing story
 
 ## The problem we are actually solving
 
@@ -46,7 +46,7 @@ The TBJS testing story is close, but still fragmented.
 Today we have pieces:
 - `node:test` for unit-style tests
 - Playwright for browser flows
-- `inertia-sails/test` for response assertions
+- `inertia-sails/test` for response assertions today
 - `getSails()` patterns for loading the app in tests
 - ad hoc seeding and fixture code per application
 
@@ -57,65 +57,381 @@ Current pain points:
 - data setup is repetitive and not expressive enough
 - E2E and app boot orchestration can get ugly fast
 - `sails-disk` and multi-process test setups collide in painful ways
-- realistic auth/email/payment flows are still too manual to test cleanly
+- realistic auth, email, and payment flows are still too manual to test cleanly
 - people are tempted to add app-code test hooks just to make tests possible
 
 The missing thing is not just a test runner.
 
 The missing thing is an **elegant testing story**.
 
+## Product goals
+
+Sounding should be:
+- unmistakably Sails-native
+- expressive enough for product-behavior tests
+- boring to maintain
+- delightful to write
+- credible for API-only apps, Inertia apps, and browser-heavy apps
+
 ## Design principles
 
 ### 1. Native first
 Sounding should build on the native Node.js test runner, not compete with it.
 
-### 2. Sails-aware, not Sails-entangled
-It should understand helpers, actions, policies, sessions, Waterline, Inertia, mail, sockets, and jobs.
+### 2. Hook first
+Sounding should be a Sails hook first and a CLI second.
+
+### 3. Sails-aware, not Sails-entangled
+It should understand helpers, actions, policies, sessions, Waterline, Inertia, mail, sockets, uploads, and jobs.
 But it should not force awkward test-only app code.
 
-### 3. Tests own test data
+### 4. Tests own test data
 Factories, traits, scenarios, and fixtures should live under `tests/`, not in the app runtime.
 
-### 4. One live runtime per browser flow
-For E2E, there should be one real app instance and one isolated test database. No shadow app instances fighting the same datastore.
+### 5. One live runtime per browser flow
+For E2E, there should be one real app instance and one isolated test datastore. No shadow app instances fighting the same datastore.
 
-### 5. Disposable databases by default
-For serious end-to-end or endpoint testing, the default should be a temporary SQLite database per run or per worker, stored under `/tmp`, not `sails-disk`.
+### 6. Good datastore defaults
+Sounding should respect normal Sails test configuration first.
 
-### 6. Realistic over synthetic
+By default, Sounding should manage a temporary `sails-sqlite` datastore under `.tmp/db`.
+When teams want stronger isolation with less ceremony, Sounding should be able to manage a temporary `sails-sqlite` datastore per run or per worker.
+
+The helper surface should mirror Sails itself: `sails.helpers.user.signupWithTeam(inputs)` should be the happy path.
+
+### 7. Realistic over synthetic
 The goal is not mocking everything. The goal is real flows with as little fake plumbing as possible.
 
-### 7. Minimal magic
+### 8. Minimal magic
 The best APIs should feel obvious. The framework should save time, not hide too much.
 
-### 8. Great failure output
+### 9. Great failure output
 When a test fails, the developer should know:
 - what world was created
 - what request or browser step failed
+- what actor was involved
 - what the relevant app state was
+
+## Hook-first architecture
+
+Sounding should be a **Sails hook first** and a **CLI second**.
+
+### Canonical runtime surfaces
+- `sails.hooks.sounding` - internal hook runtime
+- `sails.sounding` - ergonomic public alias for app and test usage
+- `config/sounding.js` - the primary configuration surface
+
+### What we should not do
+- we should **not** split the mental model between `sails.test` and `sails.sounding`
+- we should **not** use `config/test.js` as the main Sounding config namespace
+
+`config/sounding.js` is the Sails-native answer because it behaves like every other serious subsystem in the ecosystem:
+- `config/mail.js`
+- `config/quest.js`
+- `config/clearance.js`
+- `config/shipwright.js`
+
+### Config shape
+
+```js
+// config/sounding.js
+module.exports.sounding = {
+  world: {
+    factories: 'tests/factories',
+    scenarios: 'tests/scenarios',
+    seed: 1337,
+  },
+
+  datastore: {
+    mode: 'managed',
+    identity: 'default',
+
+    managed: {
+      adapter: 'sails-sqlite',
+      isolation: 'worker',
+    },
+  },
+
+  browser: {
+    enabled: true,
+    baseUrl: 'http://127.0.0.1:3333',
+    projects: ['desktop'],
+  },
+
+  mail: {
+    capture: true,
+  },
+
+  request: {
+    transport: 'virtual',
+  },
+
+  auth: {
+    defaultActor: 'guest',
+  },
+}
+```
+
+### Default behavior
+
+Sounding should ship with calm, predictable defaults:
+- `datastore.mode = 'managed'`
+- `datastore.identity = 'default'`
+- `datastore.adapter = 'sails-sqlite'`
+- `datastore.isolation = 'worker'`
+- `world.factories = 'tests/factories'`
+- `world.scenarios = 'tests/scenarios'`
+- `mail.capture = true`
+- `request.transport = 'virtual'`
+- `browser.projects = ['desktop']`
+
+Environment-specific overrides should still live in `config/env/test.js`, but `config/sounding.js` should be the home of the Sounding subsystem itself.
+
+## The core mental model
+
+Sounding should feel like this:
+
+- **App**: a booted Sails application under test
+- **World**: a realistic, named set of data created for a test
+- **Actor**: a user role in that world
+- **Trial**: the test itself
+- **Mailbox**: captured outbound mail for assertions
+- **Browser**: Playwright page and context helpers
+
+The tests should read like behavior, not setup plumbing.
+
+
+## What a trial means
+
+A **trial** is the smallest meaningful behavior Sounding asks your app to prove.
+
+It is one named claim about how the product should behave in a real Sails runtime.
+
+Examples:
+
+- a guest is redirected from the dashboard
+- a subscriber can read a members-only issue
+- a publisher can save a draft
+- requesting a magic link sends a usable email
+
+This stays close to the mental model developers already know from Jest, Pest, and the native Node test runner: one file groups related checks, and each named check proves one thing.
+
+Sounding keeps the familiar `test()` API, but uses **trial** as the conceptual word because the framework is designed around product behaviors, worlds, actors, and realistic runtime conditions.
+
+A good trial should be:
+
+- named after behavior, not implementation
+- small enough to understand quickly
+- real enough to trust
+- written at the right layer for what it is proving
+
+## What a trial context means
+
+A **trial context** is the single object passed into `test()`.
+
+It should always have one clear center of gravity: `sails`.
+
+That means:
+- `sails` is the primary runtime object
+- app-native surfaces stay where Sails developers expect them
+- Sounding capabilities live under `sails.sounding`
+- a few top-level aliases like `get()` and `post()` can exist for convenience
+- `expect` is always present
+
+This is important because Sounding should not invent a second pretend app model.
+The trial context should feel like a real Sails app that has been furnished for testing.
+
+## Design patterns for Sounding
+
+These are the patterns that should keep Sounding elegant as it grows.
+
+### 1. Runtime-rooted context
+
+Every trial should start from the real app runtime:
+
+- `sails` is the primary object
+- `sails.helpers`, `sails.models`, `sails.config`, and `sails.hooks` stay canonical
+- Sounding-specific capabilities hang off `sails.sounding`
+
+This keeps Sounding from inventing a second fake app model.
+
+### 2. Capability aliases, not parallel abstractions
+
+Top-level helpers like `get()`, `post()`, and `visit()` should exist as ergonomic shortcuts.
+
+But they should always map back to a canonical home like:
+
+- `sails.sounding.request.get()`
+- `sails.sounding.request.post()`
+- `sails.sounding.visit()`
+
+That gives us convenience without splitting the mental model.
+
+### 3. Worlds as business situations
+
+Worlds should describe business state, not just rows in a datastore.
+
+That means:
+
+- scenarios should read like product situations
+- actors should be role-based
+- tests should load a world instead of assembling ten unrelated records
+
+### 4. Calm defaults, explicit escalation
+
+Sounding should respect the app before it tries to be clever:
+
+- manage a temporary `sails-sqlite` datastore by default
+- use `config/env/test.js` as the app's truth
+- let teams opt into `inherit` or `external` only when they truly need them
+
+This keeps the first experience simple and the advanced experience deliberate.
+
+### 5. Progressive disclosure
+
+The beginner path should be tiny:
+
+- `test()`
+- `sails`
+- `expect`
+
+Then as the need grows, the trial can reach for:
+
+- `get()` / `post()`
+- `sails.sounding.world`
+- `sails.sounding.mailbox`
+- `page`
+
+We should not force complexity on the first test.
+
+### 6. Lazy heavyweight surfaces
+
+The heaviest tools should only boot when a trial really needs them.
+
+That includes:
+
+- Playwright browser state
+- mailbox capture integrations
+- richer Inertia helpers
+
+This keeps helper and endpoint trials fast without creating a separate API universe.
+
+### 7. One assertion style
+
+`expect` should be the primary assertion API everywhere.
+
+That means the same mental style for:
+
+- helpers
+- JSON APIs
+- Inertia responses
+- mail
+- browser assertions
+
+## What is a world?
+
+A world should be documented and taught as one of Sounding's signature ideas, not a side feature.
+
+The docs need to make these distinctions obvious:
+
+- a **factory** builds one kind of record
+- a **scenario** composes factories into a named business situation
+- an **actor** is the role a trial operates through inside that situation
+- the resulting **world** is the readable state the trial uses
+
+The best worlds should feel like product language, not seed-script language.
+
+
+A **world** is the named, deterministic business state that a trial lives inside.
+
+A world includes:
+- actors such as guests, publishers, subscribers, or admins
+- records like issues, subscriptions, teams, unlocks, invoices, or comments
+- the relationships between those records
+- the current business situation the trial cares about
+
+A world is not just a fixture.
+
+It is a reusable description of a product situation.
+
+That lets tests say:
+- "load the subscriber who has access to a gated issue"
+- "load the publisher with a draft issue"
+- "load the guest who requested a magic link"
+
+instead of rewriting ten lines of setup every time.
+
+## The built-in world engine
+
+Sounding should own its own world engine.
+
+That means factories, traits, states, scenarios, seeds, and world composition should live inside Sounding itself.
+
+This keeps the testing story elegant:
+- one package
+- one mental model
+- one configuration surface
+- one documentation story
+- one runtime that understands app boot, data setup, mail capture, and browser execution together
+
+### The world engine should own
+- factories
+- traits and states
+- sequences
+- deterministic seeds
+- build vs create APIs
+- relationship graphs
+- scenarios that return readable world objects
+
+### The world engine should support
+- `tests/factories`
+- `tests/scenarios`
+- `defineFactory()`
+- `defineScenario()`
+- `build()`
+- `buildMany()`
+- `create()`
+- `createMany()`
+- `trait()` / `state()`
+- `seed()`
+- `afterBuild()` / `afterCreate()`
+- `world.use()`
+
+### The world engine should not own
+- Sails app boot lifecycle
+- request clients
+- Playwright lifecycle
+- mail capture runtime
+- worker and datastore orchestration
+
+Those remain the job of the Sounding runtime around it.
 
 ## What Sounding should cover
 
-### Unit / helper tests
+### Helper trials
 - helpers
 - pure business logic
-- model-adjacent logic
-- policies when run in isolation
+- policy-like checks in isolation
+- model-adjacent rules
 
-### Endpoint / action tests
+### Endpoint and action trials
 - guest vs authenticated access
 - redirects
 - JSON and HTML responses
-- action inputs/exits
+- status codes and headers
+- action inputs and exits
 - policy interaction
+- webhooks and provider callbacks
 
-### Inertia integration tests
+### Inertia trials
 - component name assertions
 - prop assertions
-- partial reload behavior
+- nested prop paths
+- shared props
 - validation and redirect behavior
+- partial reload behavior
 
-### Browser / E2E tests
+### Browser trials
 - sign in flows
 - onboarding
 - editor flows
@@ -123,304 +439,500 @@ When a test fails, the developer should know:
 - checkout and subscription handoff
 - mobile navigation
 
-### Mail tests
+### Mail trials
 - magic link emails
 - password reset emails
 - invite emails
-- webhook-triggered notifications
+- billing and transactional notifications
 
 ### Future layers
 - sockets
 - quest jobs
-- webhook simulation
 - uploads
 - passkey/WebAuthn flows
+- payment simulation
 
-## The core mental model
+## The API surface we want
 
-Sounding should feel like this:
+### Core
+- `defineConfig()`
+- `test()`
+- `describe()`
+- `beforeEach()`
+- `afterEach()`
+- `beforeAll()`
+- `afterAll()`
+- `dataset()`
+- `expect()`
 
-- **App**: a booted Sails application under test
-- **World**: a realistic set of data created for a test
-- **Actor**: a user role in that world
-- **Trial**: the test itself
-- **Mailbox**: captured outbound mail for assertions
-- **Browser**: Playwright page/context helpers
+### One trial API
+- `test()` is the primary public entrypoint
+- the callback receives a single context object
+- `sails` is the canonical runtime surface
+- transport aliases like `get()`, `post()`, and later `visit()` are convenience helpers
+- browser-capable trials can additionally destructure `page` when needed
 
-The tests should read like behavior, not setup plumbing.
+### Runtime surfaces
+- `sails.sounding.boot()`
+- `sails.sounding.lower()`
+- `sails.sounding.world.use()`
+- `sails.helpers.user.signupWithTeam()`
+- `sails.sounding.mailbox.latest()`
+- `sails.sounding.mailbox.clear()`
 
-## What Captain Vane should become
+## Assertion style
 
-Captain Vane should not disappear.
+Sounding should prefer `expect` as the primary assertion API.
 
-Captain Vane should become the data and scenario engine that powers Sounding.
+That choice matters because it gives the framework one clear, readable style across helper, endpoint, Inertia, mail, and browser trials.
 
-### Captain Vane should own
-- factories
-- traits / states
-- sequences
-- deterministic seeds
-- build vs create APIs
-- relationship graphs
-- scenarios that return readable world objects
+`assert` from Node can remain available as an escape hatch, but it should not be the main story.
 
-### Captain Vane v2 should support
-- `tests/factories`
-- `tests/scenarios`
-- `build()`
-- `buildMany()`
-- `create()`
-- `createMany()`
-- `state()` / `trait()`
-- `seed()`
-- `afterBuild()` / `afterCreate()`
+### Core matchers
+- `toBe()`
+- `toEqual()`
+- `toContain()`
+- `toMatch()`
+- `toBeTruthy()`
+- `toBeFalsy()`
+- `toBeDefined()`
 
-### Captain Vane should not own
-- Sails app boot lifecycle
-- request clients
-- Playwright lifecycle
-- mail capture runtime
-- worker/database orchestration
+### Sails-native matchers
+- `toHaveStatus()`
+- `toRedirectTo()`
+- `toHaveJsonPath()`
+- `toHaveHeader()`
+- `toExit()`
+- `toBeInertiaPage()`
+- `toHaveProp()`
+- `toHaveValidationError()`
+- `toHaveSentMail()`
 
-That is Sounding’s job.
+## The API-only testing story
 
-## What Sounding should own
+Sounding has to be excellent for JSON and endpoint-heavy apps.
 
-### App lifecycle
-- boot Sails once for the test mode being used
-- manage ports and process lifecycle
-- expose helpers for in-process and browser-driven testing
+This is not a side quest.
+It is part of the core product.
 
-### Database lifecycle
-- create one isolated SQLite database per run or per worker by default
-- configure Sails to use it automatically in test mode
-- tear it down cleanly
-- support Postgres later for heavier projects
+### One API, multiple transports
 
-### Runtime adapters
-- request client for endpoint/action tests
-- Inertia assertion helpers
-- Playwright integration for browser tests
-- mailbox capture
-- auth/session helpers
-- socket client helpers later
-- job helpers later
+Sounding should keep one public request story while supporting more than one transport underneath.
 
-### Ergonomic API surface
-The top-level API should make Sails concepts first-class without inventing a giant DSL.
+That means `get()`, `post()`, `visit()`, and `sails.sounding.request` should feel stable even if the underlying transport changes.
 
-## Proposed API direction
+The two important transports are:
 
-### Helper test
+- **virtual** requests, powered by `sails.request()`
+- **HTTP** requests, powered by a real listening app over the network
+
+### Why `sails.request()` matters
+
+`sails.request()` is one of the most interesting native building blocks Sounding can lean on.
+
+It already gives Sails a virtual request interpreter, and its documented sweet spot is faster-running unit and integration tests.
+
+That makes it a strong fit for:
+
+- fast endpoint trials
+- action-like request flows
+- Inertia response assertions that care about server-side contracts
+- situations where lifting a full HTTP server is unnecessary
+
+### Where virtual requests should not be the whole story
+
+The Sails docs are also clear that virtual requests are not identical to true HTTP requests.
+
+That matters because:
+
+- body parsing is simpler
+- Express HTTP middleware is not fully in play
+- static assets are not involved
+- some middleware-sensitive behaviors need real HTTP parity
+
+So Sounding should not pretend `sails.request()` is the answer to everything.
+
+### The right transport strategy
+
+The elegant answer is:
+
+- keep one request API
+- choose the transport underneath based on the kind of trial
+- let the app or the trial opt into stricter parity when needed
+- make the override order obvious and boring
+
+A good switching story looks like:
+
+1. per-call override, such as `get('/health', { transport: 'http' })`
+2. per-trial override, such as `test('...', { transport: 'http' }, ...)`
+3. the default from `config/sounding.js`
+4. a scoped client when a trial wants to stay explicit: `sails.sounding.request.using('http')`
+
+So a good default would be:
+
+- use **virtual transport** for fast app-aware endpoint and Inertia-style trials when that is sufficient
+- use **HTTP transport** for browser flows and for endpoint trials that need true HTTP behavior
+
+That gives Sounding speed without lying about what is actually being exercised.
+
+### `test()` for endpoint behavior
+Use `test()` for endpoint behavior:
+- status codes
+- headers
+- redirects
+- JSON bodies
+- policy interaction
+- guest vs authenticated access
+
 ```js
-import { test } from 'drydock'
+import { test } from 'sounding'
 
-test.helper('signupWithTeam creates a team and membership', async ({ helper, expect }) => {
-  const result = await helper('user.signupWithTeam', {
-    fullName: 'Kelvin O',
-    email: 'kelvin@example.com',
-    tosAcceptedByIp: '127.0.0.1',
+test('guest gets 401 on a private JSON endpoint', async ({
+  get,
+  expect,
+}) => {
+  const response = await get('/api/issues')
+
+  expect(response).toHaveStatus(401)
+})
+```
+
+### `test()` for action contracts
+Use `test()` when the action contract matters more than raw HTTP.
+
+```js
+import { test } from 'sounding'
+
+test('issues/publish rejects incomplete drafts', async ({
+  action,
+  expect,
+}) => {
+  const result = await action('issues/publish', { id: 12 })
+
+  expect(result).toExit('invalid')
+})
+```
+
+## The Inertia testing story
+
+Inertia responses deserve their own first-class lane.
+
+They are not just JSON and not just browser pages.
+
+### `test()` for Inertia responses
+Use `test()` with `visit()` and Inertia-aware matchers for:
+- component assertions
+- prop assertions
+- nested prop paths
+- shared props
+- validation and redirect behavior
+- partial reloads
+
+```js
+import { test } from 'sounding'
+
+test('pricing page returns the correct component and props', async ({
+  visit,
+  expect,
+}) => {
+  const page = await visit('/pricing')
+
+  expect(page).toBeInertiaPage('billing/pricing')
+  expect(page).toHaveProp('plans')
+  expect(page).toHaveProp('auth.user', null)
+})
+```
+
+And for partial reloads:
+
+```js
+test('dashboard can reload only notifications', async ({ visit, expect }) => {
+  const page = await visit('/dashboard', {
+    component: 'dashboard/index',
+    only: ['notifications'],
+    reset: ['sidebar'],
   })
 
-  expect(result.user.email).toBe('kelvin@example.com')
+  expect(page).toBeInertiaPage('dashboard/index')
+  expect(page).toHaveProp('notifications')
 })
 ```
 
-### Endpoint test
+## The mail testing story
+
+Sounding should integrate cleanly with the Sails mail story and make mailbox capture feel native.
+
+For `0.0.1`, the right implementation is simple and honest:
+- wrap `sails.helpers.mail.send` when a trial boots
+- capture the real inputs that flow through `sails-hook-mail`
+- render the template preview when a template is used
+- store normalized messages in `sails.sounding.mailbox`
+- restore the original helper when the trial ends
+
+That keeps the story Sails-native without inventing a fake mail subsystem.
+
+A mail trial should let a developer say:
+
 ```js
-import { test } from 'drydock'
+import { test } from 'sounding'
 
-test.endpoint('guest is redirected from dashboard', async ({ request, expect }) => {
-  const response = await request.get('/dashboard')
-  expect(response).toRedirectTo('/login')
-})
-```
+test('magic link sends a usable email', async ({
+  sails,
+  auth,
+  expect,
+}) => {
+  await auth.requestMagicLink('reader@example.com')
 
-### Inertia test
-```js
-import { test } from 'drydock'
+  const email = await sails.sounding.mailbox.latest()
 
-test.inertia('pricing page returns the expected component and props', async ({ visit, expect }) => {
-  const page = await visit('/pricing')
-  expect(page).toBeInertiaPage('billing/pricing')
-})
-```
-
-### Browser test
-```js
-import { test } from 'drydock'
-
-test.browser('subscriber can read a members-only issue', async ({ page, world, login, expect }) => {
-  await world.use('issue-access')
-  await login.as('subscriber', page)
-
-  await page.goto(world.issues.gated.url)
-
-  await expect(page.getByText(world.issues.gated.fullText)).toBeVisible()
-})
-```
-
-### Mail test
-```js
-import { test } from 'drydock'
-
-test.mail('magic link sends a usable email', async ({ mailbox, expect }) => {
-  const email = await mailbox.latest()
+  expect(email.to).toContain('reader@example.com')
   expect(email.subject).toContain('Sign in')
-  expect(email.ctaUrl).toMatch(/magic-link/)
+  expect(email.html).toContain('/magic-link/')
 })
 ```
 
-## Database strategy
+That is the level of clarity we want.
 
-This is the most important runtime choice.
+And the captured message should be rich enough to assert on:
+- `to`, `cc`, and `bcc`
+- `subject`, `from`, and `replyTo`
+- rendered `html` and `text`
+- `template` and `templateData`
+- extracted links like `ctaUrl`
+- `status` for sent vs failed deliveries
+- `error` details when delivery fails
 
-### What we should avoid
-- `sails-disk` for serious endpoint/E2E tests
-- multi-process setups that touch the same datastore files
-- test-only HTTP routes just for seeding state
+## The browser testing story
 
-### Recommended default
-For `0.0.1`, Sounding should default to:
-- **temporary SQLite**
-- one database file per run or per worker
-- stored under something like `/tmp/drydock/<run-id>/<worker-id>.sqlite`
+Sounding should use Playwright for browser work, but it should make browser trials feel like the natural top layer of the same testing story.
 
-Why SQLite first:
-- TBJS already leans on SQLite as a sensible default
-- no external services required
-- much more realistic than `sails-disk`
-- transactions and relational behavior are available
-- dramatically better for E2E orchestration
+A browser trial should have access to:
+- Playwright `page`
+- app-aware auth helpers like `login.as()`
+- worlds and actors
+- mobile projects as first-class citizens
 
-Later, Sounding can support Postgres for teams that want parity with production.
+## What we borrow from Pest
 
-## Test data location
+The best thing to borrow from Pest is not PHP syntax.
+It is the product feel.
 
-A strong rule:
+We should borrow:
+- one beautiful home for testing
+- low ceremony
+- coherent configuration
+- first-class datasets and hooks
+- browser testing as part of the same product, not a bolt-on
+- reporting that feels like a feature
 
-**All test data definitions live under `tests/`.**
+We should not borrow:
+- too much syntax sugar
+- magic that fights the host language
+- abstractions that hide Node so much that debugging gets harder
 
-Suggested structure:
+Sounding should feel like:
+- Pest philosophy
+- Node honesty
+- Sails-native ergonomics
 
-```text
-tests/
-  factories/
-    user.js
-    issue.js
-    subscription.js
-  scenarios/
-    issue-access.js
-    publisher-editor.js
-    reader-dashboard.js
-  e2e/
-  integration/
-  unit/
+## The first credible release
+
+`0.0.1` should prove the story is real, elegant, and useful.
+
+It should include:
+- hook loading and `sails.sounding`
+- `config/sounding.js`
+- datastore inheritance and managed `sails-sqlite` orchestration
+- `test()` for helpers, endpoints, JSON, Inertia, and mail
+- `test()` with `page` when the browser matters
+- a built-in world engine
+- mailbox capture
+- a small example app and docs
+
+It does not need to do everything at once.
+It does need to make developers believe the rest of the vision is inevitable.
+
+## Migration bar: replace the African Engineer test suite
+
+Sounding should be able to replace the current test story in `/Users/koo/Gringotts/687/africanengineer.com` without asking the app to invent more test plumbing.
+
+### What the current suite looks like
+
+The current African Engineer test setup includes:
+
+- unit helper tests using `node:test` + `getSails()`
+- Playwright page smoke tests for public pages
+- guest protection tests for login redirects
+- magic-link browser tests that manually issue tokens through a test helper module
+- issue-access browser tests that seed users, subscriptions, unlocks, and bookmarks through a custom support file
+- publisher editor tests that seed a draft issue and then drive the browser editor
+
+Today, that setup relies on:
+
+- `tests/util/get-sails.js`
+- `tests/e2e/support/test-db.cjs`
+- Playwright web-server orchestration in `playwright.config.js`
+- custom fixture builders and explicit database cleanup
+
+Sounding should absorb that burden.
+
+### What Sounding must provide to replace it cleanly
+
+#### 1. One primary `test()` API
+
+The public entrypoint should stay:
+
+- `test()`
+
+And the trial context should be able to power:
+
+- helper tests
+- endpoint tests
+- Inertia tests
+- mail assertions
+- browser flows when `page` is needed
+
+#### 2. A Sails-centered trial context
+
+Every trial should be able to reach for:
+
+- `sails`
+- `expect`
+- `get()`, `post()`, `put()`, `patch()`, `del()`
+- `visit()`
+- browser-capable trials should additionally be able to destructure `page`
+
+The canonical app surfaces should remain:
+
+- `sails.helpers`
+- `sails.models`
+- `sails.config`
+- `sails.hooks`
+
+And Sounding-specific surfaces should remain under:
+
+- `sails.sounding.world`
+- `sails.sounding.request`
+- `sails.sounding.mailbox`
+
+#### 3. Virtual request transport by default
+
+For non-browser trials, Sounding should default to a request transport powered by `sails.request()`.
+
+That gives us a Sails-native replacement for most current endpoint-style and Inertia-style needs without bringing in `supertest`.
+
+It must normalize responses well enough for:
+
+- `toHaveStatus()`
+- `toRedirectTo()`
+- `toHaveHeader()`
+- `toHaveJsonPath()`
+- `toBeInertiaPage()`
+- `toHaveProp()`
+
+#### 4. True HTTP/browser capability when parity matters
+
+Sounding still needs real browser support for the flows that genuinely require it:
+
+- login journeys
+- gated issue reading in the browser
+- editor interactions
+- mobile navigation
+
+That means browser-capable trials need:
+
+- `page`
+- web-server orchestration
+- a clear way to combine browser behavior with worlds and actors
+
+#### 5. A built-in world engine strong enough to replace `tests/e2e/support/test-db.cjs`
+
+Sounding should support factories and scenarios under `tests/` that can express the current African Engineer fixtures, including:
+
+- users with roles like publisher, subscriber, unlocked reader, and guest
+- teams and memberships
+- subscriptions
+- issue unlocks
+- bookmarks
+- published and draft issues
+
+Concrete scenarios Sounding should be able to express early:
+
+- `issue-access`
+- `publisher-editor`
+- `guest-protection`
+- `magic-link-auth`
+
+#### 6. Mailbox capture that removes the need for manual magic-link token helpers
+
+African Engineer currently issues magic-link tokens by reaching into app internals from `tests/e2e/support/test-db.cjs`.
+
+Sounding should replace that with a better story:
+
+- request the magic link through the real app behavior
+- capture the resulting mail through `sails.sounding.mailbox`
+- extract the sign-in URL from the captured message
+- continue the browser flow from there
+
+That is more realistic and removes custom token-plumbing from app tests.
+
+#### 7. Simple auth helpers for browser and endpoint trials
+
+To replace the current repeated login setup, Sounding should offer lightweight auth helpers built around real app behavior.
+
+At minimum, it should support:
+
+- login via captured magic link
+- acting as a known seeded actor in request-driven trials
+
+#### 8. Enough ergonomics to replace the current unit helper tests too
+
+The helper tests in African Engineer should become straightforward Sounding trials like:
+
+```js
+const { test } = require('sounding')
+
+test('capitalize helper works', async ({ sails, expect }) => {
+  expect(sails.helpers.capitalize('hello')).toBe('Hello')
+})
 ```
 
-This keeps product code clean and keeps the testing world owned by the tests.
+That means Sounding should feel just as good for tiny tests as for browser journeys.
 
-## What 0.0.1 should actually ship
+### The concrete migration target
 
-The first release should be sharp, not huge.
+Sounding is ready to replace the current African Engineer suite when we can remove or obsolete:
 
-### 0.0.1 goals
-- native Node test runner integration
-- Playwright browser integration
-- Sails app boot manager
-- temporary SQLite database lifecycle
-- `test.helper()`
-- `test.endpoint()`
-- `test.browser()`
-- basic auth helpers for common roles
-- mailbox capture for log mailers / test mailers
-- Captain Vane adapter for factories/scenarios
-- one reference TBJS example app
+- `/Users/koo/Gringotts/687/africanengineer.com/tests/util/get-sails.js`
+- `/Users/koo/Gringotts/687/africanengineer.com/tests/e2e/support/test-db.cjs`
+- the app-specific seeding and magic-link plumbing around Playwright
+- the idea that helper, endpoint, Inertia, mail, and browser tests need separate mental models
 
-### 0.0.1 non-goals
-- custom assertion engine from scratch
-- sockets and jobs on day one
-- full payment/webhook simulation on day one
-- WebAuthn passkey coverage on day one
-- every possible Sails hook abstraction immediately
+### The first migration phases
 
-The 0.0.1 bar is: **credible, elegant, useful, and real.**
+#### Phase 1
 
-## What a good 0.0.1 feels like
+Replace:
 
-A developer should be able to:
-- install Sounding
-- point it at a Sails app
-- define factories and scenarios under `tests/`
-- run helper tests, endpoint tests, and browser tests with one coherent mental model
-- avoid touching product code to make tests possible
+- unit helper tests
+- guest-protection endpoint-style tests
+- public page smoke tests that do not need rich browser fixtures
 
-If we achieve that, the story is already strong.
+#### Phase 2
 
-## Roadmap after 0.0.1
+Replace:
 
-### 0.1.x
-- richer Captain Vane trait/state system
-- `test.inertia()`
-- storage-state auth helpers
-- mobile/browser project presets
-- better response and redirect assertions
+- issue-access tests
+- magic-link auth tests
+- basic dashboard/member flows
 
-### 0.2.x
-- sockets
-- quest jobs
-- webhooks
-- upload helpers
-- payment flow harnesses
+#### Phase 3
 
-### 0.3.x
-- passkey/WebAuthn helpers
-- scenario debugger / world inspector
-- better watch mode and failure reports
-- richer CI output
+Replace:
 
-## Risks and sharp edges
+- publisher editor tests
+- the remaining browser-heavy flows
+- mobile navigation coverage
 
-### 1. Too much magic
-If Sounding tries to hide too much, it will become hard to trust.
-
-### 2. App boot complexity
-Sails boot and teardown need to be extremely predictable.
-
-### 3. Database abstraction drift
-We should not pretend SQLite and Postgres are identical. We should be honest about the tradeoffs.
-
-### 4. Overcoupling to one stack shape
-It should be opinionated for TBJS, but still flexible enough for real Sails apps.
-
-### 5. Captain Vane boundary blur
-If Sounding and Captain Vane overlap too much, both products get muddy.
-
-## Success criteria
-
-Sounding is working if:
-- a new TBJS user can write meaningful tests quickly
-- endpoint and E2E tests do not require test-only app routes
-- browser tests can run against one isolated app + one isolated database cleanly
-- data setup reads like business scenarios, not SQL dumps
-- failures are easier to understand than today
-
-## Short naming shortlist
-
-### Chosen: Sounding
-Best balance of elegance, meaning, and distinctiveness.
-
-### Alternatives considered
-- **Drydock** — strong and concrete, but more about environment than probing behavior
-- **Seatrial** — very direct, but less elegant as a brand
-- **Harbor** — strong, but feels more like infra than testing
-- **Trials** — clear, but less distinctive
-
-## Final take
-
-Sounding should become the elegant testing story for TBJS.
-
-Captain Vane should power the world-building underneath it.
-
-If we get the boundaries right, we do not just end up with a nicer API.
-We end up with a testing system that actually matches how Sails applications are built.
+If Sounding can carry that migration, then it is not just a nice idea.
+It is a credible testing framework for real Sails applications.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,59 @@
-module.exports = {
-  name: 'sounding',
-  version: '0.0.0'
+const { createRuntime } = require('./lib/create-runtime')
+const { createAppManager } = require('./lib/create-app-manager')
+const { createMailbox } = require('./lib/create-mailbox')
+const { createMailCapture } = require('./lib/create-mail-capture')
+const { createWorldEngine } = require('./lib/create-world-engine')
+const { loadWorldFiles } = require('./lib/create-world-loader')
+const { defineFactory, defineScenario } = require('./lib/define-world')
+const { createHelperRunner } = require('./lib/create-helper-runner')
+const { createRequestClient } = require('./lib/create-request-client')
+const { createVisitClient } = require('./lib/create-visit-client')
+const { createBrowserManager } = require('./lib/create-browser-manager')
+const { createAuthHelpers } = require('./lib/create-auth-helpers')
+const { createExpect } = require('./lib/create-expect')
+const { createTestApi } = require('./lib/create-test-api')
+const { getDefaultConfig } = require('./lib/default-config')
+
+function soundingHook(sails) {
+  const runtime = createRuntime(sails)
+
+  return {
+    defaults: {
+      sounding: getDefaultConfig(),
+    },
+
+    configure() {
+      sails.hooks ||= {}
+      sails.sounding = runtime
+      sails.hooks.sounding = this
+      runtime.configure()
+    },
+
+    initialize(done) {
+      sails.sounding = runtime
+      Object.assign(this, runtime)
+      sails.hooks.sounding = this
+      return done()
+    },
+  }
 }
+
+module.exports = soundingHook
+module.exports.test = createTestApi()
+module.exports.expect = createExpect
+module.exports.defineFactory = defineFactory
+module.exports.defineScenario = defineScenario
+module.exports.createRuntime = createRuntime
+module.exports.createAppManager = createAppManager
+module.exports.createMailbox = createMailbox
+module.exports.createWorldEngine = createWorldEngine
+module.exports.loadWorldFiles = loadWorldFiles
+module.exports.createHelperRunner = createHelperRunner
+module.exports.createRequestClient = createRequestClient
+module.exports.createVisitClient = createVisitClient
+module.exports.createBrowserManager = createBrowserManager
+module.exports.createAuthHelpers = createAuthHelpers
+module.exports.createExpect = createExpect
+module.exports.createTestApi = createTestApi
+module.exports.getDefaultConfig = getDefaultConfig
+module.exports.createMailCapture = createMailCapture

--- a/lib/create-app-manager.js
+++ b/lib/create-app-manager.js
@@ -1,0 +1,329 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { getDefaultConfig } = require('./default-config')
+const { mergeConfig } = require('./merge-config')
+const { normalizeUserConfig } = require('./normalize-config')
+const { buildManagedSqlitePath, resolveManagedRoot } = require('./resolve-datastore')
+
+function resolveModuleFromApp(appPath, moduleId) {
+  return require(require.resolve(moduleId, { paths: [appPath, process.cwd(), __dirname] }))
+}
+
+function loadAppSoundingConfig(appPath) {
+  const configPath = path.join(appPath, 'config', 'sounding.js')
+
+  if (!fs.existsSync(configPath)) {
+    return getDefaultConfig()
+  }
+
+  delete require.cache[require.resolve(configPath)]
+  const loaded = require(configPath)
+  return mergeConfig(getDefaultConfig(), normalizeUserConfig(loaded?.sounding || {}))
+}
+
+function buildManagedDatastoreOverrides(config, appPath) {
+  if (config.datastore?.mode !== 'managed') {
+    return {}
+  }
+
+  const identity = config.datastore.identity || 'default'
+
+  return {
+    datastores: {
+      [identity]: {
+        adapter: config.datastore.adapter || 'sails-sqlite',
+        url: buildManagedSqlitePath({
+          root: resolveManagedRoot({
+            datastore: config.datastore,
+            appPath,
+          }),
+          identity,
+          isolation: config.datastore.isolation || 'worker',
+        }),
+      },
+    },
+    models: {
+      migrate: 'drop',
+    },
+  }
+}
+
+function createOutputFilter(config = {}) {
+  if (config.app?.quiet === false) {
+    return {
+      install() {},
+      uninstall() {},
+    }
+  }
+
+  const noisyPatterns = [
+    /start\s+build started/i,
+    /ready\s+built in/i,
+    /\[DEP0044\].*util\.isArray/i,
+    /node --trace-deprecation/i,
+    /^\s*info:\s/m,
+    /success:\s*true.*no new issues to notify/i,
+  ]
+
+  let installed = false
+  let originalStdoutWrite = null
+  let originalStderrWrite = null
+
+  function shouldSuppress(chunk) {
+    const value = String(chunk || '')
+    const normalizedValue = value.replace(/\u001b\[[0-9;]*m/g, '')
+    return noisyPatterns.some((pattern) => pattern.test(normalizedValue))
+  }
+
+  function wrapWrite(write) {
+    return function soundingWrite(chunk, encoding, callback) {
+      if (shouldSuppress(chunk)) {
+        if (typeof encoding === 'function') {
+          encoding()
+        }
+
+        if (typeof callback === 'function') {
+          callback()
+        }
+
+        return true
+      }
+
+      return write.call(this, chunk, encoding, callback)
+    }
+  }
+
+  return {
+    install() {
+      if (installed) {
+        return
+      }
+
+      originalStdoutWrite = process.stdout.write
+      originalStderrWrite = process.stderr.write
+      process.stdout.write = wrapWrite(originalStdoutWrite)
+      process.stderr.write = wrapWrite(originalStderrWrite)
+      installed = true
+    },
+
+    uninstall() {
+      if (!installed) {
+        return
+      }
+
+      process.stdout.write = originalStdoutWrite
+      process.stderr.write = originalStderrWrite
+      originalStdoutWrite = null
+      originalStderrWrite = null
+      installed = false
+    },
+  }
+}
+
+function resolveManagedDatastoreFile(config, appPath) {
+  if (config.datastore?.mode !== 'managed') {
+    return null
+  }
+
+  const identity = config.datastore.identity || 'default'
+
+  return buildManagedSqlitePath({
+    root: resolveManagedRoot({
+      datastore: config.datastore,
+      appPath,
+    }),
+    identity,
+    isolation: config.datastore.isolation || 'worker',
+  })
+}
+
+function createAppManager({
+  appPath = process.cwd(),
+  environment = 'test',
+  liftOptions = {},
+  SailsConstructor,
+} = {}) {
+  let loadedApp = null
+  let liftedApp = null
+  let loadPromise = null
+  let liftPromise = null
+  const managedArtifacts = new Set()
+  let outputFilter = null
+
+  function resolveAppPath() {
+    return path.resolve(appPath)
+  }
+
+  function resolveConfig() {
+    return loadAppSoundingConfig(resolveAppPath())
+  }
+
+  function resolveSailsConstructor() {
+    if (SailsConstructor) {
+      return SailsConstructor
+    }
+
+    return resolveModuleFromApp(resolveAppPath(), 'sails').constructor
+  }
+
+  function buildOptions(mode) {
+    const config = resolveConfig()
+    outputFilter ||= createOutputFilter(config)
+    const managedFile = resolveManagedDatastoreFile(config, resolveAppPath())
+
+    if (managedFile) {
+      managedArtifacts.add(managedFile)
+    }
+
+    const appConfig = config.app || {}
+    const baseOptions = {
+      appPath: resolveAppPath(),
+      environment: appConfig.environment || environment,
+      ...buildManagedDatastoreOverrides(config, resolveAppPath()),
+    }
+    const modeOptions =
+      mode === 'load'
+        ? mergeConfig(
+            {
+              hooks: {
+                shipwright: false,
+                content: false,
+              },
+            },
+            appConfig.loadOptions || {}
+          )
+        : mergeConfig(appConfig.liftOptions || {}, liftOptions)
+    const nextOptions = mergeConfig(baseOptions, modeOptions)
+
+    if (mode === 'load' && nextOptions.datastores?.content) {
+      delete nextOptions.datastores.content
+    }
+
+    return nextOptions
+  }
+
+  async function cleanupManagedArtifacts() {
+    for (const filePath of managedArtifacts) {
+      const companionPaths = [
+        filePath,
+        `${filePath}-journal`,
+        `${filePath}-wal`,
+        `${filePath}-shm`,
+      ]
+
+      for (const artifactPath of companionPaths) {
+        await fs.promises.rm(artifactPath, { force: true }).catch(() => {})
+      }
+    }
+  }
+
+  async function load() {
+    if (loadedApp) {
+      return loadedApp
+    }
+
+    if (loadPromise) {
+      return loadPromise
+    }
+
+    const Sails = resolveSailsConstructor()
+    const sailsApp = new Sails()
+    const nextLoadOptions = buildOptions('load')
+    outputFilter?.install()
+
+    loadPromise = new Promise((resolve, reject) => {
+      sailsApp.load(nextLoadOptions, (error, loadedSails) => {
+        if (error) {
+          loadPromise = null
+          cleanupManagedArtifacts().catch(() => {})
+          outputFilter?.uninstall()
+          reject(error)
+          return
+        }
+
+        loadedApp = loadedSails
+        globalThis.sails = loadedSails
+        globalThis.sounding = loadedSails.sounding
+        resolve(loadedSails)
+      })
+    })
+
+    return loadPromise
+  }
+
+  async function lift() {
+    if (liftedApp) {
+      return liftedApp
+    }
+
+    if (liftPromise) {
+      return liftPromise
+    }
+
+    const Sails = resolveSailsConstructor()
+    const sailsApp = new Sails()
+    const nextLiftOptions = buildOptions('lift')
+    outputFilter?.install()
+
+    liftPromise = new Promise((resolve, reject) => {
+      sailsApp.lift(nextLiftOptions, (error, liftedSails) => {
+        if (error) {
+          liftPromise = null
+          cleanupManagedArtifacts().catch(() => {})
+          outputFilter?.uninstall()
+          reject(error)
+          return
+        }
+
+        liftedApp = liftedSails
+        globalThis.sails = liftedSails
+        globalThis.sounding = liftedSails.sounding
+        resolve(liftedSails)
+      })
+    })
+
+    return liftPromise
+  }
+
+  async function runtime(options = {}) {
+    const app = options.http ? await lift() : await load()
+    return app.sounding || app.hooks?.sounding
+  }
+
+  async function lower() {
+    const apps = [loadedApp, liftedApp].filter(Boolean)
+
+    loadedApp = null
+    liftedApp = null
+    loadPromise = null
+    liftPromise = null
+
+    await Promise.all(
+      apps.map(
+        (app) =>
+          new Promise((resolve) => {
+            app.lower(() => resolve())
+          })
+      )
+    )
+
+    delete globalThis.sails
+    delete globalThis.sounding
+    outputFilter?.uninstall()
+    await cleanupManagedArtifacts()
+  }
+
+  return {
+    load,
+    lift,
+    runtime,
+    lower,
+    resolveConfig,
+  }
+}
+
+module.exports = {
+  createAppManager,
+  loadAppSoundingConfig,
+}

--- a/lib/create-auth-helpers.js
+++ b/lib/create-auth-helpers.js
@@ -1,0 +1,159 @@
+function normalizeEmail(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+}
+
+function looksLikeEmail(value) {
+  return typeof value === 'string' && value.includes('@')
+}
+
+function createAuthHelpers({ sails, world, mailbox, request }) {
+  function getUserModel() {
+    return sails?.models?.user || sails?.models?.User
+  }
+
+  async function createUserFromEmail(email, fullName) {
+    const User = getUserModel()
+
+    if (!sails?.helpers?.user?.signupWithTeam) {
+      throw new Error(
+        'Sounding auth helpers could not find `sails.helpers.user.signupWithTeam`.'
+      )
+    }
+
+    const signupResult = await sails.helpers.user.signupWithTeam.with({
+      fullName: fullName || normalizeEmail(email).split('@')[0],
+      email: normalizeEmail(email),
+      tosAcceptedByIp: '127.0.0.1',
+      emailStatus: 'verified',
+    })
+
+    if (User?.updateOne) {
+      await User.updateOne({ id: signupResult.user.id }).set({
+        emailStatus: 'verified',
+      })
+    }
+
+    if (User?.findOne) {
+      return User.findOne({ id: signupResult.user.id })
+    }
+
+    return signupResult.user
+  }
+
+  async function resolveUser(actorOrEmail, options = {}) {
+    const User = getUserModel()
+
+    if (!actorOrEmail) {
+      throw new Error('Sounding auth helpers require an actor, user, or email address.')
+    }
+
+    let candidate = actorOrEmail
+
+    if (typeof candidate === 'string' && world.current?.users?.[candidate]) {
+      candidate = world.current.users[candidate]
+    }
+
+    if (candidate?.id && User?.findOne) {
+      return User.findOne({ id: candidate.id }) || candidate
+    }
+
+    const email = candidate?.email || (looksLikeEmail(candidate) ? candidate : null)
+
+    if (!email) {
+      throw new Error(
+        `Sounding auth helpers could not resolve an email address for actor \`${candidate}\`.`
+      )
+    }
+
+    const normalizedEmail = normalizeEmail(email)
+    let user = User?.findOne ? await User.findOne({ email: normalizedEmail }) : null
+
+    if (!user && options.createIfMissing !== false) {
+      user = await createUserFromEmail(normalizedEmail, candidate?.fullName || options.fullName)
+    }
+
+    if (!user) {
+      throw new Error(
+        `Sounding auth helpers could not find a user for ${normalizedEmail}.`
+      )
+    }
+
+    return user
+  }
+
+  async function issueMagicLink(actorOrEmail, options = {}) {
+    const User = getUserModel()
+
+    if (!User?.updateOne) {
+      throw new Error('Sounding auth helpers require a User model with updateOne().')
+    }
+
+    const user = await resolveUser(actorOrEmail, {
+      createIfMissing: true,
+      ...options,
+    })
+    const token = await sails.helpers.magicLink.generateToken()
+    const hashedToken = await sails.helpers.magicLink.hashToken(token)
+
+    await User.updateOne({ id: user.id }).set({
+      emailStatus: 'verified',
+      magicLinkToken: hashedToken,
+      magicLinkTokenExpiresAt: Date.now() + 15 * 60 * 1000,
+      magicLinkTokenUsedAt: null,
+    })
+
+    const refreshedUser = User.findOne ? await User.findOne({ id: user.id }) : user
+
+    return {
+      user: refreshedUser,
+      email: refreshedUser.email,
+      token,
+      url: `/magic-link/${token}`,
+    }
+  }
+
+  async function requestMagicLink(actorOrEmail, options = {}) {
+    const user = await resolveUser(actorOrEmail, {
+      createIfMissing: true,
+      ...options,
+    })
+
+    const response = await request.post(
+      '/magic-link',
+      {
+        email: user.email,
+        fullName: options.fullName || user.fullName,
+        redirectUrl: options.redirectUrl || '/login',
+      },
+      options.requestOptions || {}
+    )
+
+    return {
+      response,
+      email: user.email,
+      message: mailbox.latest(),
+      url: mailbox.latest()?.ctaUrl,
+    }
+  }
+
+  const login = {
+    async as(actorOrEmail, page, options = {}) {
+      const magicLink = await issueMagicLink(actorOrEmail, options)
+      await page.goto(magicLink.url)
+      return magicLink
+    },
+  }
+
+  return {
+    resolveUser,
+    issueMagicLink,
+    requestMagicLink,
+    login,
+  }
+}
+
+module.exports = {
+  createAuthHelpers,
+}

--- a/lib/create-browser-manager.js
+++ b/lib/create-browser-manager.js
@@ -1,0 +1,132 @@
+const { resolveBaseUrl } = require('./create-request-client')
+
+function resolveModuleFromApp(appPath, moduleId) {
+  return require(require.resolve(moduleId, { paths: [appPath, process.cwd(), __dirname] }))
+}
+
+function defaultLoadPlaywright(appPath) {
+  return resolveModuleFromApp(appPath, 'playwright')
+}
+
+function defaultLoadPlaywrightTest(appPath) {
+  return resolveModuleFromApp(appPath, '@playwright/test')
+}
+
+function resolveProjectOptions(projectName, devices = {}) {
+  if (projectName === 'mobile') {
+    return (
+      devices['iPhone 13'] || {
+        viewport: {
+          width: 390,
+          height: 844,
+        },
+        isMobile: true,
+        hasTouch: true,
+      }
+    )
+  }
+
+  return {}
+}
+
+function createBrowserManager({
+  sails,
+  getConfig,
+  appPathResolver = () => sails?.config?.appPath || process.cwd(),
+  loadPlaywright = defaultLoadPlaywright,
+  loadPlaywrightTest = defaultLoadPlaywrightTest,
+} = {}) {
+  let session = null
+
+  async function open(options = {}) {
+    if (session) {
+      return session
+    }
+
+    const config = typeof getConfig === 'function' ? getConfig() : sails?.config?.sounding || {}
+
+    if (config.browser?.enabled === false) {
+      throw new Error('Sounding browser support is disabled in `config/sounding.js`.')
+    }
+
+    const appPath = appPathResolver()
+    const playwright = await loadPlaywright(appPath)
+    const playwrightTest = await Promise.resolve()
+      .then(() => loadPlaywrightTest(appPath))
+      .catch(() => null)
+
+    const browserTypeName = options.type || config.browser?.type || 'chromium'
+    const browserType = playwright?.[browserTypeName]
+
+    if (!browserType?.launch) {
+      throw new Error(
+        `Sounding could not find a Playwright browser type named \`${browserTypeName}\`.`
+      )
+    }
+
+    const projectName =
+      options.project ||
+      config.browser?.defaultProject ||
+      config.browser?.projects?.[0] ||
+      'desktop'
+
+    const browser = await browserType.launch({
+      headless: true,
+      ...(config.browser?.launchOptions || {}),
+      ...(options.launchOptions || {}),
+    })
+
+    const context = await browser.newContext({
+      baseURL: resolveBaseUrl({ sails, getConfig }),
+      ...resolveProjectOptions(projectName, playwright.devices || {}),
+      ...(options.contextOptions || {}),
+    })
+
+    const page = await context.newPage()
+
+    session = {
+      playwright,
+      browser,
+      context,
+      page,
+      expect: playwrightTest?.expect,
+      project: projectName,
+    }
+
+    return session
+  }
+
+  async function close() {
+    if (!session) {
+      return
+    }
+
+    await session.context?.close?.()
+    await session.browser?.close?.()
+    session = null
+  }
+
+  return {
+    open,
+    close,
+    get active() {
+      return Boolean(session?.page)
+    },
+    get page() {
+      return session?.page
+    },
+    get context() {
+      return session?.context
+    },
+    get expect() {
+      return session?.expect
+    },
+  }
+}
+
+module.exports = {
+  createBrowserManager,
+  defaultLoadPlaywright,
+  defaultLoadPlaywrightTest,
+  resolveProjectOptions,
+}

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -1,0 +1,155 @@
+const assert = require('node:assert/strict')
+
+function getPath(target, path) {
+  return path.split('.').reduce((current, segment) => current?.[segment], target)
+}
+
+function getHeader(actual, name) {
+  if (typeof actual?.header === 'function') {
+    return actual.header(name)
+  }
+
+  if (typeof actual?.headers?.get === 'function') {
+    return actual.headers.get(name)
+  }
+
+  return actual?.headers?.[name]
+}
+
+function resolveStructuredValue(actual) {
+  if (actual?.data !== undefined) {
+    return actual.data
+  }
+
+  return actual
+}
+
+function shouldUseFallback(actual) {
+  return Boolean(
+    actual &&
+      typeof actual === 'object' &&
+      !Array.isArray(actual) &&
+      actual.status === undefined &&
+      actual.data === undefined &&
+      typeof actual.header !== 'function' &&
+      typeof actual.headers?.get !== 'function'
+  )
+}
+
+function createExpect(actual, { fallback } = {}) {
+  if (fallback && shouldUseFallback(actual)) {
+    return fallback(actual)
+  }
+
+  return {
+    toBe(expected) {
+      assert.strictEqual(actual, expected)
+    },
+
+    toEqual(expected) {
+      assert.deepStrictEqual(actual, expected)
+    },
+
+    toContain(expected) {
+      if (typeof actual === 'string') {
+        assert.ok(actual.includes(expected))
+        return
+      }
+
+      if (Array.isArray(actual)) {
+        assert.ok(actual.includes(expected))
+        return
+      }
+
+      throw new TypeError('Sounding expect().toContain() only supports strings and arrays in v0.0.1.')
+    },
+
+    toMatch(expected) {
+      if (expected instanceof RegExp) {
+        assert.match(actual, expected)
+        return
+      }
+
+      assert.ok(String(actual).includes(String(expected)))
+    },
+
+    toBeTruthy() {
+      assert.ok(actual)
+    },
+
+    toBeFalsy() {
+      assert.ok(!actual)
+    },
+
+    toBeDefined() {
+      assert.notStrictEqual(actual, undefined)
+    },
+
+    toHaveStatus(expected) {
+      assert.strictEqual(actual?.status, expected)
+    },
+
+    toHaveHeader(name, expected) {
+      const header = getHeader(actual, name)
+      assert.notStrictEqual(header, null)
+      assert.notStrictEqual(header, undefined)
+
+      if (expected !== undefined) {
+        assert.strictEqual(header, expected)
+      }
+    },
+
+    toRedirectTo(expected) {
+      const location = getHeader(actual, 'location')
+      assert.strictEqual(location, expected)
+    },
+
+    toHaveJsonPath(path, expected) {
+      const value = getPath(resolveStructuredValue(actual), path)
+      assert.deepStrictEqual(value, expected)
+    },
+
+    toBeInertiaPage(component) {
+      const value = resolveStructuredValue(actual)
+      assert.strictEqual(value?.component, component)
+    },
+
+    toHaveProp(path, expected) {
+      const value = getPath(resolveStructuredValue(actual)?.props, path)
+      assert.deepStrictEqual(value, expected)
+    },
+
+    toMatchProp(path, expected) {
+      const value = getPath(resolveStructuredValue(actual)?.props, path)
+
+      if (expected instanceof RegExp) {
+        assert.match(String(value), expected)
+        return
+      }
+
+      assert.ok(String(value).includes(String(expected)))
+    },
+
+    toHaveSharedProp(path, expected) {
+      const value = getPath(resolveStructuredValue(actual)?.props, path)
+      assert.deepStrictEqual(value, expected)
+    },
+
+    toHaveValidationError(path, expected) {
+      const value = getPath(resolveStructuredValue(actual)?.props?.errors, path)
+      assert.notStrictEqual(value, undefined)
+
+      if (expected !== undefined) {
+        assert.deepStrictEqual(value, expected)
+      }
+    },
+  }
+}
+
+createExpect.withFallback = function withFallback(fallback) {
+  return function soundingExpect(actual) {
+    return createExpect(actual, { fallback })
+  }
+}
+
+module.exports = { createExpect }

--- a/lib/create-helper-runner.js
+++ b/lib/create-helper-runner.js
@@ -1,0 +1,55 @@
+function resolveHelper(sails, identity) {
+  return identity
+    .split('.')
+    .reduce((current, segment) => current?.[segment], sails.helpers)
+}
+
+function createHelperRunner({ sails }) {
+  async function invoke(identity, inputs = {}) {
+    const helper = resolveHelper(sails, identity)
+
+    if (!helper) {
+      throw new Error(`Unknown Sounding helper: ${identity}`)
+    }
+
+    if (typeof helper.with === 'function') {
+      return helper.with(inputs)
+    }
+
+    if (typeof helper === 'function') {
+      return helper(inputs)
+    }
+
+    throw new Error(`Sounding helper \`${identity}\` is not callable.`)
+  }
+
+  function buildProxy(path = []) {
+    const callable = async (...args) => {
+      if (path.length === 0) {
+        const [identity, inputs = {}] = args
+        return invoke(identity, inputs)
+      }
+
+      const [inputs = {}] = args
+      return invoke(path.join('.'), inputs)
+    }
+
+    return new Proxy(callable, {
+      get(_target, property) {
+        if (property === 'path') {
+          return path.join('.')
+        }
+
+        if (typeof property !== 'string') {
+          return undefined
+        }
+
+        return buildProxy([...path, property])
+      },
+    })
+  }
+
+  return buildProxy()
+}
+
+module.exports = { createHelperRunner }

--- a/lib/create-mail-capture.js
+++ b/lib/create-mail-capture.js
@@ -1,0 +1,391 @@
+const path = require('node:path')
+const url = require('node:url')
+
+function normalizeList(value) {
+  if (value === undefined || value === null || value === '') {
+    return []
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => normalizeList(entry))
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  }
+
+  return [value]
+}
+
+function extractLinks(html) {
+  if (!html) {
+    return []
+  }
+
+  const matches = html.matchAll(/href=["']([^"']+)["']/gi)
+  return [...matches].map((match) => match[1])
+}
+
+function resolvePrimaryLink(inputs = {}, links = []) {
+  const templateData = inputs.templateData || {}
+  const preferredKeys = [
+    'magicLinkUrl',
+    'verificationUrl',
+    'resetPasswordUrl',
+    'inviteUrl',
+    'checkoutUrl',
+    'actionUrl',
+    'url',
+  ]
+
+  for (const key of preferredKeys) {
+    if (templateData[key]) {
+      return templateData[key]
+    }
+  }
+
+  return links.find((link) => !/\/unsubscribe\b/i.test(link)) || links[0]
+}
+
+function createRenderViewPromise(view) {
+  if (!view) {
+    return Promise.resolve(undefined)
+  }
+
+  if (typeof view.intercept === 'function') {
+    return view.intercept((error) => error)
+  }
+
+  return Promise.resolve(view)
+}
+
+async function renderTemplatePreview(sails, {
+  template,
+  templateData = {},
+  layout = 'layout-email',
+}) {
+  if (!template || typeof sails?.renderView !== 'function') {
+    return undefined
+  }
+
+  const emailTemplatePath = path.join('emails/', template)
+  let emailTemplateLayout = false
+
+  if (layout) {
+    emailTemplateLayout = path.relative(
+      path.dirname(emailTemplatePath),
+      path.resolve('layouts/', layout)
+    )
+  }
+
+  return createRenderViewPromise(
+    sails.renderView(emailTemplatePath, {
+      layout: emailTemplateLayout,
+      url,
+      ...templateData,
+    })
+  )
+}
+
+function resolveMailConfig(sails) {
+  return sails?.config?.mail || {}
+}
+
+function resolveMailerName(sails, inputs = {}) {
+  return inputs.mailer || process.env.MAIL_MAILER || resolveMailConfig(sails).default
+}
+
+function resolveTransportName(sails, mailer) {
+  return resolveMailConfig(sails).mailers?.[mailer]?.transport
+}
+
+function resolveFromAddress(sails, inputs = {}) {
+  return inputs.from || resolveMailConfig(sails).from?.address || process.env.MAIL_FROM_ADDRESS
+}
+
+function resolveFromName(sails, inputs = {}) {
+  return inputs.fromName || resolveMailConfig(sails).from?.name || process.env.MAIL_FROM_NAME
+}
+
+function resolveReplyTo(sails, inputs = {}) {
+  return inputs.replyTo || resolveMailConfig(sails).replyTo || process.env.MAIL_REPLY_TO
+}
+
+function toErrorShape(error) {
+  if (!error) {
+    return undefined
+  }
+
+  return {
+    name: error.name,
+    message: error.message,
+  }
+}
+
+async function buildCapturedMail(sails, inputs = {}) {
+  const mailer = resolveMailerName(sails, inputs)
+  const transport = resolveTransportName(sails, mailer)
+  const html = await renderTemplatePreview(sails, inputs)
+  const links = extractLinks(html)
+
+  return {
+    mailer,
+    transport,
+    template: inputs.template,
+    templateData: inputs.templateData || {},
+    to: normalizeList(inputs.to),
+    cc: normalizeList(inputs.cc),
+    bcc: normalizeList(inputs.bcc),
+    toName: inputs.toName,
+    subject: inputs.subject || '',
+    from: resolveFromAddress(sails, inputs),
+    fromName: resolveFromName(sails, inputs),
+    replyTo: resolveReplyTo(sails, inputs),
+    text: inputs.text,
+    html,
+    links,
+    ctaUrl: resolvePrimaryLink(inputs, links),
+    attachments: inputs.attachments || [],
+    headers: inputs.headers || {},
+    layout: inputs.layout === undefined ? 'layout-email' : inputs.layout,
+  }
+}
+
+function createMailCapture({ sails, mailbox, getConfig }) {
+  let originalSend = null
+
+  function resolveMailSettings() {
+    const soundingConfig =
+      typeof getConfig === 'function' ? getConfig() : sails?.config?.sounding || {}
+
+    return soundingConfig.mail || {}
+  }
+
+  function isEnabled() {
+    return resolveMailSettings().capture !== false
+  }
+
+  function shouldPassthrough() {
+    const settings = resolveMailSettings()
+    return settings.deliver === true || settings.mode === 'passthrough'
+  }
+
+  function wrapDeferred(executor, onRejected) {
+    let promise = Promise.resolve().then(executor)
+
+    if (typeof onRejected === 'function') {
+      promise = promise.catch(async (error) => {
+        await onRejected(error)
+        throw error
+      })
+    }
+
+    const deferred = {
+      intercept(handler) {
+        promise = promise.catch((error) => handler(error))
+        return deferred
+      },
+
+      then(onFulfilled, onRejected) {
+        return promise.then(onFulfilled, onRejected)
+      },
+
+      catch(onRejected) {
+        return promise.catch(onRejected)
+      },
+
+      finally(onFinally) {
+        return promise.finally(onFinally)
+      },
+    }
+
+    return deferred
+  }
+
+  function directSuccess(inputs = {}) {
+    return captureSuccessfulSend(inputs).then(() => ({}))
+  }
+
+  function directPassthrough(sendHelper, inputs = {}) {
+    return Promise.resolve(resolveDirectInvoker(sendHelper)(inputs))
+      .then(async (result) => {
+        await captureSuccessfulSend(inputs)
+        return result
+      })
+      .catch(async (error) => {
+        await captureFailedSend(inputs, error)
+        throw error
+      })
+  }
+
+  function deferredSuccess(inputs = {}) {
+    return wrapDeferred(async () => {
+      await captureSuccessfulSend(inputs)
+      return {}
+    })
+  }
+
+  function deferredPassthrough(sendHelper, inputs = {}) {
+    return wrapDeferred(
+      async () => {
+        const result = await resolveWithInvoker(sendHelper)(inputs)
+        await captureSuccessfulSend(inputs)
+        return result
+      },
+      async (error) => {
+        await captureFailedSend(inputs, error)
+      }
+    )
+  }
+
+  function resolveDirectInvoker(sendHelper) {
+    if (typeof sendHelper === 'function') {
+      return sendHelper.bind(sendHelper)
+    }
+
+    if (typeof sendHelper?.with === 'function') {
+      return sendHelper.with.bind(sendHelper)
+    }
+
+    throw new Error('Sounding could not invoke `sails.helpers.mail.send`.')
+  }
+
+  function resolveWithInvoker(sendHelper) {
+    if (typeof sendHelper?.with === 'function') {
+      return sendHelper.with.bind(sendHelper)
+    }
+
+    if (typeof sendHelper === 'function') {
+      return sendHelper.bind(sendHelper)
+    }
+
+    throw new Error('Sounding could not invoke `sails.helpers.mail.send.with()`.')
+  }
+
+  async function captureSuccessfulSend(inputs = {}) {
+    try {
+      const message = await buildCapturedMail(sails, inputs)
+      mailbox.capture({
+        ...message,
+        status: 'sent',
+      })
+    } catch (error) {
+      mailbox.capture({
+        mailer: resolveMailerName(sails, inputs),
+        transport: resolveTransportName(sails, resolveMailerName(sails, inputs)),
+        to: normalizeList(inputs.to),
+        subject: inputs.subject || '',
+        template: inputs.template,
+        status: 'sent',
+        captureError: toErrorShape(error),
+      })
+    }
+  }
+
+  async function captureFailedSend(inputs = {}, error) {
+    let message
+
+    try {
+      message = await buildCapturedMail(sails, inputs)
+    } catch (captureError) {
+      message = {
+        mailer: resolveMailerName(sails, inputs),
+        transport: resolveTransportName(sails, resolveMailerName(sails, inputs)),
+        to: normalizeList(inputs.to),
+        subject: inputs.subject || '',
+        template: inputs.template,
+        captureError: toErrorShape(captureError),
+      }
+    }
+
+    mailbox.capture({
+      ...message,
+      status: 'failed',
+      error: toErrorShape(error),
+    })
+  }
+
+  function wrapSendHelper(sendHelper) {
+    const wrapped = async (inputs = {}) => {
+      return shouldPassthrough()
+        ? directPassthrough(sendHelper, inputs)
+        : directSuccess(inputs)
+    }
+
+    const descriptors = Object.getOwnPropertyDescriptors(sendHelper)
+    delete descriptors.with
+    Object.defineProperties(wrapped, descriptors)
+
+    Object.defineProperty(wrapped, 'with', {
+      value(inputs = {}) {
+        return shouldPassthrough()
+          ? deferredPassthrough(sendHelper, inputs)
+          : deferredSuccess(inputs)
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    Object.defineProperty(wrapped, '__soundingWrapped', {
+      value: true,
+      configurable: true,
+    })
+
+    Object.defineProperty(wrapped, '__soundingOriginal', {
+      value: sendHelper,
+      configurable: true,
+    })
+
+    return wrapped
+  }
+
+  function install() {
+    if (!isEnabled()) {
+      return false
+    }
+
+    const sendHelper = sails?.helpers?.mail?.send
+    if (!sendHelper) {
+      return false
+    }
+
+    if (sendHelper.__soundingWrapped) {
+      originalSend = sendHelper.__soundingOriginal || originalSend
+      return true
+    }
+
+    originalSend = sendHelper
+    sails.helpers.mail.send = wrapSendHelper(sendHelper)
+    return true
+  }
+
+  function uninstall() {
+    if (!originalSend || !sails?.helpers?.mail) {
+      return false
+    }
+
+    sails.helpers.mail.send = originalSend
+    originalSend = null
+    return true
+  }
+
+  return {
+    install,
+    uninstall,
+    get installed() {
+      return Boolean(originalSend) && Boolean(sails?.helpers?.mail?.send?.__soundingWrapped)
+    },
+  }
+}
+
+module.exports = {
+  createMailCapture,
+  buildCapturedMail,
+  extractLinks,
+  normalizeList,
+  resolvePrimaryLink,
+  renderTemplatePreview,
+}

--- a/lib/create-mailbox.js
+++ b/lib/create-mailbox.js
@@ -1,0 +1,28 @@
+function createMailbox() {
+  const messages = []
+
+  return {
+    capture(message) {
+      const normalized = {
+        capturedAt: new Date().toISOString(),
+        ...message,
+      }
+      messages.push(normalized)
+      return normalized
+    },
+
+    all() {
+      return [...messages]
+    },
+
+    latest() {
+      return messages.at(-1)
+    },
+
+    clear() {
+      messages.length = 0
+    },
+  }
+}
+
+module.exports = { createMailbox }

--- a/lib/create-request-client.js
+++ b/lib/create-request-client.js
@@ -1,0 +1,549 @@
+const { Transform } = require('node:stream')
+const QS = require('node:querystring')
+
+function isAbsoluteUrl(value) {
+  return /^https?:\/\//i.test(value)
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/$/, '')
+}
+
+function looksLikeJson({ contentType, body }) {
+  if (!body) {
+    return false
+  }
+
+  if (contentType?.includes('application/json')) {
+    return true
+  }
+
+  return /^[\[{]/.test(String(body).trim())
+}
+
+function normalizeBodyValue(value) {
+  if (value === undefined || value === null) {
+    return {
+      body: '',
+      data: undefined,
+    }
+  }
+
+  if (typeof value === 'string') {
+    return {
+      body: value,
+      data: undefined,
+    }
+  }
+
+  return {
+    body: JSON.stringify(value),
+    data: value,
+  }
+}
+
+function normalizeResponse({
+  raw,
+  status,
+  statusText = '',
+  headers = {},
+  url,
+  redirected = false,
+  responseBody,
+}) {
+  const normalizedHeaders = new Headers(headers)
+  const contentType = normalizedHeaders.get('content-type') || ''
+  let { body, data } = normalizeBodyValue(responseBody)
+
+  if (data === undefined && looksLikeJson({ contentType, body })) {
+    data = JSON.parse(body)
+  }
+
+  return {
+    raw,
+    ok: status >= 200 && status < 400,
+    status,
+    statusText,
+    url,
+    redirected,
+    headers: normalizedHeaders,
+    body,
+    data,
+    header(name) {
+      return normalizedHeaders.get(name)
+    },
+    async text() {
+      return body
+    },
+    async json() {
+      return data
+    },
+  }
+}
+
+function resolveRequestConfig({ sails, getConfig }) {
+  const soundingConfig =
+    (typeof getConfig === 'function' ? getConfig() : null) || sails?.config?.sounding || {}
+
+  return soundingConfig.request || {}
+}
+
+function resolveBaseUrl({ sails, getConfig, override }) {
+  if (override) {
+    return trimTrailingSlash(override)
+  }
+
+  const requestConfig = resolveRequestConfig({ sails, getConfig })
+  if (requestConfig.baseUrl) {
+    return trimTrailingSlash(requestConfig.baseUrl)
+  }
+
+  const soundingConfig =
+    (typeof getConfig === 'function' ? getConfig() : null) || sails?.config?.sounding || {}
+
+  if (soundingConfig.browser?.baseUrl) {
+    return trimTrailingSlash(soundingConfig.browser.baseUrl)
+  }
+
+  const address = sails?.hooks?.http?.server?.address?.()
+  if (address && typeof address === 'object' && address.port) {
+    const host =
+      !address.address || address.address === '::' || address.address === '0.0.0.0'
+        ? '127.0.0.1'
+        : address.address
+
+    return `http://${host}:${address.port}`
+  }
+
+  if (sails?.config?.port) {
+    return `http://127.0.0.1:${sails.config.port}`
+  }
+
+  throw new Error(
+    'Sounding could not resolve a base URL for HTTP request trials. Configure `sounding.request.baseUrl`, `sounding.browser.baseUrl`, or lift Sails with the HTTP hook.'
+  )
+}
+
+function resolveUrl({ sails, getConfig, target, baseUrl }) {
+  if (isAbsoluteUrl(target)) {
+    return target
+  }
+
+  const resolvedBaseUrl = resolveBaseUrl({
+    sails,
+    getConfig,
+    override: baseUrl,
+  })
+
+  if (target.startsWith('/')) {
+    return `${resolvedBaseUrl}${target}`
+  }
+
+  return `${resolvedBaseUrl}/${target}`
+}
+
+function normalizePayload(method, payload) {
+  if (payload === undefined) {
+    return undefined
+  }
+
+  if (['GET', 'HEAD', 'DELETE'].includes(method)) {
+    return payload
+  }
+
+  if (isPlainObject(payload) || Array.isArray(payload)) {
+    return payload
+  }
+
+  return payload
+}
+
+function resolveTransport({ sails, getConfig, target, options = {} }) {
+  if (options.transport) {
+    return options.transport
+  }
+
+  if (isAbsoluteUrl(target) || options.baseUrl) {
+    return 'http'
+  }
+
+  const requestConfig = resolveRequestConfig({ sails, getConfig })
+  return requestConfig.transport || 'virtual'
+}
+
+function normalizeVirtualUrl(method, target, payload) {
+  if (
+    (method === 'GET' || method === 'HEAD' || method === 'DELETE') &&
+    isPlainObject(payload)
+  ) {
+    const stringifiedParams = QS.stringify(payload)
+    const queryStringPos = target.indexOf('?')
+
+    if (queryStringPos === -1) {
+      return `${target}?${stringifiedParams}`
+    }
+
+    return `${target.substring(0, queryStringPos)}?${stringifiedParams}`
+  }
+
+  return target
+}
+
+function createFlash(session = {}) {
+  const flashStore = (session.__soundingFlashStore ||= {})
+
+  return function flash(key, value) {
+    if (arguments.length === 1) {
+      const messages = flashStore[key] || []
+      delete flashStore[key]
+      return messages
+    }
+
+    flashStore[key] ||= []
+    flashStore[key].push(value)
+    return flashStore[key]
+  }
+}
+
+class MockClientResponse extends Transform {
+  _transform(chunk, _encoding, next) {
+    this.push(chunk)
+    next()
+  }
+}
+
+function createVirtualTransport({ sails }) {
+  if (typeof sails?.router?.route !== 'function') {
+    throw new Error(
+      'Sounding could not find `sails.router.route()`. Virtual request transport requires a loaded Sails app.'
+    )
+  }
+
+  return {
+    async send(method, target, payload, options = {}) {
+      return new Promise((resolve, reject) => {
+        const session = options.session || defaultSessionState()
+        const clientRes = new MockClientResponse()
+
+        try {
+          clientRes.on('finish', () => {
+            try {
+              clientRes.body = clientRes.read()
+              clientRes.body = clientRes.body?.toString()
+            } catch {}
+
+            if (!clientRes.body) {
+              delete clientRes.body
+            }
+
+            if (
+              clientRes.body !== undefined &&
+              clientRes.headers?.['content-type'] === 'application/json'
+            ) {
+              clientRes.body = JSON.parse(clientRes.body)
+            }
+
+            const status = clientRes.statusCode || 500
+            const responseBody = clientRes.body
+
+            resolve(
+              normalizeResponse({
+                raw: clientRes,
+                status,
+                statusText: clientRes.statusMessage || '',
+                headers: clientRes.headers || {},
+                url: target,
+                redirected: status >= 300 && status < 400,
+                responseBody,
+              })
+            )
+          })
+
+          clientRes.on('error', (error) => {
+            reject(error || new Error('Error on virtual response stream'))
+          })
+
+          sails.router.route(
+            {
+              method,
+              url: normalizeVirtualUrl(method, target, normalizePayload(method, payload)),
+              body: ['GET', 'HEAD', 'DELETE'].includes(method)
+                ? undefined
+                : normalizePayload(method, payload),
+              headers: {
+                ...(options.headers || {}),
+                nosession: 'true',
+              },
+              session,
+              flash: createFlash(session),
+            },
+            {
+              _clientRes: clientRes,
+            }
+          )
+        } catch (error) {
+          reject(error)
+          return
+        }
+      })
+    },
+  }
+}
+
+function defaultSessionState() {
+  return {}
+}
+
+function normalizeBodyAndHeaders(method, payload, headers) {
+  if (payload === undefined || method === 'GET' || method === 'HEAD') {
+    return {
+      body: undefined,
+      headers,
+    }
+  }
+
+  if (
+    typeof payload === 'string' ||
+    payload instanceof URLSearchParams ||
+    (typeof FormData !== 'undefined' && payload instanceof FormData) ||
+    payload instanceof ArrayBuffer ||
+    ArrayBuffer.isView(payload)
+  ) {
+    return {
+      body: payload,
+      headers,
+    }
+  }
+
+  if (isPlainObject(payload) || Array.isArray(payload)) {
+    if (!headers.has('content-type')) {
+      headers.set('content-type', 'application/json')
+    }
+
+    return {
+      body: JSON.stringify(payload),
+      headers,
+    }
+  }
+
+  return {
+    body: payload,
+    headers,
+  }
+}
+
+function createHttpTransport({
+  sails,
+  getConfig,
+  fetchImplementation = globalThis.fetch,
+}) {
+  if (typeof fetchImplementation !== 'function') {
+    throw new Error('Sounding could not find a fetch implementation for HTTP request trials.')
+  }
+
+  return {
+    async send(method, target, payload, options = {}) {
+      const headers = new Headers({
+        accept: 'application/json',
+        ...(options.headers || {}),
+      })
+
+      const { body, headers: finalHeaders } = normalizeBodyAndHeaders(method, payload, headers)
+
+      const response = await fetchImplementation(
+        resolveUrl({
+          sails,
+          getConfig,
+          target,
+          baseUrl: options.baseUrl,
+        }),
+        {
+          method,
+          redirect: options.redirect || 'manual',
+          ...options,
+          headers: finalHeaders,
+          body,
+        }
+      )
+
+      return normalizeResponse({
+        raw: response,
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+        url: response.url,
+        redirected: response.redirected,
+        responseBody: await response.text(),
+      })
+    },
+  }
+}
+
+function createRequestClient({
+  sails,
+  getConfig,
+  fetchImplementation = globalThis.fetch,
+  defaultHeaders = {},
+  defaultSession = {},
+  transportOverride,
+} = {}) {
+  let virtualTransport = null
+  let httpTransport = null
+
+  function getVirtualTransport() {
+    virtualTransport ||= createVirtualTransport({ sails })
+    return virtualTransport
+  }
+
+  function getHttpTransport() {
+    httpTransport ||= createHttpTransport({
+      sails,
+      getConfig,
+      fetchImplementation,
+    })
+    return httpTransport
+  }
+
+  async function send(method, target, payloadOrOptions, maybeOptions) {
+    const hasPayload = !['GET', 'HEAD'].includes(method)
+    const payload = hasPayload ? payloadOrOptions : undefined
+    const options = (hasPayload ? maybeOptions : payloadOrOptions) || {}
+    const headers = {
+      ...defaultHeaders,
+      ...(options.headers || {}),
+    }
+    const session = options.session
+      ? {
+          ...defaultSession,
+          ...options.session,
+        }
+      : defaultSession
+    const transport = resolveTransport({
+      sails,
+      getConfig,
+      target,
+      options: {
+        ...options,
+        transport: options.transport || transportOverride,
+      },
+    })
+
+    const transportOptions = {
+      ...options,
+      headers,
+      session,
+    }
+
+    if (transport === 'virtual') {
+      return getVirtualTransport().send(method, target, payload, transportOptions)
+    }
+
+    if (transport === 'http') {
+      return getHttpTransport().send(method, target, payload, transportOptions)
+    }
+
+    throw new Error(`Unknown Sounding request transport: ${transport}`)
+  }
+
+  return {
+    get transport() {
+      return transportOverride || resolveRequestConfig({ sails, getConfig }).transport || 'virtual'
+    },
+
+    async request(method, target, options = {}) {
+      return send(method.toUpperCase(), target, undefined, options)
+    },
+
+    get(target, options = {}) {
+      return send('GET', target, options)
+    },
+
+    head(target, options = {}) {
+      return send('HEAD', target, options)
+    },
+
+    post(target, payload, options = {}) {
+      return send('POST', target, payload, options)
+    },
+
+    put(target, payload, options = {}) {
+      return send('PUT', target, payload, options)
+    },
+
+    patch(target, payload, options = {}) {
+      return send('PATCH', target, payload, options)
+    },
+
+    delete(target, payload, options = {}) {
+      return send('DELETE', target, payload, options)
+    },
+
+    withHeaders(headers = {}) {
+      return createRequestClient({
+        sails,
+        getConfig,
+        fetchImplementation,
+        defaultHeaders: {
+          ...defaultHeaders,
+          ...headers,
+        },
+        defaultSession,
+        transportOverride,
+      })
+    },
+
+    withSession(session = {}) {
+      return createRequestClient({
+        sails,
+        getConfig,
+        fetchImplementation,
+        defaultHeaders,
+        defaultSession: {
+          ...defaultSession,
+          ...session,
+        },
+        transportOverride,
+      })
+    },
+
+    using(transport) {
+      return createRequestClient({
+        sails,
+        getConfig,
+        fetchImplementation,
+        defaultHeaders,
+        defaultSession,
+        transportOverride: transport,
+      })
+    },
+
+    as(actor) {
+      if (!actor) {
+        return this
+      }
+
+      const actorHeaders = actor.headers || actor.sounding?.headers || {}
+      const actorSession = actor.session ||
+        actor.sounding?.session || {
+          ...(actor.id ? { userId: actor.id } : {}),
+          ...(actor.team ? { teamId: actor.team } : {}),
+        }
+
+      return this.withHeaders(actorHeaders).withSession(actorSession)
+    },
+  }
+}
+
+module.exports = {
+  createRequestClient,
+  createVirtualTransport,
+  createHttpTransport,
+  normalizeResponse,
+  resolveBaseUrl,
+  resolveTransport,
+  resolveUrl,
+}

--- a/lib/create-runtime.js
+++ b/lib/create-runtime.js
@@ -1,0 +1,170 @@
+const path = require('node:path')
+
+const { createMailbox } = require('./create-mailbox')
+const { createMailCapture } = require('./create-mail-capture')
+const { createWorldEngine } = require('./create-world-engine')
+const { loadWorldFiles } = require('./create-world-loader')
+const { createHelperRunner } = require('./create-helper-runner')
+const { createRequestClient } = require('./create-request-client')
+const { createVisitClient } = require('./create-visit-client')
+const { createBrowserManager } = require('./create-browser-manager')
+const { createAuthHelpers } = require('./create-auth-helpers')
+const { getDefaultConfig } = require('./default-config')
+const { mergeConfig } = require('./merge-config')
+const { normalizeUserConfig } = require('./normalize-config')
+const { resolveDatastore } = require('./resolve-datastore')
+
+function resolveConfig(sails) {
+  return mergeConfig(getDefaultConfig(), normalizeUserConfig(sails.config?.sounding || {}))
+}
+
+function resolveAppPath(sails, config) {
+  const basePath = sails?.config?.appPath || process.cwd()
+  return path.resolve(basePath, config.app?.path || '.')
+}
+
+function createRuntime(sails) {
+  const mailbox = createMailbox()
+  const world = createWorldEngine({ sails })
+  const helpers = createHelperRunner({ sails })
+  const request = createRequestClient({
+    sails,
+    getConfig: () => resolveConfig(sails),
+  })
+  const visit = createVisitClient({ request })
+  const browser = createBrowserManager({
+    sails,
+    getConfig: () => resolveConfig(sails),
+    appPathResolver: () => resolveAppPath(sails, resolveConfig(sails)),
+  })
+  const auth = createAuthHelpers({
+    sails,
+    world,
+    mailbox,
+    request,
+  })
+  const mailCapture = createMailCapture({
+    sails,
+    mailbox,
+    getConfig: () => resolveConfig(sails),
+  })
+  let bootState = null
+  let datastoreState = null
+
+  return {
+    get config() {
+      return resolveConfig(sails)
+    },
+
+    get appPath() {
+      return resolveAppPath(sails, this.config)
+    },
+
+    get mailbox() {
+      return mailbox
+    },
+
+    get world() {
+      return world
+    },
+
+    get helpers() {
+      return helpers
+    },
+
+    // Temporary compatibility alias while the DX settles.
+    get helper() {
+      return helpers
+    },
+
+    get request() {
+      return request
+    },
+
+    get visit() {
+      return visit
+    },
+
+    get browser() {
+      return browser
+    },
+
+    get auth() {
+      return auth
+    },
+
+    configure() {
+      datastoreState = resolveDatastore({
+        sails,
+        soundingConfig: this.config,
+      })
+
+      return datastoreState
+    },
+
+    get datastore() {
+      return datastoreState
+    },
+
+    async boot(options = {}) {
+      if (!datastoreState) {
+        datastoreState = this.configure()
+      }
+
+      world.reset({ preserveSequences: true })
+      const loadedWorldFiles = await loadWorldFiles({
+        world,
+        appPath: this.appPath,
+        config: this.config,
+        sails,
+      })
+      const captureInstalled = mailCapture.install()
+
+      bootState = {
+        bootedAt: new Date().toISOString(),
+        mode: options.mode || 'unit',
+        config: this.config,
+        datastore: datastoreState,
+        mail: {
+          captureEnabled: this.config.mail?.capture !== false,
+          captureInstalled,
+        },
+        world: {
+          loadedFiles: loadedWorldFiles,
+        },
+      }
+
+      return {
+        sails,
+        ...bootState,
+        helpers,
+        mailbox,
+        world,
+        request,
+        visit,
+        browser,
+        auth,
+        login: auth.login,
+      }
+    },
+
+    async lower() {
+      bootState = null
+      datastoreState = null
+      await browser.close()
+      mailCapture.uninstall()
+      mailbox.clear()
+      world.reset({ preserveSequences: true })
+    },
+
+    get state() {
+      return bootState
+    },
+  }
+}
+
+module.exports = {
+  createRuntime,
+  resolveConfig,
+  resolveAppPath,
+}

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -1,0 +1,228 @@
+const nodeTest = require('node:test')
+const { createAppManager } = require('./create-app-manager')
+const { createExpect } = require('./create-expect')
+
+let defaultAppManager = null
+let defaultCleanupRegistered = false
+let trialQueue = Promise.resolve()
+
+function getDefaultAppManager() {
+  defaultAppManager ||= createAppManager()
+  return defaultAppManager
+}
+
+function ensureDefaultAppManagerCleanup() {
+  if (defaultCleanupRegistered || typeof nodeTest.after !== 'function') {
+    return
+  }
+
+  nodeTest.after(async () => {
+    if (defaultAppManager) {
+      await defaultAppManager.lower()
+    }
+  })
+
+  defaultCleanupRegistered = true
+}
+
+function normalizeTestArgs(title, optionsOrHandler, maybeHandler) {
+  if (typeof optionsOrHandler === 'function') {
+    return {
+      title,
+      options: {},
+      handler: optionsOrHandler,
+    }
+  }
+
+  return {
+    title,
+    options: optionsOrHandler || {},
+    handler: maybeHandler,
+  }
+}
+
+async function resolveRuntimeFromGlobals(options = {}) {
+  const runtime = globalThis.sounding || globalThis.sails?.sounding || globalThis.sails?.hooks?.sounding
+  const requiresHttp = Boolean(options.http || options.browser)
+  const httpServer = globalThis.sails?.hooks?.http?.server
+  const hasHttpServer = Boolean(
+    httpServer &&
+      (httpServer.listening ||
+        (typeof httpServer.address === 'function' && httpServer.address()))
+  )
+
+  if (runtime && (!requiresHttp || hasHttpServer)) {
+    return {
+      sounding: runtime,
+      teardown: async () => runtime.lower(),
+    }
+  }
+
+  const appManager = getDefaultAppManager()
+  ensureDefaultAppManagerCleanup()
+  const sounding = await appManager.runtime({ http: requiresHttp })
+  return {
+    sounding,
+    teardown: async () => sounding.lower(),
+  }
+}
+
+function bindRequestMethod(request, method) {
+  return typeof request?.[method] === 'function' ? request[method].bind(request) : undefined
+}
+
+function splitTestOptions(options = {}) {
+  const {
+    transport,
+    browser,
+    ...nodeOptions
+  } = options
+
+  return {
+    nodeOptions: {
+      concurrency: false,
+      ...nodeOptions,
+    },
+    trialOptions: {
+      transport,
+      browser,
+    },
+  }
+}
+
+async function runInTrialQueue(handler) {
+  const previous = trialQueue
+  let release = () => {}
+
+  trialQueue = new Promise((resolve) => {
+    release = resolve
+  })
+
+  await previous
+
+  try {
+    return await handler()
+  } finally {
+    release()
+  }
+}
+
+async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
+  const activeRuntime = typeof runtime === 'function' ? await runtime() : runtime
+  const resolved = activeRuntime
+    ? {
+        sounding: activeRuntime,
+        teardown: async () => activeRuntime.lower(),
+      }
+    : await resolveRuntimeFromGlobals({
+        http: options.transport === 'http',
+        browser: Boolean(options.browser),
+      })
+  const sounding = resolved.sounding
+  const booted = await sounding.boot({ mode })
+  const sails = booted.sails || {}
+
+  sails.sounding ||= sounding
+  sails.hooks ||= {}
+  sails.hooks.sounding ||= sounding
+  sails.helpers ||= sounding.helpers
+
+  const request = options.transport ? sounding.request.using(options.transport) : sounding.request
+  const visit = options.transport ? sounding.visit.using(options.transport) : sounding.visit
+
+  let browserSession = null
+  if (options.browser) {
+    browserSession = await sounding.browser.open(options.browser === true ? {} : options.browser)
+  }
+
+  const expect = browserSession?.expect
+    ? createExpect.withFallback(browserSession.expect)
+    : createExpect
+
+  const context = {
+    ...nodeContext,
+    t: nodeContext,
+    expect,
+    sails,
+    request,
+    visit,
+    auth: sounding.auth,
+    login: sounding.auth?.login,
+    world: sounding.world,
+    mailbox: sounding.mailbox,
+    browser: browserSession?.browser,
+    browserContext: browserSession?.context,
+    page: browserSession?.page,
+    get: bindRequestMethod(request, 'get'),
+    head: bindRequestMethod(request, 'head'),
+    post: bindRequestMethod(request, 'post'),
+    put: bindRequestMethod(request, 'put'),
+    patch: bindRequestMethod(request, 'patch'),
+    del: bindRequestMethod(request, 'delete'),
+  }
+
+  try {
+    return await handler(context)
+  } finally {
+    await resolved.teardown()
+  }
+}
+
+function createTrialMethod(baseTest, runtime, mode) {
+  return function registerTrial(title, optionsOrHandler, maybeHandler) {
+    const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler)
+    const { nodeOptions, trialOptions } = splitTestOptions(options)
+
+    return baseTest(title, nodeOptions, async (nodeContext) => {
+      return runInTrialQueue(async () => {
+        return runTrial({
+          runtime,
+          mode,
+          nodeContext,
+          handler,
+          options: trialOptions,
+        })
+      })
+    })
+  }
+}
+
+function createTestApi({ baseTest = nodeTest, runtime } = {}) {
+  function soundingTest(title, optionsOrHandler, maybeHandler) {
+    const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler)
+    const { nodeOptions, trialOptions } = splitTestOptions(options)
+
+    return baseTest(title, nodeOptions, async (nodeContext) => {
+      return runInTrialQueue(async () => {
+        return runTrial({
+          runtime,
+          mode: 'trial',
+          nodeContext,
+          handler,
+          options: trialOptions,
+        })
+      })
+    })
+  }
+
+  soundingTest.skip = (...args) => baseTest.skip(...args)
+  soundingTest.todo = (...args) => baseTest.todo(...args)
+  if (typeof baseTest.only === 'function') {
+    soundingTest.only = (...args) => baseTest.only(...args)
+  }
+
+  // Temporary compatibility aliases while the public docs move fully to `test()`.
+  soundingTest.helper = createTrialMethod(baseTest, runtime, 'helper')
+  soundingTest.endpoint = createTrialMethod(baseTest, runtime, 'endpoint')
+
+  return soundingTest
+}
+
+module.exports = {
+  createTestApi,
+  normalizeTestArgs,
+  resolveRuntimeFromGlobals,
+  runInTrialQueue,
+  runTrial,
+  splitTestOptions,
+}

--- a/lib/create-visit-client.js
+++ b/lib/create-visit-client.js
@@ -1,0 +1,114 @@
+const DEFAULT_HEADERS = {
+  'x-inertia': 'true',
+  'x-requested-with': 'XMLHttpRequest',
+  accept: 'text/html, application/xhtml+xml',
+}
+
+function joinHeaderValue(value) {
+  return Array.isArray(value) ? value.join(',') : value
+}
+
+function buildVisitHeaders(options = {}) {
+  const headers = {
+    ...(options.headers || {}),
+  }
+
+  if (options.version) {
+    headers['x-inertia-version'] = options.version
+  }
+
+  if (options.errorBag) {
+    headers['x-inertia-error-bag'] = options.errorBag
+  }
+
+  if (options.only?.length) {
+    if (!options.component) {
+      throw new Error('Sounding visit() requires `component` when using `only`.')
+    }
+
+    headers['x-inertia-partial-component'] = options.component
+    headers['x-inertia-partial-data'] = joinHeaderValue(options.only)
+  }
+
+  if (options.except?.length) {
+    if (!options.component) {
+      throw new Error('Sounding visit() requires `component` when using `except`.')
+    }
+
+    headers['x-inertia-partial-component'] = options.component
+    headers['x-inertia-partial-except'] = joinHeaderValue(options.except)
+  }
+
+  if (options.reset?.length) {
+    headers['x-inertia-reset'] = joinHeaderValue(options.reset)
+  }
+
+  return headers
+}
+
+function buildRequestOptions(options = {}) {
+  const {
+    component,
+    only,
+    except,
+    reset,
+    errorBag,
+    version,
+    ...requestOptions
+  } = options
+
+  const visitHeaders = buildVisitHeaders({
+    component,
+    only,
+    except,
+    reset,
+    errorBag,
+    version,
+    headers: requestOptions.headers,
+  })
+
+  const output = {
+    ...requestOptions,
+  }
+
+  if (Object.keys(visitHeaders).length > 0) {
+    output.headers = visitHeaders
+  }
+
+  return output
+}
+
+function createVisitClient({ request }) {
+  const client = request.withHeaders(DEFAULT_HEADERS)
+
+  function visit(target, options = {}) {
+    return client.get(target, buildRequestOptions(options))
+  }
+
+  visit.get = (target, options = {}) => client.get(target, buildRequestOptions(options))
+  visit.head = (target, options = {}) => client.head(target, buildRequestOptions(options))
+  visit.post = (target, payload, options = {}) => client.post(target, payload, buildRequestOptions(options))
+  visit.put = (target, payload, options = {}) => client.put(target, payload, buildRequestOptions(options))
+  visit.patch = (target, payload, options = {}) =>
+    client.patch(target, payload, buildRequestOptions(options))
+  visit.delete = (target, payload, options = {}) =>
+    client.delete(target, payload, buildRequestOptions(options))
+  visit.del = visit.delete
+  visit.using = (transport) => createVisitClient({ request: request.using(transport) })
+
+  Object.defineProperty(visit, 'transport', {
+    enumerable: true,
+    get() {
+      return client.transport
+    },
+  })
+
+  return visit
+}
+
+module.exports = {
+  createVisitClient,
+  DEFAULT_HEADERS,
+  buildVisitHeaders,
+  buildRequestOptions,
+}

--- a/lib/create-world-engine.js
+++ b/lib/create-world-engine.js
@@ -1,0 +1,300 @@
+const {
+  isFactoryDefinition,
+  isScenarioDefinition,
+} = require('./define-world')
+
+function mergeValue(base, patch) {
+  if (typeof patch === 'function') {
+    return patch(base)
+  }
+
+  return {
+    ...base,
+    ...(patch || {}),
+  }
+}
+
+function createFakeHelpers({ sequence }) {
+  return {
+    person: {
+      fullName() {
+        return `Test User ${sequence('fake-person')}`
+      },
+    },
+    internet: {
+      email() {
+        return `user${sequence('fake-email')}@example.com`
+      },
+    },
+    lorem: {
+      words(count = 3) {
+        return Array.from({ length: count }, () => `word-${sequence('fake-word')}`).join(' ')
+      },
+      sentence(count = 6) {
+        return `${Array.from({ length: count }, () => `word-${sequence('fake-sentence')}`).join(' ')}.`
+      },
+    },
+  }
+}
+
+function createThenableBuilder(executor, initialOverrides = {}) {
+  const state = {
+    overrides: initialOverrides,
+    traits: [],
+  }
+
+  function run() {
+    return executor(state.overrides, {
+      traits: [...state.traits],
+    })
+  }
+
+  const builder = {
+    trait(name) {
+      state.traits.push(name)
+      return builder
+    },
+
+    traits(names = []) {
+      state.traits.push(...names)
+      return builder
+    },
+
+    with(overrides = {}) {
+      state.overrides = overrides
+      return builder
+    },
+
+    value() {
+      return run()
+    },
+
+    then(onFulfilled, onRejected) {
+      return Promise.resolve(run()).then(onFulfilled, onRejected)
+    },
+
+    catch(onRejected) {
+      return Promise.resolve(run()).catch(onRejected)
+    },
+
+    finally(onFinally) {
+      return Promise.resolve(run()).finally(onFinally)
+    },
+  }
+
+  return builder
+}
+
+function createWorldEngine({ sails }) {
+  const factories = new Map()
+  const scenarios = new Map()
+  const sequences = new Map()
+  let currentWorld = null
+  let currentSeed = null
+
+  function sequence(nameOrBuilder = 'default', maybeBuilder) {
+    const name = typeof nameOrBuilder === 'function' ? 'default' : nameOrBuilder
+    const builder = typeof nameOrBuilder === 'function' ? nameOrBuilder : maybeBuilder
+    const next = (sequences.get(name) || 0) + 1
+    sequences.set(name, next)
+    return typeof builder === 'function' ? builder(next) : next
+  }
+
+  function resolveFactory(name) {
+    const entry = factories.get(name)
+
+    if (!entry) {
+      throw new Error(`Unknown Sounding factory: ${name}`)
+    }
+
+    return entry
+  }
+
+  function buildOne(name, overrides = {}, options = {}) {
+    const entry = resolveFactory(name)
+    const helpers = {
+      fake: createFakeHelpers({ sequence }),
+      sequence,
+      seed: currentSeed,
+      sails,
+    }
+
+    let value =
+      typeof entry.definition === 'function'
+        ? entry.definition(helpers)
+        : { ...entry.definition }
+
+    for (const traitName of options.traits || []) {
+      if (!entry.traits.has(traitName)) {
+        throw new Error(`Unknown Sounding trait \`${traitName}\` for factory \`${name}\``)
+      }
+
+      value = mergeValue(value, entry.traits.get(traitName))
+    }
+
+    return {
+      ...value,
+      ...overrides,
+    }
+  }
+
+  async function createOne(name, overrides = {}, options = {}) {
+    const value = buildOne(name, overrides, options)
+    const model = sails?.models?.[name]
+
+    if (model?.create) {
+      const query = model.create(value)
+      return typeof query.fetch === 'function' ? query.fetch() : query
+    }
+
+    return value
+  }
+
+  function registerFactoryDefinition(entry) {
+    const nextEntry = {
+      definition: entry.definition,
+      traits: new Map(entry.traits || []),
+    }
+
+    factories.set(entry.name, nextEntry)
+
+    return {
+      trait(traitName, patch) {
+        nextEntry.traits.set(traitName, patch)
+        return this
+      },
+    }
+  }
+
+  function registerScenarioDefinition(entry) {
+    scenarios.set(entry.name, entry.definition)
+    return entry
+  }
+
+  function defineFactory(nameOrEntry, definition) {
+    if (isFactoryDefinition(nameOrEntry)) {
+      return registerFactoryDefinition(nameOrEntry)
+    }
+
+    const entry = {
+      name: nameOrEntry,
+      definition,
+      traits: [],
+    }
+
+    return registerFactoryDefinition(entry)
+  }
+
+  function defineScenario(nameOrEntry, definition) {
+    if (isScenarioDefinition(nameOrEntry)) {
+      return registerScenarioDefinition(nameOrEntry)
+    }
+
+    return registerScenarioDefinition({
+      name: nameOrEntry,
+      definition,
+    })
+  }
+
+  async function use(name, context = {}) {
+    const definition = scenarios.get(name)
+
+    if (!definition) {
+      throw new Error(`Unknown Sounding scenario: ${name}`)
+    }
+
+    currentWorld = await definition({
+      build(name, overrides = {}) {
+        return createThenableBuilder(
+          (nextOverrides, options) => buildOne(name, nextOverrides, options),
+          overrides
+        )
+      },
+      create(name, overrides = {}) {
+        return createThenableBuilder(
+          (nextOverrides, options) => createOne(name, nextOverrides, options),
+          overrides
+        )
+      },
+      defineFactory,
+      defineScenario,
+      sails,
+      sequence,
+      seed: currentSeed,
+      context,
+    })
+
+    return currentWorld
+  }
+
+  return {
+    build(name, overrides = {}, options = {}) {
+      return buildOne(name, overrides, options)
+    },
+
+    async buildMany(name, count, overrides = {}, options = {}) {
+      return Array.from({ length: count }, () => buildOne(name, overrides, options))
+    },
+
+    create(name, overrides = {}, options = {}) {
+      return createOne(name, overrides, options)
+    },
+
+    async createMany(name, count, overrides = {}, options = {}) {
+      const records = []
+      for (let index = 0; index < count; index += 1) {
+        records.push(await createOne(name, overrides, options))
+      }
+      return records
+    },
+
+    defineFactory,
+    defineScenario,
+
+    register(definition) {
+      if (isFactoryDefinition(definition)) {
+        return defineFactory(definition)
+      }
+
+      if (isScenarioDefinition(definition)) {
+        return defineScenario(definition)
+      }
+
+      throw new Error('Sounding could not register an unknown world definition.')
+    },
+
+    get current() {
+      return currentWorld
+    },
+
+    get factories() {
+      return Array.from(factories.keys())
+    },
+
+    get scenarios() {
+      return Array.from(scenarios.keys())
+    },
+
+    reset(options = {}) {
+      const { preserveSequences = false } = options
+
+      factories.clear()
+      scenarios.clear()
+      if (!preserveSequences) {
+        sequences.clear()
+      }
+      currentWorld = null
+      currentSeed = null
+    },
+
+    seed(value) {
+      currentSeed = value
+      return currentSeed
+    },
+
+    sequence,
+    use,
+  }
+}
+
+module.exports = { createWorldEngine }

--- a/lib/create-world-loader.js
+++ b/lib/create-world-loader.js
@@ -1,0 +1,128 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+
+const {
+  defineFactory,
+  defineScenario,
+  isFactoryDefinition,
+  isScenarioDefinition,
+} = require('./define-world')
+
+const WORLD_EXTENSIONS = new Set(['.js', '.cjs', '.mjs'])
+
+function listDefinitionFiles(directory) {
+  const output = []
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const nextPath = path.join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      output.push(...listDefinitionFiles(nextPath))
+      continue
+    }
+
+    if (WORLD_EXTENSIONS.has(path.extname(entry.name))) {
+      output.push(nextPath)
+    }
+  }
+
+  return output.sort()
+}
+
+async function loadModule(filePath) {
+  try {
+    delete require.cache[require.resolve(filePath)]
+    return require(filePath)
+  } catch (error) {
+    if (error.code !== 'ERR_REQUIRE_ESM') {
+      throw error
+    }
+
+    return import(`${pathToFileURL(filePath).href}?t=${Date.now()}`)
+  }
+}
+
+async function registerExport(value, api, source) {
+  const entry = value?.default ?? value
+
+  if (entry === undefined || entry === null) {
+    return
+  }
+
+  if (Array.isArray(entry)) {
+    for (const item of entry) {
+      await registerExport(item, api, source)
+    }
+    return
+  }
+
+  if (isFactoryDefinition(entry) || isScenarioDefinition(entry)) {
+    api.world.register(entry)
+    return
+  }
+
+  if (typeof entry === 'function') {
+    const returned = await entry(api)
+
+    if (returned !== undefined) {
+      await registerExport(returned, api, source)
+    }
+
+    return
+  }
+
+  if (typeof entry === 'object' && (entry.factories || entry.scenarios)) {
+    for (const factory of entry.factories || []) {
+      await registerExport(factory, api, source)
+    }
+
+    for (const scenario of entry.scenarios || []) {
+      await registerExport(scenario, api, source)
+    }
+
+    return
+  }
+
+  throw new Error(
+    `Sounding could not understand the world definition exported from ${source}.`
+  )
+}
+
+async function loadWorldFiles({ world, appPath, config, sails }) {
+  const directories = [config.world?.factories, config.world?.scenarios]
+    .filter(Boolean)
+    .map((relativePath) => path.resolve(appPath, relativePath))
+
+  const loadedFiles = []
+  const api = {
+    sails,
+    world,
+    defineFactory,
+    defineScenario,
+    factory: defineFactory,
+    scenario: defineScenario,
+    registerFactory: world.defineFactory.bind(world),
+    registerScenario: world.defineScenario.bind(world),
+  }
+
+  for (const directory of directories) {
+    if (!fs.existsSync(directory)) {
+      continue
+    }
+
+    for (const filePath of listDefinitionFiles(directory)) {
+      const loaded = await loadModule(filePath)
+      await registerExport(loaded, api, filePath)
+      loadedFiles.push(filePath)
+    }
+  }
+
+  return loadedFiles
+}
+
+module.exports = {
+  loadWorldFiles,
+  listDefinitionFiles,
+  loadModule,
+}

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,0 +1,60 @@
+const DEFAULT_CONFIG = Object.freeze({
+  app: {
+    path: '.',
+    environment: 'test',
+    quiet: true,
+    liftOptions: {},
+  },
+  world: {
+    factories: 'tests/factories',
+    scenarios: 'tests/scenarios',
+  },
+  datastore: {
+    mode: 'managed',
+    identity: 'default',
+    adapter: 'sails-sqlite',
+    root: '.tmp/db',
+    isolation: 'worker',
+  },
+  browser: {
+    enabled: true,
+    type: 'chromium',
+    projects: ['desktop'],
+    defaultProject: 'desktop',
+    launchOptions: {
+      headless: true,
+    },
+  },
+  mail: {
+    capture: true,
+  },
+  request: {
+    transport: 'virtual',
+  },
+  auth: {
+    defaultActor: 'guest',
+  },
+})
+
+function cloneValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneValue)
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, cloneValue(nested)])
+    )
+  }
+
+  return value
+}
+
+function getDefaultConfig() {
+  return cloneValue(DEFAULT_CONFIG)
+}
+
+module.exports = {
+  DEFAULT_CONFIG,
+  getDefaultConfig,
+}

--- a/lib/define-world.js
+++ b/lib/define-world.js
@@ -1,0 +1,37 @@
+function defineFactory(name, definition) {
+  const entry = {
+    __soundingType: 'factory',
+    name,
+    definition,
+    traits: [],
+    trait(traitName, patch) {
+      entry.traits.push([traitName, patch])
+      return entry
+    },
+  }
+
+  return entry
+}
+
+function defineScenario(name, definition) {
+  return {
+    __soundingType: 'scenario',
+    name,
+    definition,
+  }
+}
+
+function isFactoryDefinition(value) {
+  return value?.__soundingType === 'factory'
+}
+
+function isScenarioDefinition(value) {
+  return value?.__soundingType === 'scenario'
+}
+
+module.exports = {
+  defineFactory,
+  defineScenario,
+  isFactoryDefinition,
+  isScenarioDefinition,
+}

--- a/lib/merge-config.js
+++ b/lib/merge-config.js
@@ -1,0 +1,25 @@
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function mergeConfig(base, override) {
+  const output = { ...base }
+
+  for (const [key, value] of Object.entries(override || {})) {
+    if (Array.isArray(value)) {
+      output[key] = [...value]
+      continue
+    }
+
+    if (isPlainObject(value) && isPlainObject(base[key])) {
+      output[key] = mergeConfig(base[key], value)
+      continue
+    }
+
+    output[key] = value
+  }
+
+  return output
+}
+
+module.exports = { mergeConfig }

--- a/lib/normalize-config.js
+++ b/lib/normalize-config.js
@@ -1,0 +1,54 @@
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeDatastore(datastore) {
+  if (typeof datastore === 'string') {
+    return {
+      mode: datastore,
+    }
+  }
+
+  if (!isPlainObject(datastore)) {
+    return datastore
+  }
+
+  const normalized = { ...datastore }
+  const legacyManaged = isPlainObject(normalized.managed) ? normalized.managed : {}
+
+  if (normalized.adapter == null && legacyManaged.adapter != null) {
+    normalized.adapter = legacyManaged.adapter
+  }
+
+  if (normalized.root == null) {
+    normalized.root = legacyManaged.root ?? legacyManaged.directory
+  }
+
+  if (normalized.isolation == null && legacyManaged.isolation != null) {
+    normalized.isolation = legacyManaged.isolation
+  }
+
+  delete normalized.managed
+  delete normalized.directory
+
+  return normalized
+}
+
+function normalizeUserConfig(config = {}) {
+  if (!isPlainObject(config)) {
+    return {}
+  }
+
+  const normalized = { ...config }
+
+  if ('datastore' in normalized) {
+    normalized.datastore = normalizeDatastore(normalized.datastore)
+  }
+
+  return normalized
+}
+
+module.exports = {
+  normalizeDatastore,
+  normalizeUserConfig,
+}

--- a/lib/resolve-datastore.js
+++ b/lib/resolve-datastore.js
@@ -1,0 +1,97 @@
+const path = require('node:path')
+
+function getWorkerToken(env = process.env) {
+  return (
+    env.SOUNDING_WORKER_INDEX ||
+    env.PLAYWRIGHT_WORKER_INDEX ||
+    env.TEST_WORKER_INDEX ||
+    String(process.pid)
+  )
+}
+
+function buildManagedSqlitePath({
+  root = path.join(process.cwd(), '.tmp', 'db'),
+  identity = 'default',
+  isolation = 'worker',
+  env = process.env,
+}) {
+  const workerToken = isolation === 'run' ? 'run' : `worker-${getWorkerToken(env)}`
+  return path.join(root, identity, `${workerToken}.db`)
+}
+
+function resolveManagedRoot({ sails, datastore = {}, appPath } = {}) {
+  const configuredRoot = datastore.root || path.join('.tmp', 'db')
+
+  if (path.isAbsolute(configuredRoot)) {
+    return configuredRoot
+  }
+
+  return path.resolve(appPath || sails?.config?.appPath || process.cwd(), configuredRoot)
+}
+
+function resolveDatastore({ sails, soundingConfig }) {
+  const datastoreConfig = soundingConfig.datastore || {}
+  const mode = datastoreConfig.mode || 'managed'
+  const identity = datastoreConfig.identity || 'default'
+  const datastores = (sails.config.datastores ||= {})
+
+  if (mode === 'inherit' || mode === 'external') {
+    const configuredDatastore = datastores[identity]
+
+    if (!configuredDatastore) {
+      throw new Error(
+        `Sounding could not find datastore \`${identity}\` in sails.config.datastores for mode \`${mode}\`.`
+      )
+    }
+
+    return {
+      mode,
+      identity,
+      config: { ...configuredDatastore },
+      managed: false,
+    }
+  }
+
+  if (mode === 'managed') {
+    const adapter = datastoreConfig.adapter || 'sails-sqlite'
+
+    if (adapter !== 'sails-sqlite') {
+      throw new Error(
+        `Sounding only supports managed adapter \`sails-sqlite\` in v0.0.1. Received \`${adapter}\`.`
+      )
+    }
+
+    const filePath = buildManagedSqlitePath({
+      root: resolveManagedRoot({
+        sails,
+        datastore: datastoreConfig,
+      }),
+      identity,
+      isolation: datastoreConfig.isolation || 'worker',
+    })
+
+    const nextDatastore = {
+      ...(datastores[identity] || {}),
+      adapter,
+      url: filePath,
+    }
+
+    datastores[identity] = nextDatastore
+
+    return {
+      mode,
+      identity,
+      config: { ...nextDatastore },
+      managed: true,
+      filePath,
+    }
+  }
+
+  throw new Error(`Unknown Sounding datastore mode: ${mode}`)
+}
+
+module.exports = {
+  buildManagedSqlitePath,
+  resolveManagedRoot,
+  resolveDatastore,
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sounding",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Testing framework for Sails applications and The Boring JavaScript Stack.",
   "main": "index.js",
   "license": "MIT",
@@ -13,12 +13,17 @@
   ],
   "files": [
     "index.js",
+    "lib",
     "README.md",
     "RESEARCH.md",
     "LICENSE"
   ],
-  "publishConfig": {
-    "access": "public"
+  "scripts": {
+    "test": "node --test"
+  },
+  "sails": {
+    "isHook": true,
+    "hookName": "sounding"
   },
   "repository": {
     "type": "git",
@@ -27,5 +32,8 @@
   "homepage": "https://github.com/sailscastshq/sounding#readme",
   "bugs": {
     "url": "https://github.com/sailscastshq/sounding/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/test/app-manager.test.js
+++ b/test/app-manager.test.js
@@ -1,0 +1,148 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const {
+  createAppManager,
+  loadAppSoundingConfig,
+} = require('../lib/create-app-manager')
+
+test('loadAppSoundingConfig falls back to Sounding defaults when the app has no config/sounding.js', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-app-config-'))
+  const config = loadAppSoundingConfig(tempRoot)
+
+  assert.equal(config.datastore.mode, 'managed')
+  assert.equal(config.app.environment, 'test')
+})
+
+test('loadAppSoundingConfig normalizes shorthand and legacy datastore config', () => {
+  const shorthandRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-app-config-'))
+  fs.mkdirSync(path.join(shorthandRoot, 'config'), { recursive: true })
+  fs.writeFileSync(
+    path.join(shorthandRoot, 'config', 'sounding.js'),
+    "module.exports.sounding = { datastore: 'inherit' }\n"
+  )
+
+  const shorthandConfig = loadAppSoundingConfig(shorthandRoot)
+  assert.equal(shorthandConfig.datastore.mode, 'inherit')
+  assert.equal(shorthandConfig.datastore.root, '.tmp/db')
+
+  const legacyRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-app-config-'))
+  fs.mkdirSync(path.join(legacyRoot, 'config'), { recursive: true })
+  fs.writeFileSync(
+    path.join(legacyRoot, 'config', 'sounding.js'),
+    "module.exports.sounding = { datastore: { managed: { directory: '.tmp/legacy-db' } } }\n"
+  )
+
+  const legacyConfig = loadAppSoundingConfig(legacyRoot)
+  assert.equal(legacyConfig.datastore.mode, 'managed')
+  assert.equal(legacyConfig.datastore.root, '.tmp/legacy-db')
+})
+
+test('createAppManager loads consumer apps by default and disables shipwright for virtual trials', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-app-manager-'))
+  fs.mkdirSync(path.join(tempRoot, 'config'), { recursive: true })
+  fs.writeFileSync(
+    path.join(tempRoot, 'config', 'sounding.js'),
+    "module.exports.sounding = { datastore: 'inherit', app: { environment: 'test' } }\n"
+  )
+
+  const runtime = { boot: async () => ({ sails: {} }), lower: async () => {} }
+  const loadCalls = []
+  const liftCalls = []
+
+  class FakeSails {
+    load(options, done) {
+      loadCalls.push(options)
+      this.config = { appPath: tempRoot }
+      this.sounding = runtime
+      this.hooks = { sounding: runtime }
+      done(undefined, this)
+    }
+
+    lift(options, done) {
+      liftCalls.push(options)
+      this.config = { appPath: tempRoot }
+      this.sounding = runtime
+      this.hooks = { sounding: runtime }
+      done(undefined, this)
+    }
+
+    lower(done) {
+      done()
+    }
+  }
+
+  const manager = createAppManager({
+    appPath: tempRoot,
+    SailsConstructor: FakeSails,
+  })
+
+  const resolvedRuntime = await manager.runtime()
+  assert.equal(resolvedRuntime, runtime)
+  assert.equal(loadCalls[0].environment, 'test')
+  assert.equal(loadCalls[0].hooks.shipwright, false)
+  assert.equal(loadCalls[0].datastores, undefined)
+  assert.equal(liftCalls.length, 0)
+
+  const liftedRuntime = await manager.runtime({ http: true })
+  assert.equal(liftedRuntime, runtime)
+  assert.equal(liftCalls[0].environment, 'test')
+
+  await manager.lower()
+})
+
+test('createAppManager suppresses noisy app boot logs when quiet mode is enabled', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-app-quiet-'))
+  fs.mkdirSync(path.join(tempRoot, 'config'), { recursive: true })
+
+  const captured = []
+  const originalWrite = process.stdout.write
+  process.stdout.write = function soundingCapture(chunk, encoding, callback) {
+    captured.push(String(chunk || ''))
+
+    if (typeof encoding === 'function') {
+      encoding()
+    }
+
+    if (typeof callback === 'function') {
+      callback()
+    }
+
+    return true
+  }
+
+  class FakeSails {
+    load(options, done) {
+      this.config = { appPath: tempRoot }
+      this.sounding = { lower: async () => {}, boot: async () => ({ sails: this }) }
+      this.hooks = { sounding: this.sounding }
+      process.stdout.write(' info: Initializing custom hook (`quest`)...\n')
+      process.stdout.write("{ success: true, message: 'No new issues to notify' }\n")
+      process.stdout.write('A real application log we should keep.\n')
+      done(undefined, this)
+    }
+
+    lower(done) {
+      done()
+    }
+  }
+
+  try {
+    const manager = createAppManager({
+      appPath: tempRoot,
+      SailsConstructor: FakeSails,
+    })
+
+    await manager.runtime()
+    await manager.lower()
+  } finally {
+    process.stdout.write = originalWrite
+  }
+
+  assert.equal(captured.some((line) => line.includes('Initializing custom hook')), false)
+  assert.equal(captured.some((line) => line.includes('No new issues to notify')), false)
+  assert.equal(captured.some((line) => line.includes('A real application log we should keep.')), true)
+})

--- a/test/browser-auth.test.js
+++ b/test/browser-auth.test.js
@@ -1,0 +1,172 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createBrowserManager } = require('../lib/create-browser-manager')
+const { createAuthHelpers } = require('../lib/create-auth-helpers')
+const { createExpect } = require('../lib/create-expect')
+
+test('createBrowserManager opens a browser session with the configured base URL', async () => {
+  const calls = []
+  const fakePage = {
+    goto: async (target) => {
+      calls.push(['goto', target])
+    },
+  }
+
+  const manager = createBrowserManager({
+    sails: {
+      config: {
+        appPath: '/tmp/app',
+        port: 3333,
+        sounding: {
+          browser: {
+            enabled: true,
+            projects: ['desktop'],
+            defaultProject: 'desktop',
+          },
+        },
+      },
+    },
+    getConfig: () => ({
+      browser: {
+        enabled: true,
+        projects: ['desktop'],
+        defaultProject: 'desktop',
+      },
+    }),
+    loadPlaywright: async () => ({
+      chromium: {
+        launch: async (launchOptions) => ({
+          launchOptions,
+          newContext: async (contextOptions) => ({
+            contextOptions,
+            newPage: async () => fakePage,
+            close: async () => {
+              calls.push(['context:close'])
+            },
+          }),
+          close: async () => {
+            calls.push(['browser:close'])
+          },
+        }),
+      },
+      devices: {},
+    }),
+    loadPlaywrightTest: async () => ({
+      expect(actual) {
+        return {
+          async toBeVisible() {
+            calls.push(['expect', actual])
+          },
+        }
+      },
+    }),
+  })
+
+  const session = await manager.open()
+  assert.equal(session.page, fakePage)
+  assert.equal(session.context.contextOptions.baseURL, 'http://127.0.0.1:3333')
+  await manager.close()
+  assert.deepEqual(calls, [
+    ['context:close'],
+    ['browser:close'],
+  ])
+})
+
+test('createAuthHelpers can issue magic links and log a browser page in as an actor', async () => {
+  const updates = []
+  const page = {
+    visits: [],
+    async goto(target) {
+      this.visits.push(target)
+    },
+  }
+
+  const sails = {
+    helpers: {
+      magicLink: {
+        generateToken: async () => 'token-123',
+        hashToken: async (value) => `hashed:${value}`,
+      },
+      user: {
+        signupWithTeam: {
+          with: async (inputs) => ({
+            user: {
+              id: 1,
+              email: inputs.email,
+              fullName: inputs.fullName,
+            },
+            team: {
+              id: 1,
+              name: `${inputs.fullName}'s Team`,
+            },
+          }),
+        },
+      },
+    },
+    models: {
+      user: {
+        async findOne(criteria) {
+          if (criteria.email === 'reader@example.com' || criteria.id === 1) {
+            return {
+              id: 1,
+              email: 'reader@example.com',
+              fullName: 'Reader Example',
+            }
+          }
+
+          return null
+        },
+        updateOne(criteria) {
+          return {
+            set(values) {
+              updates.push([criteria, values])
+              return Promise.resolve(values)
+            },
+          }
+        },
+      },
+    },
+  }
+
+  const auth = createAuthHelpers({
+    sails,
+    world: {
+      current: {
+        users: {
+          reader: {
+            id: 1,
+            email: 'reader@example.com',
+          },
+        },
+      },
+    },
+    mailbox: {
+      latest() {
+        return null
+      },
+    },
+    request: {
+      post: async () => ({ status: 302, header: () => '/check-email' }),
+    },
+  })
+
+  const issued = await auth.issueMagicLink('reader')
+  assert.equal(issued.url, '/magic-link/token-123')
+  assert.equal(updates[0][1].magicLinkToken, 'hashed:token-123')
+
+  await auth.login.as('reader', page)
+  assert.deepEqual(page.visits, ['/magic-link/token-123'])
+})
+
+test('createExpect can fall back to Playwright expect for browser objects', async () => {
+  const calls = []
+  const browserExpect = (actual) => ({
+    async toBeVisible() {
+      calls.push(actual)
+    },
+  })
+
+  await createExpect.withFallback(browserExpect)({ locator: true }).toBeVisible()
+  assert.deepEqual(calls, [{ locator: true }])
+})

--- a/test/mail-capture.test.js
+++ b/test/mail-capture.test.js
@@ -1,0 +1,178 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createRuntime } = require('../lib/create-runtime')
+const { buildCapturedMail } = require('../lib/create-mail-capture')
+
+function createRenderView(htmlBuilder) {
+  return (viewPath, locals) => ({
+    intercept: async () => htmlBuilder(viewPath, locals),
+  })
+}
+
+test('buildCapturedMail renders the email preview and extracts links', async () => {
+  const sails = {
+    config: {
+      mail: {
+        default: 'transactional',
+        mailers: {
+          transactional: {
+            transport: 'smtp',
+          },
+        },
+        from: {
+          address: 'hello@africanengineer.com',
+          name: 'The African Engineer',
+        },
+        replyTo: 'support@africanengineer.com',
+      },
+    },
+    renderView: createRenderView((_viewPath, locals) => {
+      return `<a href="${locals.magicLink}">Sign in</a>`
+    }),
+  }
+
+  const message = await buildCapturedMail(sails, {
+    template: 'email-magic-link',
+    templateData: {
+      magicLink: 'https://example.com/magic-link/token-123',
+    },
+    to: 'reader@example.com',
+    subject: 'Sign in',
+  })
+
+  assert.equal(message.mailer, 'transactional')
+  assert.equal(message.transport, 'smtp')
+  assert.deepEqual(message.to, ['reader@example.com'])
+  assert.equal(message.subject, 'Sign in')
+  assert.equal(message.from, 'hello@africanengineer.com')
+  assert.equal(message.fromName, 'The African Engineer')
+  assert.equal(message.replyTo, 'support@africanengineer.com')
+  assert.equal(message.ctaUrl, 'https://example.com/magic-link/token-123')
+  assert.deepEqual(message.links, ['https://example.com/magic-link/token-123'])
+})
+
+test('runtime boot installs in-memory mail capture and lower restores the original helper', async () => {
+  const sendCalls = []
+  const originalSend = async function send(inputs) {
+    sendCalls.push(['direct', inputs])
+    return { accepted: [inputs.to] }
+  }
+  originalSend.with = async (inputs) => {
+    sendCalls.push(['with', inputs])
+    return { accepted: [inputs.to] }
+  }
+
+  const sails = {
+    config: {
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+      mail: {
+        default: 'transactional',
+        mailers: {
+          transactional: {
+            transport: 'smtp',
+          },
+        },
+      },
+    },
+    models: {},
+    helpers: {
+      mail: {
+        send: originalSend,
+      },
+    },
+    renderView: createRenderView((_viewPath, locals) => {
+      return `<a href="${locals.magicLink}">Sign in</a>`
+    }),
+  }
+
+  const runtime = createRuntime(sails)
+  const booted = await runtime.boot({ mode: 'trial' })
+
+  assert.equal(booted.mail.captureInstalled, true)
+  assert.notEqual(sails.helpers.mail.send, originalSend)
+
+  await sails.helpers.mail.send.with({
+    template: 'email-magic-link',
+    templateData: {
+      magicLink: 'https://example.com/magic-link/kelvin',
+    },
+    to: 'reader@example.com',
+    subject: 'Sign in',
+  })
+
+  assert.deepEqual(sendCalls, [])
+
+  assert.equal(runtime.mailbox.latest().status, 'sent')
+  assert.equal(runtime.mailbox.latest().subject, 'Sign in')
+  assert.equal(runtime.mailbox.latest().ctaUrl, 'https://example.com/magic-link/kelvin')
+
+  await runtime.lower()
+
+  assert.equal(sails.helpers.mail.send, originalSend)
+  assert.equal(runtime.mailbox.all().length, 0)
+})
+
+test('runtime can capture failed mail sends when passthrough delivery is enabled', async () => {
+  const originalSend = async function send() {
+    throw new Error('SMTP is down')
+  }
+  originalSend.with = async () => {
+    throw new Error('SMTP is down')
+  }
+
+  const sails = {
+    config: {
+      sounding: {
+        mail: {
+          deliver: true,
+        },
+      },
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+      mail: {
+        default: 'transactional',
+        mailers: {
+          transactional: {
+            transport: 'smtp',
+          },
+        },
+      },
+    },
+    models: {},
+    helpers: {
+      mail: {
+        send: originalSend,
+      },
+    },
+    renderView: createRenderView(() => '<p>No luck</p>'),
+  }
+
+  const runtime = createRuntime(sails)
+  await runtime.boot({ mode: 'trial' })
+
+  await assert.rejects(
+    async () => {
+      await sails.helpers.mail.send.with({
+        to: 'reader@example.com',
+        subject: 'Sign in',
+      })
+    },
+    /SMTP is down/
+  )
+
+  assert.equal(runtime.mailbox.latest().status, 'failed')
+  assert.equal(runtime.mailbox.latest().subject, 'Sign in')
+  assert.equal(runtime.mailbox.latest().error.message, 'SMTP is down')
+
+  await runtime.lower()
+})

--- a/test/request-client.test.js
+++ b/test/request-client.test.js
@@ -1,0 +1,229 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const http = require('node:http')
+
+const { createRequestClient } = require('../lib/create-request-client')
+const { createExpect } = require('../lib/create-expect')
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address()))
+  })
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}
+
+test('createRequestClient defaults to the Sails-native virtual transport', async () => {
+  const calls = []
+  const sails = {
+    router: {
+      route(req, res) {
+        calls.push(req)
+        res._clientRes.statusCode = 200
+        res._clientRes.headers = {
+          'content-type': 'application/json',
+        }
+        res._clientRes.end(JSON.stringify({ ok: true }))
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+
+  const request = createRequestClient({ sails })
+  const response = await request.get('/health')
+
+  assert.equal(request.transport, 'virtual')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].method, 'GET')
+  assert.equal(calls[0].url, '/health')
+  assert.deepEqual(calls[0].headers, { nosession: 'true' })
+  assert.equal(calls[0].data, undefined)
+  assert.deepEqual(calls[0].session.__soundingFlashStore, {})
+  assert.equal(typeof calls[0].flash, 'function')
+  createExpect(response).toHaveStatus(200)
+  createExpect(response).toHaveJsonPath('ok', true)
+  assert.deepEqual(await response.json(), { ok: true })
+})
+
+test('createRequestClient can attach an actor session for virtual policy checks', async () => {
+  const calls = []
+  const sails = {
+    router: {
+      route(req, res) {
+        calls.push(req)
+        res._clientRes.statusCode = 200
+        res._clientRes.headers = {
+          'content-type': 'application/json',
+        }
+        res._clientRes.end(JSON.stringify({ ok: true }))
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+
+  const request = createRequestClient({ sails })
+  await request.as({ id: 24, team: 8 }).get('/dashboard')
+
+  assert.equal(calls[0].session.userId, 24)
+  assert.equal(calls[0].session.teamId, 8)
+  assert.deepEqual(calls[0].session.__soundingFlashStore, {})
+})
+
+test('createRequestClient normalizes non-2xx virtual responses without rejecting', async () => {
+  const sails = {
+    router: {
+      route(_req, res) {
+        res._clientRes.statusCode = 401
+        res._clientRes.headers = {
+          'content-type': 'application/json',
+        }
+        res._clientRes.end(JSON.stringify({ message: 'Unauthorized' }))
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+
+  const request = createRequestClient({ sails })
+  const response = await request.get('/private')
+
+  createExpect(response).toHaveStatus(401)
+  createExpect(response).toHaveJsonPath('message', 'Unauthorized')
+})
+
+test('createRequestClient can follow the Sails-native redirect matcher contract over virtual transport', async () => {
+  const sails = {
+    router: {
+      route(_req, res) {
+        res._clientRes.statusCode = 302
+        res._clientRes.headers = {
+          location: '/login',
+        }
+        res._clientRes.end('')
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+
+  const request = createRequestClient({ sails })
+  const response = await request.get('/dashboard')
+
+  createExpect(response).toHaveStatus(302)
+  createExpect(response).toRedirectTo('/login')
+})
+
+test('createRequestClient can use explicit HTTP transport when parity matters more', async () => {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true }))
+      return
+    }
+
+    res.writeHead(404)
+    res.end()
+  })
+
+  const address = await listen(server)
+
+  try {
+    const request = createRequestClient({
+      sails: {
+        router: {
+          route() {
+            throw new Error('virtual transport should not be used in this test')
+          },
+        },
+        request() {
+          throw new Error('virtual transport should not be used in this test')
+        },
+        config: {
+          sounding: {
+            request: {
+              transport: 'http',
+              baseUrl: `http://127.0.0.1:${address.port}`,
+            },
+          },
+        },
+      },
+    })
+
+    const response = await request.get('/health')
+
+    assert.equal(request.transport, 'http')
+    createExpect(response).toHaveStatus(200)
+    createExpect(response).toHaveJsonPath('ok', true)
+    assert.deepEqual(await response.json(), { ok: true })
+  } finally {
+    await close(server)
+  }
+})
+
+
+test('createRequestClient can scope a client to http transport without changing the original client', async () => {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, transport: 'http' }))
+      return
+    }
+
+    res.writeHead(404)
+    res.end()
+  })
+
+  const address = await listen(server)
+
+  try {
+    const sails = {
+      router: {
+        route(_req, res) {
+          res._clientRes.statusCode = 200
+          res._clientRes.headers = {
+            'content-type': 'application/json',
+          }
+          res._clientRes.end(JSON.stringify({ ok: true, transport: 'virtual' }))
+        },
+      },
+      config: {
+        sounding: {
+          request: {
+            transport: 'virtual',
+            baseUrl: `http://127.0.0.1:${address.port}`,
+          },
+        },
+      },
+    }
+
+    const request = createRequestClient({ sails })
+    const httpRequest = request.using('http')
+
+    const httpResponse = await httpRequest.get('/health')
+    const virtualResponse = await request.get('/health')
+
+    assert.equal(request.transport, 'virtual')
+    assert.equal(httpRequest.transport, 'http')
+    createExpect(httpResponse).toHaveJsonPath('transport', 'http')
+    createExpect(virtualResponse).toHaveJsonPath('transport', 'virtual')
+  } finally {
+    await close(server)
+  }
+})

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -1,0 +1,192 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const soundingHook = require('../index')
+const { createRuntime, resolveConfig } = require('../lib/create-runtime')
+const { getDefaultConfig } = require('../lib/default-config')
+const { buildManagedSqlitePath } = require('../lib/resolve-datastore')
+
+test('Sounding resolves calm Sails-native defaults', () => {
+  const config = resolveConfig({ config: {} })
+
+  assert.deepEqual(config, getDefaultConfig())
+  assert.equal(config.datastore.mode, 'managed')
+  assert.equal(config.datastore.identity, 'default')
+  assert.equal(config.datastore.adapter, 'sails-sqlite')
+  assert.equal(config.datastore.root, '.tmp/db')
+  assert.equal(config.datastore.isolation, 'worker')
+  assert.equal(config.request.transport, 'virtual')
+  assert.equal(config.browser.projects[0], 'desktop')
+})
+
+test('Sounding normalizes shorthand and legacy datastore config shapes', () => {
+  const shorthand = resolveConfig({
+    config: {
+      sounding: {
+        datastore: 'inherit',
+      },
+    },
+  })
+
+  assert.equal(shorthand.datastore.mode, 'inherit')
+  assert.equal(shorthand.datastore.root, '.tmp/db')
+  assert.equal(shorthand.datastore.adapter, 'sails-sqlite')
+
+  const legacyManaged = resolveConfig({
+    config: {
+      sounding: {
+        datastore: {
+          managed: {
+            directory: '.tmp/custom-db',
+            isolation: 'run',
+          },
+        },
+      },
+    },
+  })
+
+  assert.equal(legacyManaged.datastore.mode, 'managed')
+  assert.equal(legacyManaged.datastore.root, '.tmp/custom-db')
+  assert.equal(legacyManaged.datastore.isolation, 'run')
+})
+
+test('createRuntime manages a temporary datastore by default', async () => {
+  const sails = {
+    config: {
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+    },
+    models: {},
+    helpers: {
+      user: {
+        signupWithTeam: {
+          with: async (inputs) => ({
+            user: { email: inputs.email },
+            team: { name: `${inputs.fullName}'s Team` },
+          }),
+        },
+      },
+    },
+  }
+
+  const runtime = createRuntime(sails)
+  const booted = await runtime.boot({ mode: 'browser' })
+
+  assert.equal(booted.mode, 'browser')
+  assert.equal(booted.config.datastore.mode, 'managed')
+  assert.equal(booted.datastore.identity, 'default')
+  assert.equal(booted.datastore.config.adapter, 'sails-sqlite')
+  assert.match(booted.datastore.config.url, /\.tmp\/db\/default\/worker-\d+\.db$/)
+  assert.equal(runtime.request.transport, 'virtual')
+  assert.equal(runtime.visit.transport, 'virtual')
+
+  const resultFromChain = await runtime.helpers.user.signupWithTeam({
+    fullName: 'Kelvin O',
+    email: 'kelvin@example.com',
+  })
+  const resultFromString = await runtime.helpers('user.signupWithTeam', {
+    fullName: 'Kelvin O',
+    email: 'kelvin@example.com',
+  })
+
+  assert.equal(resultFromChain.user.email, 'kelvin@example.com')
+  assert.equal(resultFromChain.team.name, "Kelvin O's Team")
+  assert.equal(resultFromString.user.email, 'kelvin@example.com')
+
+  runtime.mailbox.capture({ to: ['reader@example.com'], subject: 'Sign in' })
+  assert.equal(runtime.mailbox.latest().subject, 'Sign in')
+
+  runtime.world.defineFactory('user', ({ sequence }) => ({
+    email: sequence('user', (number) => `user${number}@example.com`),
+  }))
+
+  const built = runtime.world.build('user')
+  assert.equal(built.email, 'user1@example.com')
+
+  await runtime.lower()
+  assert.equal(runtime.mailbox.all().length, 0)
+  assert.equal(runtime.world.factories.length, 0)
+})
+
+test('createRuntime can switch to an inherited datastore explicitly', async () => {
+  const sails = {
+    config: {
+      sounding: {
+        datastore: 'inherit',
+      },
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+    },
+    models: {},
+    helpers: {},
+  }
+
+  const runtime = createRuntime(sails)
+  const datastore = runtime.configure()
+
+  assert.equal(datastore.mode, 'inherit')
+  assert.equal(datastore.config.url, '.tmp/test.db')
+})
+
+test('buildManagedSqlitePath uses the worker token by default', () => {
+  const filePath = buildManagedSqlitePath({
+    root: '/tmp',
+    identity: 'default',
+    env: {
+      PLAYWRIGHT_WORKER_INDEX: '4',
+    },
+  })
+
+  assert.equal(filePath, '/tmp/default/worker-4.db')
+})
+
+test('the hook exposes sails.sounding and sails.hooks.sounding', async () => {
+  const sails = {
+    config: {
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+      sounding: {
+        world: {
+          factories: 'tests/factories',
+        },
+      },
+    },
+    hooks: {},
+    models: {},
+    helpers: {},
+  }
+
+  const hook = soundingHook(sails)
+  hook.configure()
+
+  await new Promise((resolve, reject) => {
+    hook.initialize((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+
+  assert.ok(sails.sounding)
+  assert.ok(sails.hooks.sounding)
+  assert.equal(typeof sails.sounding.boot, 'function')
+  assert.equal(typeof sails.sounding.world.defineFactory, 'function')
+  assert.equal(typeof sails.sounding.helpers.user, 'function')
+  assert.equal(sails.sounding.request.transport, 'virtual')
+  assert.equal(sails.hooks.sounding.boot, sails.sounding.boot)
+  assert.equal(sails.sounding.datastore.identity, 'default')
+})

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -1,0 +1,303 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createTestApi } = require('../lib/create-test-api')
+
+test('test() boots the runtime and passes a Sails-native helper context', async () => {
+  const calls = []
+  const baseRegistrations = []
+  const runtime = {
+    helpers: {
+      user: {
+        signupWithTeam: async (inputs) => ({
+          user: { email: inputs.email },
+          team: { name: `${inputs.fullName}'s Team` },
+        }),
+      },
+    },
+    world: {
+      use: async () => ({}),
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      get: async () => ({ status: 200, data: { ok: true } }),
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({
+    baseTest,
+    runtime,
+  })
+
+  soundingTest('signupWithTeam returns a team', async ({ sails, expect }) => {
+    const result = await sails.helpers.user.signupWithTeam({
+      fullName: 'Kelvin O',
+      email: 'kelvin@example.com',
+    })
+
+    expect(result.user.email).toBe('kelvin@example.com')
+    expect(result.team.name).toContain('Kelvin O')
+    assert.equal(sails.sounding, runtime)
+  })
+
+  assert.equal(baseRegistrations.length, 1)
+  await baseRegistrations[0].handler({})
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['lower'],
+  ])
+})
+
+test('test() exposes request verb aliases for endpoint-style trials', async () => {
+  const calls = []
+  const baseRegistrations = []
+  const runtime = {
+    helpers: {},
+    world: {
+      use: async () => ({}),
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      get: async () => ({
+        status: 200,
+        data: {
+          ok: true,
+        },
+        header: () => null,
+      }),
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({
+    baseTest,
+    runtime,
+  })
+
+  soundingTest('health endpoint is available', async ({ get, request, expect, sails }) => {
+    const response = await get('/health')
+
+    expect(response).toHaveStatus(200)
+    expect(response).toHaveJsonPath('ok', true)
+    assert.equal(request, sails.sounding.request)
+  })
+
+  assert.equal(baseRegistrations.length, 1)
+  await baseRegistrations[0].handler({})
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['lower'],
+  ])
+})
+
+test('test() can override transport for the whole trial', async () => {
+  const calls = []
+  const baseRegistrations = []
+  const runtime = {
+    helpers: {},
+    world: {
+      use: async () => ({}),
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+      using(transport) {
+        calls.push(['using', transport])
+        return {
+          transport,
+          get: async () => ({
+            status: 200,
+            data: { transport },
+            header: () => null,
+          }),
+        }
+      },
+      get: async () => ({
+        status: 200,
+        data: { transport: 'virtual' },
+        header: () => null,
+      }),
+    },
+    visit: {
+      transport: 'virtual',
+      using(transport) {
+        calls.push(['visit:using', transport])
+        return {
+          transport,
+        }
+      },
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest(
+    'csrf path can opt into http transport',
+    { transport: 'http' },
+    async ({ get, expect, request, sails }) => {
+      const response = await get('/signup')
+
+      expect(response).toHaveStatus(200)
+      expect(response).toHaveJsonPath('transport', 'http')
+      assert.equal(typeof request.get, 'function')
+      assert.equal(request.transport, 'http')
+      assert.equal(sails.sounding.request.transport, 'virtual')
+    }
+  )
+
+  await baseRegistrations[0].handler({})
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['using', 'http'],
+    ['visit:using', 'http'],
+    ['lower'],
+  ])
+})
+
+
+test('test() exposes visit for Inertia-style trials', async () => {
+  const calls = []
+  const baseRegistrations = []
+  const runtime = {
+    helpers: {},
+    world: {
+      use: async () => ({}),
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: Object.assign(
+      async (target) => {
+        calls.push(['visit', target])
+        return {
+          status: 200,
+          data: {
+            component: 'billing/pricing',
+            props: { plans: [] },
+          },
+          header: () => null,
+        }
+      },
+      {
+        transport: 'virtual',
+        using(transport) {
+          calls.push(['using', transport])
+          return Object.assign(
+            async (target) => {
+              calls.push(['visit:scoped', target])
+              return {
+                status: 200,
+                data: {
+                  component: 'billing/pricing',
+                  props: { transport },
+                },
+                header: () => null,
+              }
+            },
+            {
+              transport,
+            }
+          )
+        },
+      }
+    ),
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('pricing page can be visited as an Inertia response', async ({ visit, expect, sails }) => {
+    const page = await visit('/pricing')
+
+    expect(page).toBeInertiaPage('billing/pricing')
+    expect(page).toHaveProp('plans', [])
+    assert.equal(visit.transport, 'virtual')
+    assert.equal(sails.sounding.visit.transport, 'virtual')
+  })
+
+  await baseRegistrations[0].handler({})
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['visit', '/pricing'],
+    ['lower'],
+  ])
+})

--- a/test/visit-client.test.js
+++ b/test/visit-client.test.js
@@ -1,0 +1,198 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createVisitClient, DEFAULT_HEADERS } = require('../lib/create-visit-client')
+const { createExpect } = require('../lib/create-expect')
+
+test('createVisitClient defaults to a GET visit with Inertia headers', async () => {
+  const calls = []
+  const request = {
+    transport: 'virtual',
+    withHeaders(headers) {
+      calls.push(['withHeaders', headers])
+      return {
+        transport: 'virtual',
+        get: async (target, options = {}) => {
+          calls.push(['get', target, options])
+          return {
+            status: 200,
+            data: {
+              component: 'billing/pricing',
+              props: { plans: [] },
+            },
+            header: () => null,
+          }
+        },
+        head: async () => null,
+        post: async () => null,
+        put: async () => null,
+        patch: async () => null,
+        delete: async () => null,
+        using() {
+          throw new Error('not needed in this test')
+        },
+      }
+    },
+  }
+
+  const visit = createVisitClient({ request })
+  const page = await visit('/pricing')
+
+  assert.equal(visit.transport, 'virtual')
+  assert.deepEqual(calls[0], ['withHeaders', DEFAULT_HEADERS])
+  assert.deepEqual(calls[1], ['get', '/pricing', {}])
+  createExpect(page).toBeInertiaPage('billing/pricing')
+})
+
+test('createVisitClient exposes post and transport scoping', async () => {
+  const calls = []
+  const request = {
+    transport: 'virtual',
+    withHeaders(headers) {
+      calls.push(['withHeaders', headers])
+      return {
+        transport: 'virtual',
+        get: async () => null,
+        head: async () => null,
+        post: async (target, payload, options = {}) => {
+          calls.push(['post', target, payload, options])
+          return {
+            status: 200,
+            data: {
+              component: 'auth/signup',
+              props: {
+                errors: {
+                  fullName: 'Full name is required.',
+                },
+              },
+            },
+            header: () => null,
+          }
+        },
+        put: async () => null,
+        patch: async () => null,
+        delete: async () => null,
+      }
+    },
+    using(transport) {
+      calls.push(['using', transport])
+      return {
+        withHeaders(nextHeaders) {
+          calls.push(['withHeaders:scoped', nextHeaders])
+          return {
+            transport,
+            get: async () => null,
+            head: async () => null,
+            post: async () => ({ status: 200, data: { component: 'scoped', props: {} }, header: () => null }),
+            put: async () => null,
+            patch: async () => null,
+            delete: async () => null,
+          }
+        },
+      }
+    },
+  }
+
+  const visit = createVisitClient({ request })
+  const page = await visit.post('/signup', {
+    fullName: '',
+    emailAddress: 'not-an-email',
+  })
+  const httpVisit = visit.using('http')
+
+  createExpect(page).toBeInertiaPage('auth/signup')
+  createExpect(page).toHaveValidationError('fullName', 'Full name is required.')
+  assert.equal(httpVisit.transport, 'http')
+  assert.deepEqual(calls[0], ['withHeaders', DEFAULT_HEADERS])
+  assert.deepEqual(calls[1], [
+    'post',
+    '/signup',
+    {
+      fullName: '',
+      emailAddress: 'not-an-email',
+    },
+    {},
+  ])
+  assert.deepEqual(calls[2], ['using', 'http'])
+  assert.deepEqual(calls[3], ['withHeaders:scoped', DEFAULT_HEADERS])
+})
+
+
+test('createVisitClient can express partial reload headers cleanly', async () => {
+  const calls = []
+  const request = {
+    transport: 'virtual',
+    withHeaders(headers) {
+      calls.push(['withHeaders', headers])
+      return {
+        transport: 'virtual',
+        get: async (target, options = {}) => {
+          calls.push(['get', target, options])
+          return {
+            status: 200,
+            data: {
+              component: 'dashboard/index',
+              props: {
+                notifications: [],
+              },
+            },
+            header: () => null,
+          }
+        },
+        head: async () => null,
+        post: async () => null,
+        put: async () => null,
+        patch: async () => null,
+        delete: async () => null,
+      }
+    },
+  }
+
+  const visit = createVisitClient({ request })
+  const page = await visit('/dashboard', {
+    component: 'dashboard/index',
+    only: ['notifications'],
+    reset: ['sidebar'],
+    version: 'v1',
+  })
+
+  createExpect(page).toBeInertiaPage('dashboard/index')
+  assert.deepEqual(calls[1], [
+    'get',
+    '/dashboard',
+    {
+      headers: {
+        'x-inertia-partial-component': 'dashboard/index',
+        'x-inertia-partial-data': 'notifications',
+        'x-inertia-reset': 'sidebar',
+        'x-inertia-version': 'v1',
+      },
+    },
+  ])
+})
+
+test('createVisitClient requires a component for partial reload selectors', async () => {
+  const request = {
+    transport: 'virtual',
+    withHeaders() {
+      return {
+        transport: 'virtual',
+        get: async () => null,
+        head: async () => null,
+        post: async () => null,
+        put: async () => null,
+        patch: async () => null,
+        delete: async () => null,
+      }
+    },
+  }
+
+  const visit = createVisitClient({ request })
+
+  await assert.rejects(
+    async () => {
+      await visit('/dashboard', { only: ['notifications'] })
+    },
+    /requires `component` when using `only`/
+  )
+})

--- a/test/world-loader.test.js
+++ b/test/world-loader.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { createWorldEngine } = require('../lib/create-world-engine')
+const { loadWorldFiles } = require('../lib/create-world-loader')
+
+test('loadWorldFiles discovers factory and scenario definitions from tests/', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-worlds-'))
+  const factoriesDir = path.join(tempRoot, 'tests', 'factories')
+  const scenariosDir = path.join(tempRoot, 'tests', 'scenarios')
+
+  fs.mkdirSync(factoriesDir, { recursive: true })
+  fs.mkdirSync(scenariosDir, { recursive: true })
+
+  fs.writeFileSync(
+    path.join(factoriesDir, 'user.js'),
+    "module.exports = ({ factory }) => factory('user', ({ sequence }) => ({ email: sequence('user', (n) => `user${n}@example.com`) })).trait('subscriber', { role: 'subscriber' })\n"
+  )
+
+  fs.writeFileSync(
+    path.join(scenariosDir, 'issue-access.js'),
+    "module.exports = ({ scenario }) => scenario('issue-access', async ({ create }) => { const subscriber = await create('user').trait('subscriber'); return { users: { subscriber } }; })\n"
+  )
+
+  const world = createWorldEngine({ sails: {} })
+  const loaded = await loadWorldFiles({
+    world,
+    appPath: tempRoot,
+    config: {
+      world: {
+        factories: 'tests/factories',
+        scenarios: 'tests/scenarios',
+      },
+    },
+    sails: {},
+  })
+
+  assert.equal(loaded.length, 2)
+  assert.deepEqual(world.factories, ['user'])
+  assert.deepEqual(world.scenarios, ['issue-access'])
+
+  const current = await world.use('issue-access')
+  assert.equal(current.users.subscriber.role, 'subscriber')
+  assert.match(current.users.subscriber.email, /^user\d+@example.com$/)
+})


### PR DESCRIPTION
## What this ships

This is the first real Sounding release PR.

It ships the core 0.0.1 shape:

- a Sails-native Sounding hook runtime
- one `test()` API with a Sails-centered trial context
- request trials through `get()`, `post()`, and friends
- Inertia-aware trials through `visit()`
- browser-capable trials when `{ browser: true }` is present
- managed SQLite datastores under `.tmp/db` by default
- real mail capture through the Sails mail path
- worlds, factories, scenarios, and actors as first-class concepts
- docs and release notes for the public 0.0.1 story

## Notes

- Sounding now owns its own world engine instead of depending on a separate Captain Vane integration path.
- The release notes for the GitHub release live in `RELEASE.md`.
- African Engineer and the Boring Stack are already aligned around the 0.0.1 consumption story.

Closes #1
Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
