### PR TITLE
fix: align mail capture layout default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The default configuration story is intentionally calm:
 - managed SQLite artifacts live under `.tmp/db`
 - the default datastore identity is `default`
 - browser projects start with `desktop`
+- mail capture previews use the `mail` layout by default, matching the current `sails-hook-mail` convention
+- apps with a different mail layout can set `sounding.mail.layout`, for example `layout-email`
 - `inherit` remains available when an app already has a serious test datastore story
 
 For example:

--- a/lib/create-mail-capture.js
+++ b/lib/create-mail-capture.js
@@ -1,6 +1,8 @@
 const path = require('node:path')
 const url = require('node:url')
 
+const DEFAULT_MAIL_LAYOUT = 'mail'
+
 function normalizeList(value) {
   if (value === undefined || value === null || value === '') {
     return []
@@ -62,22 +64,21 @@ function createRenderViewPromise(view) {
   return Promise.resolve(view)
 }
 
-async function renderTemplatePreview(sails, {
-  template,
-  templateData = {},
-  layout = 'layout-email',
-}) {
+async function renderTemplatePreview(sails, inputs = {}, options = {}) {
+  const { template, templateData = {} } = inputs
+
   if (!template || typeof sails?.renderView !== 'function') {
     return undefined
   }
 
+  const resolvedLayout = resolvePreviewLayout(sails, inputs, options)
   const emailTemplatePath = path.join('emails/', template)
   let emailTemplateLayout = false
 
-  if (layout) {
+  if (resolvedLayout) {
     emailTemplateLayout = path.relative(
       path.dirname(emailTemplatePath),
-      path.resolve('layouts/', layout)
+      path.resolve('layouts/', resolvedLayout)
     )
   }
 
@@ -92,6 +93,31 @@ async function renderTemplatePreview(sails, {
 
 function resolveMailConfig(sails) {
   return sails?.config?.mail || {}
+}
+
+function resolveSoundingMailConfig(sails, options = {}) {
+  if (options.mailSettings) {
+    return options.mailSettings
+  }
+
+  const soundingConfig =
+    options.soundingConfig || options.config || sails?.config?.sounding || {}
+
+  return soundingConfig.mail || {}
+}
+
+function resolvePreviewLayout(sails, inputs = {}, options = {}) {
+  if (Object.prototype.hasOwnProperty.call(inputs, 'layout')) {
+    return inputs.layout
+  }
+
+  const mailSettings = resolveSoundingMailConfig(sails, options)
+
+  if (Object.prototype.hasOwnProperty.call(mailSettings, 'layout')) {
+    return mailSettings.layout
+  }
+
+  return DEFAULT_MAIL_LAYOUT
 }
 
 function resolveMailerName(sails, inputs = {}) {
@@ -125,10 +151,11 @@ function toErrorShape(error) {
   }
 }
 
-async function buildCapturedMail(sails, inputs = {}) {
+async function buildCapturedMail(sails, inputs = {}, options = {}) {
   const mailer = resolveMailerName(sails, inputs)
   const transport = resolveTransportName(sails, mailer)
-  const html = await renderTemplatePreview(sails, inputs)
+  const layout = resolvePreviewLayout(sails, inputs, options)
+  const html = await renderTemplatePreview(sails, inputs, options)
   const links = extractLinks(html)
 
   return {
@@ -150,7 +177,7 @@ async function buildCapturedMail(sails, inputs = {}) {
     ctaUrl: resolvePrimaryLink(inputs, links),
     attachments: inputs.attachments || [],
     headers: inputs.headers || {},
-    layout: inputs.layout === undefined ? 'layout-email' : inputs.layout,
+    layout,
   }
 }
 
@@ -171,6 +198,12 @@ function createMailCapture({ sails, mailbox, getConfig }) {
   function shouldPassthrough() {
     const settings = resolveMailSettings()
     return settings.deliver === true || settings.mode === 'passthrough'
+  }
+
+  function resolveMessageLayout(inputs = {}) {
+    return resolvePreviewLayout(sails, inputs, {
+      mailSettings: resolveMailSettings(),
+    })
   }
 
   function wrapDeferred(executor, onRejected) {
@@ -267,7 +300,9 @@ function createMailCapture({ sails, mailbox, getConfig }) {
 
   async function captureSuccessfulSend(inputs = {}) {
     try {
-      const message = await buildCapturedMail(sails, inputs)
+      const message = await buildCapturedMail(sails, inputs, {
+        mailSettings: resolveMailSettings(),
+      })
       mailbox.capture({
         ...message,
         status: 'sent',
@@ -279,6 +314,7 @@ function createMailCapture({ sails, mailbox, getConfig }) {
         to: normalizeList(inputs.to),
         subject: inputs.subject || '',
         template: inputs.template,
+        layout: resolveMessageLayout(inputs),
         status: 'sent',
         captureError: toErrorShape(error),
       })
@@ -289,7 +325,9 @@ function createMailCapture({ sails, mailbox, getConfig }) {
     let message
 
     try {
-      message = await buildCapturedMail(sails, inputs)
+      message = await buildCapturedMail(sails, inputs, {
+        mailSettings: resolveMailSettings(),
+      })
     } catch (captureError) {
       message = {
         mailer: resolveMailerName(sails, inputs),
@@ -297,6 +335,7 @@ function createMailCapture({ sails, mailbox, getConfig }) {
         to: normalizeList(inputs.to),
         subject: inputs.subject || '',
         template: inputs.template,
+        layout: resolveMessageLayout(inputs),
         captureError: toErrorShape(captureError),
       }
     }
@@ -388,4 +427,5 @@ module.exports = {
   normalizeList,
   resolvePrimaryLink,
   renderTemplatePreview,
+  resolvePreviewLayout,
 }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -30,6 +30,7 @@ const DEFAULT_CONFIG = Object.freeze({
   },
   mail: {
     capture: true,
+    layout: 'mail',
   },
   request: {
     transport: 'virtual',

--- a/test/mail-capture.test.js
+++ b/test/mail-capture.test.js
@@ -11,6 +11,7 @@ function createRenderView(htmlBuilder) {
 }
 
 test('buildCapturedMail renders the email preview and extracts links', async () => {
+  let previewLayout
   const sails = {
     config: {
       mail: {
@@ -28,6 +29,7 @@ test('buildCapturedMail renders the email preview and extracts links', async () 
       },
     },
     renderView: createRenderView((_viewPath, locals) => {
+      previewLayout = locals.layout
       return `<a href="${locals.magicLink}">Sign in</a>`
     }),
   }
@@ -50,6 +52,53 @@ test('buildCapturedMail renders the email preview and extracts links', async () 
   assert.equal(message.replyTo, 'support@africanengineer.com')
   assert.equal(message.ctaUrl, 'https://example.com/magic-link/token-123')
   assert.deepEqual(message.links, ['https://example.com/magic-link/token-123'])
+  assert.equal(message.layout, 'mail')
+  assert.equal(previewLayout, '../layouts/mail')
+})
+
+test('buildCapturedMail honors the configured preview layout for compatibility', async () => {
+  let previewLayout
+  const sails = {
+    config: {
+      sounding: {
+        mail: {
+          layout: 'layout-email',
+        },
+      },
+    },
+    renderView: createRenderView((_viewPath, locals) => {
+      previewLayout = locals.layout
+      return '<p>Hello</p>'
+    }),
+  }
+
+  const message = await buildCapturedMail(sails, {
+    template: 'reset-password',
+    to: 'reader@example.com',
+  })
+
+  assert.equal(message.layout, 'layout-email')
+  assert.equal(previewLayout, '../layouts/layout-email')
+})
+
+test('buildCapturedMail keeps explicit layout overrides in preview metadata', async () => {
+  let previewLayout
+  const sails = {
+    config: {},
+    renderView: createRenderView((_viewPath, locals) => {
+      previewLayout = locals.layout
+      return '<p>Hello</p>'
+    }),
+  }
+
+  const message = await buildCapturedMail(sails, {
+    template: 'reset-password',
+    to: 'reader@example.com',
+    layout: false,
+  })
+
+  assert.equal(message.layout, false)
+  assert.equal(previewLayout, false)
 })
 
 test('runtime boot installs in-memory mail capture and lower restores the original helper', async () => {
@@ -111,11 +160,58 @@ test('runtime boot installs in-memory mail capture and lower restores the origin
   assert.equal(runtime.mailbox.latest().status, 'sent')
   assert.equal(runtime.mailbox.latest().subject, 'Sign in')
   assert.equal(runtime.mailbox.latest().ctaUrl, 'https://example.com/magic-link/kelvin')
+  assert.equal(runtime.mailbox.latest().layout, 'mail')
 
   await runtime.lower()
 
   assert.equal(sails.helpers.mail.send, originalSend)
   assert.equal(runtime.mailbox.all().length, 0)
+})
+
+test('runtime mail capture honors sounding mail layout config', async () => {
+  let previewLayout
+  const originalSend = async () => ({})
+  originalSend.with = async () => ({})
+
+  const sails = {
+    config: {
+      sounding: {
+        mail: {
+          layout: 'layout-email',
+        },
+      },
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+    },
+    models: {},
+    helpers: {
+      mail: {
+        send: originalSend,
+      },
+    },
+    renderView: createRenderView((_viewPath, locals) => {
+      previewLayout = locals.layout
+      return '<p>Hello</p>'
+    }),
+  }
+
+  const runtime = createRuntime(sails)
+  await runtime.boot({ mode: 'trial' })
+
+  await sails.helpers.mail.send.with({
+    template: 'reset-password',
+    to: 'reader@example.com',
+    subject: 'Reset your password',
+  })
+
+  assert.equal(runtime.mailbox.latest().layout, 'layout-email')
+  assert.equal(previewLayout, '../layouts/layout-email')
+
+  await runtime.lower()
 })
 
 test('runtime can capture failed mail sends when passthrough delivery is enabled', async () => {


### PR DESCRIPTION
## Summary

- Change Sounding mail preview capture to default to the `mail` layout.
- Add `sounding.mail.layout` so apps that still use another default, such as `layout-email`, can opt into that behavior.
- Record the resolved layout in captured mail metadata and cover the behavior with focused tests.

## Root Cause

Mail capture hard-coded `layout-email` when a send omitted `layout`, which drifted from the current `sails-hook-mail` default of `mail`.

## Validation

- `npm test`

Closes #18