### PR TITLE
fix: disable sounding in production by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Sounding also owns its own built-in world engine, so the same package can:
 - capture outgoing mail by wrapping `sails.helpers.mail.send` and storing normalized messages in `sails.sounding.mailbox`
 
 The default configuration story is intentionally calm:
+- Sounding disables its hook automatically when Sails runs in `production`
+- set `sounding.enableInProduction = true` only for controlled production-like environments such as staging
 - Sounding manages a temporary `sails-sqlite` datastore by default
 - managed SQLite artifacts live under `.tmp/db`
 - the default datastore identity is `default`

--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ const { createExpect } = require('./lib/create-expect')
 const { createTestApi } = require('./lib/create-test-api')
 const { getDefaultConfig } = require('./lib/default-config')
 
+function isProductionEnvironment(sails) {
+  return (sails.config?.environment || process.env.NODE_ENV) === 'production'
+}
+
+function shouldEnableHook(sails) {
+  return sails.config?.sounding?.enableInProduction === true || !isProductionEnvironment(sails)
+}
+
 function soundingHook(sails) {
   const runtime = createRuntime(sails)
 
@@ -23,6 +31,10 @@ function soundingHook(sails) {
     },
 
     configure() {
+      if (!shouldEnableHook(sails)) {
+        return
+      }
+
       sails.hooks ||= {}
       sails.sounding = runtime
       sails.hooks.sounding = this
@@ -30,6 +42,10 @@ function soundingHook(sails) {
     },
 
     initialize(done) {
+      if (!shouldEnableHook(sails)) {
+        return done()
+      }
+
       sails.sounding = runtime
       Object.assign(this, runtime)
       sails.hooks.sounding = this

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,4 +1,5 @@
 const DEFAULT_CONFIG = Object.freeze({
+  enableInProduction: false,
   app: {
     path: '.',
     environment: 'test',

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -10,6 +10,7 @@ test('Sounding resolves calm Sails-native defaults', () => {
   const config = resolveConfig({ config: {} })
 
   assert.deepEqual(config, getDefaultConfig())
+  assert.equal(config.enableInProduction, false)
   assert.equal(config.datastore.mode, 'managed')
   assert.equal(config.datastore.identity, 'default')
   assert.equal(config.datastore.adapter, 'sails-sqlite')
@@ -189,4 +190,70 @@ test('the hook exposes sails.sounding and sails.hooks.sounding', async () => {
   assert.equal(sails.sounding.request.transport, 'virtual')
   assert.equal(sails.hooks.sounding.boot, sails.sounding.boot)
   assert.equal(sails.sounding.datastore.identity, 'default')
+})
+
+test('the hook stays disabled in production by default', async () => {
+  const sails = {
+    config: {
+      environment: 'production',
+      sounding: {},
+    },
+    hooks: {},
+    models: {},
+    helpers: {},
+  }
+
+  const hook = soundingHook(sails)
+  hook.configure()
+
+  await new Promise((resolve, reject) => {
+    hook.initialize((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+
+  assert.equal(sails.sounding, undefined)
+  assert.equal(sails.hooks.sounding, undefined)
+  assert.equal(typeof hook.boot, 'undefined')
+})
+
+test('the hook can be enabled explicitly in production-like environments', async () => {
+  const sails = {
+    config: {
+      environment: 'production',
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+      sounding: {
+        enableInProduction: true,
+      },
+    },
+    hooks: {},
+    models: {},
+    helpers: {},
+  }
+
+  const hook = soundingHook(sails)
+  hook.configure()
+
+  await new Promise((resolve, reject) => {
+    hook.initialize((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+
+  assert.ok(sails.sounding)
+  assert.ok(sails.hooks.sounding)
+  assert.equal(typeof hook.boot, 'function')
 })


### PR DESCRIPTION
## Summary
- disable the Sounding hook automatically when Sails is running in production
- add a `sounding.enableInProduction` escape hatch for staging and other controlled environments
- cover the production default and override behavior in runtime tests

## Testing
- npm run test

Closes #11
Fixes #11
Resolves #11