### PR TITLE
Add TypeScript-consumable JSDoc for public APIs

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,21 @@ const { createExpect } = require('./lib/create-expect')
 const { createTestApi } = require('./lib/create-test-api')
 const { getDefaultConfig } = require('./lib/default-config')
 
+/** @typedef {import('./lib/types').SoundingSailsApp} SoundingSailsApp */
+/** @typedef {import('./lib/types').SoundingSailsHook} SoundingSailsHook */
+
+/**
+ * @param {SoundingSailsApp} sails
+ * @returns {string | undefined}
+ */
 function getCurrentEnvironment(sails) {
   return sails.config?.environment || process.env.NODE_ENV
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @returns {string[]}
+ */
 function getEnabledEnvironments(sails) {
   const configured = sails.config?.sounding?.environments
 
@@ -28,10 +39,20 @@ function getEnabledEnvironments(sails) {
   return getDefaultConfig().environments
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @returns {boolean}
+ */
 function shouldEnableHook(sails) {
   return getEnabledEnvironments(sails).includes(getCurrentEnvironment(sails))
 }
 
+/**
+ * Sails hook factory.
+ *
+ * @param {SoundingSailsApp} sails
+ * @returns {SoundingSailsHook}
+ */
 function soundingHook(sails) {
   const runtime = createRuntime(sails)
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": false,
+    "skipLibCheck": true
+  },
+  "include": ["index.js", "lib/**/*.js", "typecheck/**/*.js"]
+}

--- a/lib/create-app-manager.js
+++ b/lib/create-app-manager.js
@@ -6,10 +6,26 @@ const { mergeConfig } = require('./merge-config')
 const { normalizeUserConfig } = require('./normalize-config')
 const { buildManagedSqlitePath, resolveManagedRoot } = require('./resolve-datastore')
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingAppManager} SoundingAppManager */
+/** @typedef {import('./types').SoundingAppManagerOptions} SoundingAppManagerOptions */
+/** @typedef {import('./types').SoundingConfig} SoundingConfig */
+/** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {string} appPath
+ * @param {string} moduleId
+ * @returns {any}
+ */
 function resolveModuleFromApp(appPath, moduleId) {
   return require(require.resolve(moduleId, { paths: [appPath, process.cwd(), __dirname] }))
 }
 
+/**
+ * @param {string} appPath
+ * @returns {SoundingConfig}
+ */
 function loadAppSoundingConfig(appPath) {
   const configPath = path.join(appPath, 'config', 'sounding.js')
 
@@ -19,9 +35,16 @@ function loadAppSoundingConfig(appPath) {
 
   delete require.cache[require.resolve(configPath)]
   const loaded = require(configPath)
-  return mergeConfig(getDefaultConfig(), normalizeUserConfig(loaded?.sounding || {}))
+  return /** @type {SoundingConfig} */ (
+    mergeConfig(getDefaultConfig(), normalizeUserConfig(loaded?.sounding || {}))
+  )
 }
 
+/**
+ * @param {SoundingConfig} config
+ * @param {string} appPath
+ * @returns {AnyRecord}
+ */
 function buildManagedDatastoreOverrides(config, appPath) {
   if (config.datastore?.mode !== 'managed') {
     return {}
@@ -49,6 +72,10 @@ function buildManagedDatastoreOverrides(config, appPath) {
   }
 }
 
+/**
+ * @param {Partial<SoundingConfig>} [config]
+ * @returns {{ install(): void, uninstall(): void }}
+ */
 function createOutputFilter(config = {}) {
   if (config.app?.quiet === false) {
     return {
@@ -121,6 +148,11 @@ function createOutputFilter(config = {}) {
   }
 }
 
+/**
+ * @param {SoundingConfig} config
+ * @param {string} appPath
+ * @returns {string | null}
+ */
 function resolveManagedDatastoreFile(config, appPath) {
   if (config.datastore?.mode !== 'managed') {
     return null
@@ -138,6 +170,10 @@ function resolveManagedDatastoreFile(config, appPath) {
   })
 }
 
+/**
+ * @param {SoundingAppManagerOptions} [options]
+ * @returns {SoundingAppManager}
+ */
 function createAppManager({
   appPath = process.cwd(),
   environment = 'test',
@@ -176,7 +212,9 @@ function createAppManager({
       managedArtifacts.add(managedFile)
     }
 
+    /** @type {AnyRecord} */
     const appConfig = config.app || {}
+    /** @type {AnyRecord} */
     const baseOptions = {
       appPath: resolveAppPath(),
       environment: appConfig.environment || environment,
@@ -194,6 +232,7 @@ function createAppManager({
             appConfig.loadOptions || {}
           )
         : mergeConfig(appConfig.liftOptions || {}, liftOptions)
+    /** @type {AnyRecord} */
     const nextOptions = mergeConfig(baseOptions, modeOptions)
 
     if (mode === 'load' && nextOptions.datastores?.content) {

--- a/lib/create-auth-helpers.js
+++ b/lib/create-auth-helpers.js
@@ -1,15 +1,45 @@
 const { resolveAuthConfig } = require('./resolve-auth-config')
 
+/** @typedef {import('./types').SoundingActor} SoundingActor */
+/** @typedef {import('./types').SoundingAuthHelpers} SoundingAuthHelpers */
+/** @typedef {import('./types').SoundingBrowserLoginResult} SoundingBrowserLoginResult */
+/** @typedef {import('./types').SoundingMagicLink} SoundingMagicLink */
+/** @typedef {import('./types').SoundingMailbox} SoundingMailbox */
+/** @typedef {import('./types').SoundingPage} SoundingPage */
+/** @typedef {import('./types').SoundingPasswordRequestResult} SoundingPasswordRequestResult */
+/** @typedef {import('./types').SoundingRequestMagicLinkResult} SoundingRequestMagicLinkResult */
+/** @typedef {import('./types').SoundingRequestOptions} SoundingRequestOptions */
+/** @typedef {import('./types').SoundingRequestClient} SoundingRequestClient */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+/** @typedef {import('./types').SoundingWorldEngine} SoundingWorldEngine */
+
+/**
+ * @param {any} value
+ * @returns {string}
+ */
 function normalizeEmail(value) {
   return String(value || '')
     .trim()
     .toLowerCase()
 }
 
+/**
+ * @param {any} value
+ * @returns {value is string}
+ */
 function looksLikeEmail(value) {
   return typeof value === 'string' && value.includes('@')
 }
 
+/**
+ * @param {{
+ *   sails?: SoundingSailsApp,
+ *   world: SoundingWorldEngine,
+ *   mailbox: SoundingMailbox,
+ *   request: SoundingRequestClient,
+ * }} input
+ * @returns {SoundingAuthHelpers}
+ */
 function createAuthHelpers({ sails, world, mailbox, request }) {
   function getAuthConfig() {
     return resolveAuthConfig({ sails })
@@ -19,6 +49,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     return getAuthConfig().model
   }
 
+  /**
+   * @param {string} alias
+   * @returns {SoundingActor | null}
+   */
   function resolveWorldActor(alias) {
     if (!alias || typeof alias !== 'string') {
       return null
@@ -34,6 +68,11 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     )
   }
 
+  /**
+   * @param {string} email
+   * @param {string} [fullName]
+   * @returns {Promise<Record<string, any>>}
+   */
   async function createUserFromEmail(email, fullName) {
     const auth = getAuthConfig()
     const User = getAuthModel()
@@ -70,6 +109,11 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     return signupResult.user
   }
 
+  /**
+   * @param {SoundingActor | string} actorOrEmail
+   * @param {{ createIfMissing?: boolean, fullName?: string, [key: string]: any }} [options]
+   * @returns {Promise<Record<string, any>>}
+   */
   async function resolveActor(actorOrEmail, options = {}) {
     const auth = getAuthConfig()
     const User = getAuthModel()
@@ -84,11 +128,16 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
       candidate = resolveWorldActor(candidate) || candidate
     }
 
-    if (candidate?.id && User?.findOne) {
+    if (typeof candidate !== 'string' && candidate?.id && User?.findOne) {
       return User.findOne({ id: candidate.id }) || candidate
     }
 
-    const email = candidate?.email || (looksLikeEmail(candidate) ? candidate : null)
+    const email =
+      typeof candidate === 'string'
+        ? looksLikeEmail(candidate)
+          ? candidate
+          : null
+        : candidate?.email || null
 
     if (!email) {
       throw new Error(
@@ -100,7 +149,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     let user = User?.findOne ? await User.findOne({ email: normalizedEmail }) : null
 
     if (!user && options.createIfMissing !== false) {
-      user = await createUserFromEmail(normalizedEmail, candidate?.fullName || options.fullName)
+      user = await createUserFromEmail(
+        normalizedEmail,
+        (typeof candidate !== 'string' && candidate?.fullName) || options.fullName
+      )
     }
 
     if (!user) {
@@ -112,6 +164,11 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     return user
   }
 
+  /**
+   * @param {SoundingActor | string} actorOrEmail
+   * @param {{ createIfMissing?: boolean, fullName?: string, [key: string]: any }} [options]
+   * @returns {Promise<SoundingMagicLink>}
+   */
   async function issueMagicLink(actorOrEmail, options = {}) {
     const User = getAuthModel()
 
@@ -143,6 +200,11 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     }
   }
 
+  /**
+   * @param {SoundingActor | string} actorOrEmail
+   * @param {{ fullName?: string, redirectUrl?: string, requestOptions?: SoundingRequestOptions, [key: string]: any }} [options]
+   * @returns {Promise<SoundingRequestMagicLinkResult>}
+   */
   async function requestMagicLink(actorOrEmail, options = {}) {
     const user = await resolveActor(actorOrEmail, {
       createIfMissing: true,
@@ -167,6 +229,12 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     }
   }
 
+  /**
+   * @param {SoundingActor | string} actorOrEmail
+   * @param {SoundingPage} page
+   * @param {{ password?: string, rememberMe?: boolean, returnUrl?: string, [key: string]: any }} [options]
+   * @returns {Promise<SoundingBrowserLoginResult>}
+   */
   async function loginWithPassword(actorOrEmail, page, options = {}) {
     if (!page || typeof page.goto !== 'function') {
       throw new Error('Sounding password browser login requires a Playwright page.')
@@ -212,6 +280,11 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     }
   }
 
+  /**
+   * @param {SoundingActor | string} actorOrEmail
+   * @param {{ password?: string, rememberMe?: boolean, returnUrl?: string, request?: SoundingRequestClient, requestOptions?: SoundingRequestOptions, [key: string]: any }} [options]
+   * @returns {Promise<SoundingPasswordRequestResult>}
+   */
   async function requestWithPassword(actorOrEmail, options = {}) {
     const auth = getAuthConfig()
     const actor = await resolveActor(actorOrEmail, {
@@ -224,6 +297,7 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
       throw new Error('Sounding password request auth requires a `password` option.')
     }
 
+    /** @type {Record<string, any>} */
     const payload = {
       [auth.password.form.email]: email,
       [auth.password.form.password]: options.password,

--- a/lib/create-browser-manager.js
+++ b/lib/create-browser-manager.js
@@ -1,17 +1,41 @@
 const { resolveBaseUrl } = require('./create-request-client')
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingBrowserManager} SoundingBrowserManager */
+/** @typedef {import('./types').SoundingBrowserOpenOptions} SoundingBrowserOpenOptions */
+/** @typedef {import('./types').SoundingBrowserSession} SoundingBrowserSession */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {string} appPath
+ * @param {string} moduleId
+ * @returns {any}
+ */
 function resolveModuleFromApp(appPath, moduleId) {
   return require(require.resolve(moduleId, { paths: [appPath, process.cwd(), __dirname] }))
 }
 
+/**
+ * @param {string} appPath
+ * @returns {any}
+ */
 function defaultLoadPlaywright(appPath) {
   return resolveModuleFromApp(appPath, 'playwright')
 }
 
+/**
+ * @param {string} appPath
+ * @returns {any}
+ */
 function defaultLoadPlaywrightTest(appPath) {
   return resolveModuleFromApp(appPath, '@playwright/test')
 }
 
+/**
+ * @param {string} projectName
+ * @param {AnyRecord} [devices]
+ * @returns {AnyRecord}
+ */
 function resolveProjectOptions(projectName, devices = {}) {
   if (projectName === 'mobile') {
     return (
@@ -29,6 +53,16 @@ function resolveProjectOptions(projectName, devices = {}) {
   return {}
 }
 
+/**
+ * @param {{
+ *   sails?: SoundingSailsApp,
+ *   getConfig?: () => AnyRecord,
+ *   appPathResolver?: () => string,
+ *   loadPlaywright?: (appPath: string) => any,
+ *   loadPlaywrightTest?: (appPath: string) => any,
+ * }} [options]
+ * @returns {SoundingBrowserManager}
+ */
 function createBrowserManager({
   sails,
   getConfig,
@@ -38,6 +72,10 @@ function createBrowserManager({
 } = {}) {
   let session = null
 
+  /**
+   * @param {SoundingBrowserOpenOptions} [options]
+   * @returns {Promise<SoundingBrowserSession>}
+   */
   async function open(options = {}) {
     if (session) {
       return session

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -1,9 +1,22 @@
 const assert = require('node:assert/strict')
 
+/** @typedef {import('./types').SoundingExpect} SoundingExpect */
+/** @typedef {import('./types').SoundingExpectation} SoundingExpectation */
+
+/**
+ * @param {any} target
+ * @param {string} path
+ * @returns {any}
+ */
 function getPath(target, path) {
   return path.split('.').reduce((current, segment) => current?.[segment], target)
 }
 
+/**
+ * @param {any} actual
+ * @param {string} name
+ * @returns {any}
+ */
 function getHeader(actual, name) {
   if (typeof actual?.header === 'function') {
     return actual.header(name)
@@ -16,6 +29,10 @@ function getHeader(actual, name) {
   return actual?.headers?.[name]
 }
 
+/**
+ * @param {any} actual
+ * @returns {any}
+ */
 function resolveStructuredValue(actual) {
   if (actual?.data !== undefined) {
     return actual.data
@@ -24,6 +41,10 @@ function resolveStructuredValue(actual) {
   return actual
 }
 
+/**
+ * @param {any} actual
+ * @returns {boolean}
+ */
 function shouldUseFallback(actual) {
   return Boolean(
     actual &&
@@ -36,6 +57,11 @@ function shouldUseFallback(actual) {
   )
 }
 
+/**
+ * @param {any} actual
+ * @param {{ fallback?: (actual: any) => any }} [options]
+ * @returns {SoundingExpectation | any}
+ */
 function createExpect(actual, { fallback } = {}) {
   if (fallback && shouldUseFallback(actual)) {
     return fallback(actual)
@@ -146,10 +172,17 @@ function createExpect(actual, { fallback } = {}) {
   }
 }
 
+/**
+ * @param {(actual: any) => any} fallback
+ * @returns {SoundingExpect}
+ */
 createExpect.withFallback = function withFallback(fallback) {
-  return function soundingExpect(actual) {
+  function soundingExpect(actual) {
     return createExpect(actual, { fallback })
   }
+
+  soundingExpect.withFallback = createExpect.withFallback
+  return soundingExpect
 }
 
 module.exports = { createExpect }

--- a/lib/create-helper-runner.js
+++ b/lib/create-helper-runner.js
@@ -1,10 +1,28 @@
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingHelperRunner} SoundingHelperRunner */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {string} identity
+ * @returns {any}
+ */
 function resolveHelper(sails, identity) {
   return identity
     .split('.')
     .reduce((current, segment) => current?.[segment], sails.helpers)
 }
 
+/**
+ * @param {{ sails: SoundingSailsApp }} input
+ * @returns {SoundingHelperRunner}
+ */
 function createHelperRunner({ sails }) {
+  /**
+   * @param {string} identity
+   * @param {AnyRecord} [inputs]
+   * @returns {Promise<any>}
+   */
   async function invoke(identity, inputs = {}) {
     const helper = resolveHelper(sails, identity)
 
@@ -23,6 +41,10 @@ function createHelperRunner({ sails }) {
     throw new Error(`Sounding helper \`${identity}\` is not callable.`)
   }
 
+  /**
+   * @param {string[]} [path]
+   * @returns {SoundingHelperRunner}
+   */
   function buildProxy(path = []) {
     const callable = async (...args) => {
       if (path.length === 0) {

--- a/lib/create-mail-capture.js
+++ b/lib/create-mail-capture.js
@@ -3,6 +3,16 @@ const url = require('node:url')
 
 const DEFAULT_MAIL_LAYOUT = 'mail'
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingMailCapture} SoundingMailCapture */
+/** @typedef {import('./types').SoundingMailbox} SoundingMailbox */
+/** @typedef {import('./types').SoundingMailMessage} SoundingMailMessage */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {any} value
+ * @returns {any[]}
+ */
 function normalizeList(value) {
   if (value === undefined || value === null || value === '') {
     return []
@@ -22,6 +32,10 @@ function normalizeList(value) {
   return [value]
 }
 
+/**
+ * @param {string | undefined} html
+ * @returns {string[]}
+ */
 function extractLinks(html) {
   if (!html) {
     return []
@@ -31,6 +45,11 @@ function extractLinks(html) {
   return [...matches].map((match) => match[1])
 }
 
+/**
+ * @param {AnyRecord} [inputs]
+ * @param {string[]} [links]
+ * @returns {string | undefined}
+ */
 function resolvePrimaryLink(inputs = {}, links = []) {
   const templateData = inputs.templateData || {}
   const preferredKeys = [
@@ -52,6 +71,10 @@ function resolvePrimaryLink(inputs = {}, links = []) {
   return links.find((link) => !/\/unsubscribe\b/i.test(link)) || links[0]
 }
 
+/**
+ * @param {any} view
+ * @returns {Promise<string | undefined>}
+ */
 function createRenderViewPromise(view) {
   if (!view) {
     return Promise.resolve(undefined)
@@ -64,6 +87,12 @@ function createRenderViewPromise(view) {
   return Promise.resolve(view)
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {AnyRecord} [inputs]
+ * @param {AnyRecord} [options]
+ * @returns {Promise<string | undefined>}
+ */
 async function renderTemplatePreview(sails, inputs = {}, options = {}) {
   const { template, templateData = {} } = inputs
 
@@ -73,6 +102,7 @@ async function renderTemplatePreview(sails, inputs = {}, options = {}) {
 
   const resolvedLayout = resolvePreviewLayout(sails, inputs, options)
   const emailTemplatePath = path.join('emails/', template)
+  /** @type {string | false} */
   let emailTemplateLayout = false
 
   if (resolvedLayout) {
@@ -91,10 +121,19 @@ async function renderTemplatePreview(sails, inputs = {}, options = {}) {
   )
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @returns {AnyRecord}
+ */
 function resolveMailConfig(sails) {
   return sails?.config?.mail || {}
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {AnyRecord} [options]
+ * @returns {AnyRecord}
+ */
 function resolveSoundingMailConfig(sails, options = {}) {
   if (options.mailSettings) {
     return options.mailSettings
@@ -106,6 +145,12 @@ function resolveSoundingMailConfig(sails, options = {}) {
   return soundingConfig.mail || {}
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {AnyRecord} [inputs]
+ * @param {AnyRecord} [options]
+ * @returns {string | false | undefined}
+ */
 function resolvePreviewLayout(sails, inputs = {}, options = {}) {
   if (Object.prototype.hasOwnProperty.call(inputs, 'layout')) {
     return inputs.layout
@@ -151,6 +196,12 @@ function toErrorShape(error) {
   }
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {AnyRecord} [inputs]
+ * @param {AnyRecord} [options]
+ * @returns {Promise<SoundingMailMessage>}
+ */
 async function buildCapturedMail(sails, inputs = {}, options = {}) {
   const mailer = resolveMailerName(sails, inputs)
   const transport = resolveTransportName(sails, mailer)
@@ -181,6 +232,10 @@ async function buildCapturedMail(sails, inputs = {}, options = {}) {
   }
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, mailbox: SoundingMailbox, getConfig?: () => AnyRecord }} input
+ * @returns {SoundingMailCapture}
+ */
 function createMailCapture({ sails, mailbox, getConfig }) {
   let originalSend = null
 

--- a/lib/create-mailbox.js
+++ b/lib/create-mailbox.js
@@ -1,7 +1,18 @@
+/** @typedef {import('./types').SoundingMailbox} SoundingMailbox */
+/** @typedef {import('./types').SoundingMailMessage} SoundingMailMessage */
+
+/**
+ * @returns {SoundingMailbox}
+ */
 function createMailbox() {
+  /** @type {SoundingMailMessage[]} */
   const messages = []
 
   return {
+    /**
+     * @param {SoundingMailMessage} message
+     * @returns {SoundingMailMessage}
+     */
     capture(message) {
       const normalized = {
         capturedAt: new Date().toISOString(),
@@ -11,14 +22,23 @@ function createMailbox() {
       return normalized
     },
 
+    /**
+     * @returns {SoundingMailMessage[]}
+     */
     all() {
       return [...messages]
     },
 
+    /**
+     * @returns {SoundingMailMessage | undefined}
+     */
     latest() {
       return messages.at(-1)
     },
 
+    /**
+     * @returns {void}
+     */
     clear() {
       messages.length = 0
     },

--- a/lib/create-request-client.js
+++ b/lib/create-request-client.js
@@ -2,18 +2,41 @@ const { Transform } = require('node:stream')
 const QS = require('node:querystring')
 const { resolveAuthConfig } = require('./resolve-auth-config')
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingRequestClient} SoundingRequestClient */
+/** @typedef {import('./types').SoundingRequestOptions} SoundingRequestOptions */
+/** @typedef {import('./types').SoundingResponse} SoundingResponse */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+/** @typedef {import('./types').SoundingTransport} SoundingTransport */
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
 function isAbsoluteUrl(value) {
   return /^https?:\/\//i.test(value)
 }
 
+/**
+ * @param {any} value
+ * @returns {value is AnyRecord}
+ */
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
+/**
+ * @param {string} value
+ * @returns {string}
+ */
 function trimTrailingSlash(value) {
   return value.replace(/\/$/, '')
 }
 
+/**
+ * @param {{ contentType?: string, body?: any }} input
+ * @returns {boolean}
+ */
 function looksLikeJson({ contentType, body }) {
   if (!body) {
     return false
@@ -26,6 +49,10 @@ function looksLikeJson({ contentType, body }) {
   return /^[\[{]/.test(String(body).trim())
 }
 
+/**
+ * @param {any} value
+ * @returns {{ body: string, data: any }}
+ */
 function normalizeBodyValue(value) {
   if (value === undefined || value === null) {
     return {
@@ -47,6 +74,18 @@ function normalizeBodyValue(value) {
   }
 }
 
+/**
+ * @param {{
+ *   raw: unknown,
+ *   status: number,
+ *   statusText?: string,
+ *   headers?: HeadersInit | AnyRecord,
+ *   url?: string,
+ *   redirected?: boolean,
+ *   responseBody?: any,
+ * }} input
+ * @returns {SoundingResponse}
+ */
 function normalizeResponse({
   raw,
   status,
@@ -86,6 +125,10 @@ function normalizeResponse({
   }
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, getConfig?: () => AnyRecord }} input
+ * @returns {AnyRecord}
+ */
 function resolveRequestConfig({ sails, getConfig }) {
   const soundingConfig =
     (typeof getConfig === 'function' ? getConfig() : null) || sails?.config?.sounding || {}
@@ -93,6 +136,10 @@ function resolveRequestConfig({ sails, getConfig }) {
   return soundingConfig.request || {}
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, getConfig?: () => AnyRecord, override?: string }} input
+ * @returns {string}
+ */
 function resolveBaseUrl({ sails, getConfig, override }) {
   if (override) {
     return trimTrailingSlash(override)
@@ -129,6 +176,10 @@ function resolveBaseUrl({ sails, getConfig, override }) {
   )
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, getConfig?: () => AnyRecord, target: string, baseUrl?: string }} input
+ * @returns {string}
+ */
 function resolveUrl({ sails, getConfig, target, baseUrl }) {
   if (isAbsoluteUrl(target)) {
     return target
@@ -147,6 +198,11 @@ function resolveUrl({ sails, getConfig, target, baseUrl }) {
   return `${resolvedBaseUrl}/${target}`
 }
 
+/**
+ * @param {string} method
+ * @param {any} payload
+ * @returns {any}
+ */
 function normalizePayload(method, payload) {
   if (payload === undefined) {
     return undefined
@@ -163,6 +219,10 @@ function normalizePayload(method, payload) {
   return payload
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, getConfig?: () => AnyRecord, target: string, options?: SoundingRequestOptions }} input
+ * @returns {SoundingTransport}
+ */
 function resolveTransport({ sails, getConfig, target, options = {} }) {
   if (options.transport) {
     return options.transport
@@ -176,6 +236,12 @@ function resolveTransport({ sails, getConfig, target, options = {} }) {
   return requestConfig.transport || 'virtual'
 }
 
+/**
+ * @param {string} method
+ * @param {string} target
+ * @param {any} payload
+ * @returns {string}
+ */
 function normalizeVirtualUrl(method, target, payload) {
   if (
     (method === 'GET' || method === 'HEAD' || method === 'DELETE') &&
@@ -194,6 +260,10 @@ function normalizeVirtualUrl(method, target, payload) {
   return target
 }
 
+/**
+ * @param {AnyRecord} [session]
+ * @returns {(key: string, value?: any) => any[]}
+ */
 function createFlash(session = {}) {
   const flashStore = (session.__soundingFlashStore ||= {})
 
@@ -217,6 +287,10 @@ class MockClientResponse extends Transform {
   }
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp }} input
+ * @returns {{ send(method: string, target: string, payload?: any, options?: SoundingRequestOptions): Promise<SoundingResponse> }}
+ */
 function createVirtualTransport({ sails }) {
   if (typeof sails?.router?.route !== 'function') {
     throw new Error(
@@ -228,6 +302,7 @@ function createVirtualTransport({ sails }) {
     async send(method, target, payload, options = {}) {
       return new Promise((resolve, reject) => {
         const session = options.session || defaultSessionState()
+        /** @type {MockClientResponse & { body?: any, headers?: AnyRecord, statusCode?: number, statusMessage?: string }} */
         const clientRes = new MockClientResponse()
 
         try {
@@ -295,10 +370,19 @@ function createVirtualTransport({ sails }) {
   }
 }
 
+/**
+ * @returns {AnyRecord}
+ */
 function defaultSessionState() {
   return {}
 }
 
+/**
+ * @param {string} method
+ * @param {any} payload
+ * @param {Headers} headers
+ * @returns {{ body: any, headers: Headers }}
+ */
 function normalizeBodyAndHeaders(method, payload, headers) {
   if (payload === undefined || method === 'GET' || method === 'HEAD') {
     return {
@@ -337,6 +421,14 @@ function normalizeBodyAndHeaders(method, payload, headers) {
   }
 }
 
+/**
+ * @param {{
+ *   sails?: SoundingSailsApp,
+ *   getConfig?: () => AnyRecord,
+ *   fetchImplementation?: typeof fetch,
+ * }} input
+ * @returns {{ send(method: string, target: string, payload?: any, options?: SoundingRequestOptions): Promise<SoundingResponse> }}
+ */
 function createHttpTransport({
   sails,
   getConfig,
@@ -384,6 +476,17 @@ function createHttpTransport({
   }
 }
 
+/**
+ * @param {{
+ *   sails?: SoundingSailsApp,
+ *   getConfig?: () => AnyRecord,
+ *   fetchImplementation?: typeof fetch,
+ *   defaultHeaders?: HeadersInit | AnyRecord,
+ *   defaultSession?: AnyRecord,
+ *   transportOverride?: SoundingTransport,
+ * }} [options]
+ * @returns {SoundingRequestClient}
+ */
 function createRequestClient({
   sails,
   getConfig,

--- a/lib/create-runtime.js
+++ b/lib/create-runtime.js
@@ -14,15 +14,37 @@ const { mergeConfig } = require('./merge-config')
 const { normalizeUserConfig } = require('./normalize-config')
 const { resolveDatastore } = require('./resolve-datastore')
 
+/** @typedef {import('./types').SoundingBootResult} SoundingBootResult */
+/** @typedef {import('./types').SoundingConfig} SoundingConfig */
+/** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {SoundingSailsApp} sails
+ * @returns {SoundingConfig}
+ */
 function resolveConfig(sails) {
-  return mergeConfig(getDefaultConfig(), normalizeUserConfig(sails.config?.sounding || {}))
+  return /** @type {SoundingConfig} */ (
+    mergeConfig(getDefaultConfig(), normalizeUserConfig(sails.config?.sounding || {}))
+  )
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {SoundingConfig} config
+ * @returns {string}
+ */
 function resolveAppPath(sails, config) {
   const basePath = sails?.config?.appPath || process.cwd()
   return path.resolve(basePath, config.app?.path || '.')
 }
 
+/**
+ * Create a Sounding runtime bound to a loaded Sails app.
+ *
+ * @param {SoundingSailsApp} sails
+ * @returns {SoundingRuntime}
+ */
 function createRuntime(sails) {
   const mailbox = createMailbox()
   const world = createWorldEngine({ sails })
@@ -106,6 +128,10 @@ function createRuntime(sails) {
       return datastoreState
     },
 
+    /**
+     * @param {{ mode?: string }} [options]
+     * @returns {Promise<SoundingBootResult>}
+     */
     async boot(options = {}) {
       if (!datastoreState) {
         datastoreState = this.configure()

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -2,6 +2,15 @@ const nodeTest = require('node:test')
 const { createAppManager } = require('./create-app-manager')
 const { createExpect } = require('./create-expect')
 
+/** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
+/** @typedef {import('./types').SoundingExpect} SoundingExpect */
+/** @typedef {import('./types').SoundingTest} SoundingTest */
+/** @typedef {import('./types').SoundingTestOptions} SoundingTestOptions */
+/** @typedef {import('./types').SoundingTrialContext} SoundingTrialContext */
+/** @typedef {import('./types').SoundingTrialHandler} SoundingTrialHandler */
+/** @typedef {import('./types').SoundingTrialRegistrar} SoundingTrialRegistrar */
+/** @typedef {Function & { skip?: Function, todo?: Function, only?: Function }} NodeTestLike */
+
 let defaultAppManager = null
 let defaultCleanupRegistered = false
 let trialQueue = Promise.resolve()
@@ -25,6 +34,12 @@ function ensureDefaultAppManagerCleanup() {
   defaultCleanupRegistered = true
 }
 
+/**
+ * @param {string} title
+ * @param {SoundingTestOptions | SoundingTrialHandler} optionsOrHandler
+ * @param {SoundingTrialHandler} [maybeHandler]
+ * @returns {{ title: string, options: SoundingTestOptions, handler: SoundingTrialHandler }}
+ */
 function normalizeTestArgs(title, optionsOrHandler, maybeHandler) {
   if (typeof optionsOrHandler === 'function') {
     return {
@@ -41,6 +56,10 @@ function normalizeTestArgs(title, optionsOrHandler, maybeHandler) {
   }
 }
 
+/**
+ * @param {{ http?: boolean, browser?: boolean }} [options]
+ * @returns {Promise<{ sounding: SoundingRuntime, teardown(): Promise<void> }>}
+ */
 async function resolveRuntimeFromGlobals(options = {}) {
   const runtime = globalThis.sounding || globalThis.sails?.sounding || globalThis.sails?.hooks?.sounding
   const requiresHttp = Boolean(options.http || options.browser)
@@ -67,10 +86,19 @@ async function resolveRuntimeFromGlobals(options = {}) {
   }
 }
 
+/**
+ * @param {import('./types').SoundingRequestClient} request
+ * @param {'get' | 'head' | 'post' | 'put' | 'patch' | 'delete'} method
+ * @returns {Function | undefined}
+ */
 function bindRequestMethod(request, method) {
   return typeof request?.[method] === 'function' ? request[method].bind(request) : undefined
 }
 
+/**
+ * @param {SoundingTestOptions} [options]
+ * @returns {{ nodeOptions: Record<string, any>, trialOptions: SoundingTestOptions }}
+ */
 function splitTestOptions(options = {}) {
   const {
     transport,
@@ -90,6 +118,11 @@ function splitTestOptions(options = {}) {
   }
 }
 
+/**
+ * @template T
+ * @param {() => Promise<T>} handler
+ * @returns {Promise<T>}
+ */
 async function runInTrialQueue(handler) {
   const previous = trialQueue
   let release = () => {}
@@ -107,6 +140,16 @@ async function runInTrialQueue(handler) {
   }
 }
 
+/**
+ * @param {{
+ *   runtime?: SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>),
+ *   mode: string,
+ *   nodeContext: Record<string, any>,
+ *   handler: SoundingTrialHandler,
+ *   options?: SoundingTestOptions,
+ * }} args
+ * @returns {Promise<any>}
+ */
 async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
   const activeRuntime = typeof runtime === 'function' ? await runtime() : runtime
   const resolved = activeRuntime
@@ -135,10 +178,12 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
     browserSession = await sounding.browser.open(options.browser === true ? {} : options.browser)
   }
 
+  /** @type {SoundingExpect} */
   const expect = browserSession?.expect
     ? createExpect.withFallback(browserSession.expect)
-    : createExpect
+    : /** @type {SoundingExpect} */ (createExpect)
 
+  /** @type {SoundingTrialContext} */
   const context = {
     ...nodeContext,
     t: nodeContext,
@@ -153,12 +198,12 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
     browser: browserSession?.browser,
     browserContext: browserSession?.context,
     page: browserSession?.page,
-    get: bindRequestMethod(request, 'get'),
-    head: bindRequestMethod(request, 'head'),
-    post: bindRequestMethod(request, 'post'),
-    put: bindRequestMethod(request, 'put'),
-    patch: bindRequestMethod(request, 'patch'),
-    del: bindRequestMethod(request, 'delete'),
+    get: /** @type {any} */ (bindRequestMethod(request, 'get')),
+    head: /** @type {any} */ (bindRequestMethod(request, 'head')),
+    post: /** @type {any} */ (bindRequestMethod(request, 'post')),
+    put: /** @type {any} */ (bindRequestMethod(request, 'put')),
+    patch: /** @type {any} */ (bindRequestMethod(request, 'patch')),
+    del: /** @type {any} */ (bindRequestMethod(request, 'delete')),
   }
 
   try {
@@ -168,8 +213,14 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
   }
 }
 
+/**
+ * @param {NodeTestLike} baseTest
+ * @param {SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>) | undefined} runtime
+ * @param {string} mode
+ * @returns {SoundingTrialRegistrar}
+ */
 function createTrialMethod(baseTest, runtime, mode) {
-  return function registerTrial(title, optionsOrHandler, maybeHandler) {
+  const registerTrial = function registerTrial(title, optionsOrHandler, maybeHandler) {
     const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler)
     const { nodeOptions, trialOptions } = splitTestOptions(options)
 
@@ -185,8 +236,16 @@ function createTrialMethod(baseTest, runtime, mode) {
       })
     })
   }
+
+  return /** @type {SoundingTrialRegistrar} */ (registerTrial)
 }
 
+/**
+ * Create Sounding's `test()` API.
+ *
+ * @param {{ baseTest?: NodeTestLike, runtime?: SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>) }} [options]
+ * @returns {SoundingTest}
+ */
 function createTestApi({ baseTest = nodeTest, runtime } = {}) {
   function soundingTest(title, optionsOrHandler, maybeHandler) {
     const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler)
@@ -205,8 +264,8 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
     })
   }
 
-  soundingTest.skip = (...args) => baseTest.skip(...args)
-  soundingTest.todo = (...args) => baseTest.todo(...args)
+  soundingTest.skip = (...args) => baseTest.skip?.(...args)
+  soundingTest.todo = (...args) => baseTest.todo?.(...args)
   if (typeof baseTest.only === 'function') {
     soundingTest.only = (...args) => baseTest.only(...args)
   }

--- a/lib/create-visit-client.js
+++ b/lib/create-visit-client.js
@@ -4,10 +4,25 @@ const DEFAULT_HEADERS = {
   accept: 'text/html, application/xhtml+xml',
 }
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingRequestClient} SoundingRequestClient */
+/** @typedef {import('./types').SoundingRequestOptions} SoundingRequestOptions */
+/** @typedef {import('./types').SoundingTransport} SoundingTransport */
+/** @typedef {import('./types').SoundingVisitClient} SoundingVisitClient */
+/** @typedef {import('./types').SoundingVisitOptions} SoundingVisitOptions */
+
+/**
+ * @param {string | string[]} value
+ * @returns {string}
+ */
 function joinHeaderValue(value) {
   return Array.isArray(value) ? value.join(',') : value
 }
 
+/**
+ * @param {SoundingVisitOptions} [options]
+ * @returns {AnyRecord}
+ */
 function buildVisitHeaders(options = {}) {
   const headers = {
     ...(options.headers || {}),
@@ -46,6 +61,10 @@ function buildVisitHeaders(options = {}) {
   return headers
 }
 
+/**
+ * @param {SoundingVisitOptions} [options]
+ * @returns {SoundingRequestOptions}
+ */
 function buildRequestOptions(options = {}) {
   const {
     component,
@@ -78,6 +97,10 @@ function buildRequestOptions(options = {}) {
   return output
 }
 
+/**
+ * @param {{ request: SoundingRequestClient }} input
+ * @returns {SoundingVisitClient}
+ */
 function createVisitClient({ request }) {
   const client = request.withHeaders(DEFAULT_HEADERS)
 

--- a/lib/create-world-engine.js
+++ b/lib/create-world-engine.js
@@ -3,6 +3,19 @@ const {
   isScenarioDefinition,
 } = require('./define-world')
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingBuilder} SoundingBuilder */
+/** @typedef {import('./types').SoundingFactoryDefinition} SoundingFactoryDefinition */
+/** @typedef {import('./types').SoundingFactoryRegistration} SoundingFactoryRegistration */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+/** @typedef {import('./types').SoundingScenarioDefinition} SoundingScenarioDefinition */
+/** @typedef {import('./types').SoundingWorldEngine} SoundingWorldEngine */
+
+/**
+ * @param {AnyRecord} base
+ * @param {AnyRecord | ((base: AnyRecord) => AnyRecord)} patch
+ * @returns {AnyRecord}
+ */
 function mergeValue(base, patch) {
   if (typeof patch === 'function') {
     return patch(base)
@@ -14,6 +27,10 @@ function mergeValue(base, patch) {
   }
 }
 
+/**
+ * @param {{ sequence: Function }} input
+ * @returns {import('./types').SoundingFactoryHelpers['fake']}
+ */
 function createFakeHelpers({ sequence }) {
   return {
     person: {
@@ -37,6 +54,11 @@ function createFakeHelpers({ sequence }) {
   }
 }
 
+/**
+ * @param {(overrides: AnyRecord, options: { traits: string[] }) => any} executor
+ * @param {AnyRecord} [initialOverrides]
+ * @returns {SoundingBuilder}
+ */
 function createThenableBuilder(executor, initialOverrides = {}) {
   const state = {
     overrides: initialOverrides,
@@ -85,6 +107,10 @@ function createThenableBuilder(executor, initialOverrides = {}) {
   return builder
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp }} input
+ * @returns {SoundingWorldEngine}
+ */
 function createWorldEngine({ sails }) {
   const factories = new Map()
   const scenarios = new Map()
@@ -150,6 +176,10 @@ function createWorldEngine({ sails }) {
     return value
   }
 
+  /**
+   * @param {any} entry
+   * @returns {SoundingFactoryRegistration}
+   */
   function registerFactoryDefinition(entry) {
     const nextEntry = {
       definition: entry.definition,
@@ -166,11 +196,20 @@ function createWorldEngine({ sails }) {
     }
   }
 
+  /**
+   * @param {any} entry
+   * @returns {SoundingScenarioDefinition}
+   */
   function registerScenarioDefinition(entry) {
     scenarios.set(entry.name, entry.definition)
     return entry
   }
 
+  /**
+   * @param {string | any} nameOrEntry
+   * @param {any} [definition]
+   * @returns {SoundingFactoryRegistration}
+   */
   function defineFactory(nameOrEntry, definition) {
     if (isFactoryDefinition(nameOrEntry)) {
       return registerFactoryDefinition(nameOrEntry)
@@ -185,6 +224,11 @@ function createWorldEngine({ sails }) {
     return registerFactoryDefinition(entry)
   }
 
+  /**
+   * @param {string | any} nameOrEntry
+   * @param {any} [definition]
+   * @returns {SoundingScenarioDefinition}
+   */
   function defineScenario(nameOrEntry, definition) {
     if (isScenarioDefinition(nameOrEntry)) {
       return registerScenarioDefinition(nameOrEntry)

--- a/lib/create-world-loader.js
+++ b/lib/create-world-loader.js
@@ -9,8 +9,17 @@ const {
   isScenarioDefinition,
 } = require('./define-world')
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingConfig} SoundingConfig */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+/** @typedef {import('./types').SoundingWorldEngine} SoundingWorldEngine */
+
 const WORLD_EXTENSIONS = new Set(['.js', '.cjs', '.mjs'])
 
+/**
+ * @param {string} directory
+ * @returns {string[]}
+ */
 function listDefinitionFiles(directory) {
   const output = []
 
@@ -30,6 +39,10 @@ function listDefinitionFiles(directory) {
   return output.sort()
 }
 
+/**
+ * @param {string} filePath
+ * @returns {Promise<any>}
+ */
 async function loadModule(filePath) {
   try {
     delete require.cache[require.resolve(filePath)]
@@ -43,6 +56,12 @@ async function loadModule(filePath) {
   }
 }
 
+/**
+ * @param {any} value
+ * @param {AnyRecord} api
+ * @param {string} source
+ * @returns {Promise<void>}
+ */
 async function registerExport(value, api, source) {
   const entry = value?.default ?? value
 
@@ -89,6 +108,10 @@ async function registerExport(value, api, source) {
   )
 }
 
+/**
+ * @param {{ world: SoundingWorldEngine, appPath: string, config: SoundingConfig, sails?: SoundingSailsApp }} input
+ * @returns {Promise<string[]>}
+ */
 async function loadWorldFiles({ world, appPath, config, sails }) {
   const directories = [config.world?.factories, config.world?.scenarios]
     .filter(Boolean)

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,3 +1,6 @@
+/** @typedef {import('./types').SoundingConfig} SoundingConfig */
+
+/** @type {Readonly<SoundingConfig>} */
 const DEFAULT_CONFIG = Object.freeze({
   // Sails environments where the Sounding hook should boot.
   // Keep this test-only by default so non-test processes stay dark.
@@ -55,6 +58,10 @@ const DEFAULT_CONFIG = Object.freeze({
   },
 })
 
+/**
+ * @param {any} value
+ * @returns {any}
+ */
 function cloneValue(value) {
   if (Array.isArray(value)) {
     return value.map(cloneValue)
@@ -69,6 +76,9 @@ function cloneValue(value) {
   return value
 }
 
+/**
+ * @returns {SoundingConfig}
+ */
 function getDefaultConfig() {
   return cloneValue(DEFAULT_CONFIG)
 }

--- a/lib/define-world.js
+++ b/lib/define-world.js
@@ -1,6 +1,16 @@
+/** @typedef {import('./types').SoundingFactoryDefinition} SoundingFactoryDefinition */
+/** @typedef {import('./types').SoundingScenarioDefinition} SoundingScenarioDefinition */
+
+/**
+ * Define a reusable record factory for Sounding worlds.
+ *
+ * @param {string} name
+ * @param {SoundingFactoryDefinition['definition']} definition
+ * @returns {SoundingFactoryDefinition}
+ */
 function defineFactory(name, definition) {
   const entry = {
-    __soundingType: 'factory',
+    __soundingType: /** @type {'factory'} */ ('factory'),
     name,
     definition,
     traits: [],
@@ -13,18 +23,33 @@ function defineFactory(name, definition) {
   return entry
 }
 
+/**
+ * Define a named scenario that can seed a trial with product-language data.
+ *
+ * @param {string} name
+ * @param {SoundingScenarioDefinition['definition']} definition
+ * @returns {SoundingScenarioDefinition}
+ */
 function defineScenario(name, definition) {
   return {
-    __soundingType: 'scenario',
+    __soundingType: /** @type {'scenario'} */ ('scenario'),
     name,
     definition,
   }
 }
 
+/**
+ * @param {any} value
+ * @returns {value is SoundingFactoryDefinition}
+ */
 function isFactoryDefinition(value) {
   return value?.__soundingType === 'factory'
 }
 
+/**
+ * @param {any} value
+ * @returns {value is SoundingScenarioDefinition}
+ */
 function isScenarioDefinition(value) {
   return value?.__soundingType === 'scenario'
 }

--- a/lib/merge-config.js
+++ b/lib/merge-config.js
@@ -1,7 +1,18 @@
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+
+/**
+ * @param {any} value
+ * @returns {value is AnyRecord}
+ */
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
+/**
+ * @param {AnyRecord} base
+ * @param {AnyRecord} override
+ * @returns {AnyRecord}
+ */
 function mergeConfig(base, override) {
   const output = { ...base }
 

--- a/lib/normalize-config.js
+++ b/lib/normalize-config.js
@@ -1,7 +1,18 @@
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingUserConfig} SoundingUserConfig */
+
+/**
+ * @param {any} value
+ * @returns {value is AnyRecord}
+ */
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
+/**
+ * @param {any} datastore
+ * @returns {any}
+ */
 function normalizeDatastore(datastore) {
   if (typeof datastore === 'string') {
     return {
@@ -34,6 +45,10 @@ function normalizeDatastore(datastore) {
   return normalized
 }
 
+/**
+ * @param {any} [config]
+ * @returns {SoundingUserConfig}
+ */
 function normalizeUserConfig(config = {}) {
   if (!isPlainObject(config)) {
     return {}

--- a/lib/resolve-auth-config.js
+++ b/lib/resolve-auth-config.js
@@ -1,7 +1,18 @@
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {any} value
+ * @returns {value is AnyRecord}
+ */
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
 
+/**
+ * @param {any} value
+ * @returns {string | null}
+ */
 function normalizeIdentity(value) {
   if (typeof value !== 'string') {
     return null
@@ -11,6 +22,10 @@ function normalizeIdentity(value) {
   return normalized || null
 }
 
+/**
+ * @param {string | null} value
+ * @returns {string | null}
+ */
 function titleCase(value) {
   if (!value) {
     return value
@@ -19,10 +34,19 @@ function titleCase(value) {
   return `${value[0].toUpperCase()}${value.slice(1)}`
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, getConfig?: () => AnyRecord }} [input]
+ * @returns {AnyRecord}
+ */
 function resolveSoundingConfig({ sails, getConfig } = {}) {
   return (typeof getConfig === 'function' ? getConfig() : null) || sails?.config?.sounding || {}
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {string | null} identity
+ * @returns {AnyRecord | null}
+ */
 function getModelByIdentity(sails, identity) {
   const normalizedIdentity = normalizeIdentity(identity)
 
@@ -33,6 +57,10 @@ function getModelByIdentity(sails, identity) {
   return sails?.models?.[normalizedIdentity] || sails?.models?.[titleCase(normalizedIdentity)] || null
 }
 
+/**
+ * @param {SoundingSailsApp} sails
+ * @returns {string}
+ */
 function detectModelIdentity(sails) {
   for (const candidate of ['user', 'creator']) {
     if (getModelByIdentity(sails, candidate)) {
@@ -43,6 +71,10 @@ function detectModelIdentity(sails) {
   return 'user'
 }
 
+/**
+ * @param {AnyRecord} [authConfig]
+ * @returns {AnyRecord}
+ */
 function resolvePasswordConfig(authConfig = {}) {
   const passwordConfig = isPlainObject(authConfig.password) ? authConfig.password : {}
   const formConfig = isPlainObject(passwordConfig.form) ? passwordConfig.form : {}
@@ -71,6 +103,10 @@ function resolvePasswordConfig(authConfig = {}) {
   }
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, getConfig?: () => AnyRecord }} [input]
+ * @returns {AnyRecord}
+ */
 function resolveAuthConfig({ sails, getConfig } = {}) {
   const soundingConfig = resolveSoundingConfig({ sails, getConfig })
   const authConfig = isPlainObject(soundingConfig.auth) ? soundingConfig.auth : {}

--- a/lib/resolve-datastore.js
+++ b/lib/resolve-datastore.js
@@ -1,5 +1,14 @@
 const path = require('node:path')
 
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingConfig} SoundingConfig */
+/** @typedef {import('./types').SoundingDatastoreState} SoundingDatastoreState */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {NodeJS.ProcessEnv | AnyRecord} [env]
+ * @returns {string}
+ */
 function getWorkerToken(env = process.env) {
   return (
     env.SOUNDING_WORKER_INDEX ||
@@ -9,6 +18,15 @@ function getWorkerToken(env = process.env) {
   )
 }
 
+/**
+ * @param {{
+ *   root?: string,
+ *   identity?: string,
+ *   isolation?: string,
+ *   env?: NodeJS.ProcessEnv | AnyRecord,
+ * }} options
+ * @returns {string}
+ */
 function buildManagedSqlitePath({
   root = path.join(process.cwd(), '.tmp', 'db'),
   identity = 'default',
@@ -19,6 +37,10 @@ function buildManagedSqlitePath({
   return path.join(root, identity, `${workerToken}.db`)
 }
 
+/**
+ * @param {{ sails?: SoundingSailsApp, datastore?: AnyRecord, appPath?: string }} options
+ * @returns {string}
+ */
 function resolveManagedRoot({ sails, datastore = {}, appPath } = {}) {
   const configuredRoot = datastore.root || path.join('.tmp', 'db')
 
@@ -29,7 +51,12 @@ function resolveManagedRoot({ sails, datastore = {}, appPath } = {}) {
   return path.resolve(appPath || sails?.config?.appPath || process.cwd(), configuredRoot)
 }
 
+/**
+ * @param {{ sails: SoundingSailsApp, soundingConfig: SoundingConfig }} input
+ * @returns {SoundingDatastoreState & { managed: boolean, filePath?: string }}
+ */
 function resolveDatastore({ sails, soundingConfig }) {
+  /** @type {AnyRecord} */
   const datastoreConfig = soundingConfig.datastore || {}
   const mode = datastoreConfig.mode || 'managed'
   const identity = datastoreConfig.identity || 'default'

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,491 @@
+/**
+ * Shared TypeScript-consumable JSDoc typedefs for Sounding's public API.
+ *
+ * These comments are intentionally colocated with the JavaScript source so JSDoc
+ * stays the source of truth for editor autocomplete and local type checks.
+ *
+ * @typedef {'virtual' | 'http'} SoundingTransport
+ *
+ * @typedef {Record<string, any>} AnyRecord
+ *
+ * @typedef {string | number | boolean | null} JsonPrimitive
+ *
+ * @typedef {JsonPrimitive | any[] | AnyRecord} JsonValue
+ *
+ * @typedef {{
+ *   id?: string | number,
+ *   email?: string,
+ *   fullName?: string,
+ *   team?: string | number,
+ *   teamId?: string | number,
+ *   headers?: HeadersInit | AnyRecord,
+ *   session?: AnyRecord,
+ *   sounding?: {
+ *     headers?: HeadersInit | AnyRecord,
+ *     session?: AnyRecord,
+ *   },
+ *   [key: string]: any,
+ * }} SoundingActor
+ *
+ * @typedef {RequestInit & {
+ *   headers?: HeadersInit | AnyRecord,
+ *   session?: AnyRecord,
+ *   transport?: SoundingTransport,
+ *   baseUrl?: string,
+ *   requestOptions?: SoundingRequestOptions,
+ *   [key: string]: any,
+ * }} SoundingRequestOptions
+ *
+ * @typedef {{
+ *   raw: unknown,
+ *   ok: boolean,
+ *   status: number,
+ *   statusText: string,
+ *   url?: string,
+ *   redirected: boolean,
+ *   headers: Headers,
+ *   body: string,
+ *   data: any,
+ *   header(name: string): string | null,
+ *   text(): Promise<string>,
+ *   json(): Promise<any>,
+ * }} SoundingResponse
+ *
+ * @typedef {{
+ *   readonly transport: SoundingTransport,
+ *   request(method: string, target: string, options?: SoundingRequestOptions): Promise<SoundingResponse>,
+ *   get(target: string, options?: SoundingRequestOptions): Promise<SoundingResponse>,
+ *   head(target: string, options?: SoundingRequestOptions): Promise<SoundingResponse>,
+ *   post(target: string, payload?: any, options?: SoundingRequestOptions): Promise<SoundingResponse>,
+ *   put(target: string, payload?: any, options?: SoundingRequestOptions): Promise<SoundingResponse>,
+ *   patch(target: string, payload?: any, options?: SoundingRequestOptions): Promise<SoundingResponse>,
+ *   delete(target: string, payload?: any, options?: SoundingRequestOptions): Promise<SoundingResponse>,
+ *   withHeaders(headers?: HeadersInit | AnyRecord): SoundingRequestClient,
+ *   withSession(session?: AnyRecord): SoundingRequestClient,
+ *   using(transport: SoundingTransport): SoundingRequestClient,
+ *   as(actor?: SoundingActor | null): SoundingRequestClient,
+ * }} SoundingRequestClient
+ *
+ * @typedef {SoundingRequestOptions & {
+ *   component?: string,
+ *   only?: string[],
+ *   except?: string[],
+ *   reset?: string[],
+ *   errorBag?: string,
+ *   version?: string,
+ * }} SoundingVisitOptions
+ *
+ * @typedef {{
+ *   (target: string, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   readonly transport: SoundingTransport;
+ *   get(target: string, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   head(target: string, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   post(target: string, payload?: any, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   put(target: string, payload?: any, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   patch(target: string, payload?: any, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   delete(target: string, payload?: any, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   del(target: string, payload?: any, options?: SoundingVisitOptions): Promise<SoundingResponse>;
+ *   using(transport: SoundingTransport): SoundingVisitClient;
+ * }} SoundingVisitClient
+ *
+ * @typedef {{
+ *   capturedAt?: string,
+ *   to?: string | string[],
+ *   from?: string,
+ *   subject?: string,
+ *   text?: string,
+ *   html?: string,
+ *   ctaUrl?: string,
+ *   [key: string]: any,
+ * }} SoundingMailMessage
+ *
+ * @typedef {{
+ *   capture(message: SoundingMailMessage): SoundingMailMessage,
+ *   all(): SoundingMailMessage[],
+ *   latest(): SoundingMailMessage | undefined,
+ *   clear(): void,
+ * }} SoundingMailbox
+ *
+ * @typedef {{
+ *   install(): boolean,
+ *   uninstall(): boolean,
+ *   readonly installed: boolean,
+ * }} SoundingMailCapture
+ *
+ * @typedef {{
+ *   toBe(expected: any): void,
+ *   toEqual(expected: any): void,
+ *   toContain(expected: any): void,
+ *   toMatch(expected: string | RegExp): void,
+ *   toBeTruthy(): void,
+ *   toBeFalsy(): void,
+ *   toBeDefined(): void,
+ *   toHaveStatus(expected: number): void,
+ *   toHaveHeader(name: string, expected?: string): void,
+ *   toRedirectTo(expected: string): void,
+ *   toHaveJsonPath(path: string, expected: any): void,
+ *   toBeInertiaPage(component: string): void,
+ *   toHaveProp(path: string, expected: any): void,
+ *   toMatchProp(path: string, expected: string | RegExp): void,
+ *   toHaveSharedProp(path: string, expected: any): void,
+ *   toHaveValidationError(path: string, expected?: any): void,
+ *   [key: string]: any,
+ * }} SoundingExpectation
+ *
+ * @typedef {{
+ *   (actual: any): SoundingExpectation;
+ *   withFallback(fallback: (actual: any) => any): (actual: any) => SoundingExpectation | any;
+ * }} SoundingExpect
+ *
+ * @typedef {{
+ *   goto(target: string): Promise<any> | any,
+ *   fill(selector: string, value: string): Promise<any> | any,
+ *   click(selector: string): Promise<any> | any,
+ *   check?(selector: string): Promise<any> | any,
+ *   [key: string]: any,
+ * }} SoundingPage
+ *
+ * @typedef {{
+ *   type?: string,
+ *   project?: string,
+ *   launchOptions?: AnyRecord,
+ *   contextOptions?: AnyRecord,
+ * }} SoundingBrowserOpenOptions
+ *
+ * @typedef {{
+ *   playwright: AnyRecord,
+ *   browser: AnyRecord,
+ *   context: AnyRecord,
+ *   page: SoundingPage,
+ *   expect?: (actual: any) => any,
+ *   project: string,
+ * }} SoundingBrowserSession
+ *
+ * @typedef {{
+ *   open(options?: SoundingBrowserOpenOptions): Promise<SoundingBrowserSession>,
+ *   close(): Promise<void>,
+ *   readonly active: boolean,
+ *   readonly page?: SoundingPage,
+ *   readonly context?: AnyRecord,
+ *   readonly expect?: (actual: any) => any,
+ * }} SoundingBrowserManager
+ *
+ * @typedef {{
+ *   sequence(nameOrBuilder?: string | ((next: number) => any), maybeBuilder?: (next: number) => any): any,
+ *   fake: {
+ *     person: { fullName(): string },
+ *     internet: { email(): string },
+ *     lorem: {
+ *       words(count?: number): string,
+ *       sentence(count?: number): string,
+ *     },
+ *   },
+ *   seed: any,
+ *   sails: SoundingSailsApp,
+ * }} SoundingFactoryHelpers
+ *
+ * @typedef {{
+ *   name: string,
+ *   __soundingType: 'factory',
+ *   definition: AnyRecord | ((helpers: SoundingFactoryHelpers) => AnyRecord),
+ *   traits: Array<[string, AnyRecord | ((base: AnyRecord) => AnyRecord)]>,
+ *   trait(traitName: string, patch: AnyRecord | ((base: AnyRecord) => AnyRecord)): SoundingFactoryDefinition,
+ * }} SoundingFactoryDefinition
+ *
+ * @typedef {{
+ *   trait(traitName: string, patch: AnyRecord | ((base: AnyRecord) => AnyRecord)): SoundingFactoryRegistration,
+ * }} SoundingFactoryRegistration
+ *
+ * @typedef {PromiseLike<any> & {
+ *   trait(name: string): SoundingBuilder,
+ *   traits(names?: string[]): SoundingBuilder,
+ *   with(overrides?: AnyRecord): SoundingBuilder,
+ *   value(): any,
+ *   catch(onRejected?: ((reason: any) => any) | null): Promise<any>,
+ *   finally(onFinally?: (() => void) | null): Promise<any>,
+ * }} SoundingBuilder
+ *
+ * @typedef {{
+ *   build(name: string, overrides?: AnyRecord): SoundingBuilder,
+ *   create(name: string, overrides?: AnyRecord): SoundingBuilder,
+ *   defineFactory: SoundingWorldEngine['defineFactory'],
+ *   defineScenario: SoundingWorldEngine['defineScenario'],
+ *   sails: SoundingSailsApp,
+ *   sequence(nameOrBuilder?: string | ((next: number) => any), maybeBuilder?: (next: number) => any): any,
+ *   seed: any,
+ *   context: AnyRecord,
+ * }} SoundingScenarioHelpers
+ *
+ * @typedef {{
+ *   name: string,
+ *   __soundingType: 'scenario',
+ *   definition: (helpers: SoundingScenarioHelpers) => Promise<AnyRecord> | AnyRecord,
+ * }} SoundingScenarioDefinition
+ *
+ * @typedef {{
+ *   build(name: string, overrides?: AnyRecord, options?: { traits?: string[] }): AnyRecord,
+ *   buildMany(name: string, count: number, overrides?: AnyRecord, options?: { traits?: string[] }): Promise<AnyRecord[]>,
+ *   create(name: string, overrides?: AnyRecord, options?: { traits?: string[] }): Promise<AnyRecord>,
+ *   createMany(name: string, count: number, overrides?: AnyRecord, options?: { traits?: string[] }): Promise<AnyRecord[]>,
+ *   defineFactory(name: string, definition: AnyRecord | ((helpers: SoundingFactoryHelpers) => AnyRecord)): SoundingFactoryRegistration,
+ *   defineFactory(definition: SoundingFactoryDefinition): SoundingFactoryRegistration,
+ *   defineScenario(name: string, definition: SoundingScenarioDefinition['definition']): SoundingScenarioDefinition,
+ *   defineScenario(definition: SoundingScenarioDefinition): SoundingScenarioDefinition,
+ *   register(definition: SoundingFactoryDefinition | SoundingScenarioDefinition): SoundingFactoryRegistration | SoundingScenarioDefinition,
+ *   readonly current: AnyRecord | null,
+ *   readonly factories: string[],
+ *   readonly scenarios: string[],
+ *   reset(options?: { preserveSequences?: boolean }): void,
+ *   seed(value: any): any,
+ *   sequence(nameOrBuilder?: string | ((next: number) => any), maybeBuilder?: (next: number) => any): any,
+ *   use(name: string, context?: AnyRecord): Promise<AnyRecord>,
+ * }} SoundingWorldEngine
+ *
+ * @typedef {{
+ *   user: AnyRecord,
+ *   email: string,
+ *   token: string,
+ *   url: string,
+ * }} SoundingMagicLink
+ *
+ * @typedef {{
+ *   response: SoundingResponse,
+ *   email: string,
+ *   message?: SoundingMailMessage,
+ *   url?: string,
+ * }} SoundingRequestMagicLinkResult
+ *
+ * @typedef {{
+ *   actor: AnyRecord,
+ *   email: string,
+ *   path: string,
+ * }} SoundingBrowserLoginResult
+ *
+ * @typedef {{
+ *   actor: AnyRecord,
+ *   email: string,
+ *   request: SoundingRequestClient,
+ *   response: SoundingResponse,
+ * }} SoundingPasswordRequestResult
+ *
+ * @typedef {{
+ *   as(actorOrEmail: SoundingActor | string, page: SoundingPage, options?: AnyRecord): Promise<SoundingMagicLink>,
+ *   withPassword(actorOrEmail: SoundingActor | string, page: SoundingPage, options: { password: string, rememberMe?: boolean, returnUrl?: string, [key: string]: any }): Promise<SoundingBrowserLoginResult>,
+ * }} SoundingLoginHelpers
+ *
+ * @typedef {{
+ *   conventions: AnyRecord,
+ *   resolveActor(actorOrEmail: SoundingActor | string, options?: AnyRecord): Promise<AnyRecord>,
+ *   resolveUser(actorOrEmail: SoundingActor | string, options?: AnyRecord): Promise<AnyRecord>,
+ *   issueMagicLink(actorOrEmail: SoundingActor | string, options?: AnyRecord): Promise<SoundingMagicLink>,
+ *   requestMagicLink(actorOrEmail: SoundingActor | string, options?: AnyRecord): Promise<SoundingRequestMagicLinkResult>,
+ *   request: {
+ *     withPassword(actorOrEmail: SoundingActor | string, options: { password: string, rememberMe?: boolean, returnUrl?: string, request?: SoundingRequestClient, requestOptions?: SoundingRequestOptions, [key: string]: any }): Promise<SoundingPasswordRequestResult>,
+ *   },
+ *   login: SoundingLoginHelpers,
+ * }} SoundingAuthHelpers
+ *
+ * @typedef {((identity: string, inputs?: AnyRecord) => Promise<any>) & {
+ *   readonly path?: string,
+ *   [key: string]: any,
+ * }} SoundingHelperRunner
+ *
+ * @typedef {{
+ *   config?: AnyRecord,
+ *   hooks?: AnyRecord,
+ *   helpers?: AnyRecord,
+ *   models?: AnyRecord,
+ *   router?: {
+ *     route?: (...args: any[]) => any,
+ *   },
+ *   sounding?: SoundingRuntime,
+ *   request?: (...args: any[]) => any,
+ *   lower?: (done?: (error?: Error) => void) => any,
+ *   [key: string]: any,
+ * }} SoundingSailsApp
+ *
+ * @typedef {{
+ *   environments: string[],
+ *   app: {
+ *     path: string,
+ *     environment: string,
+ *     quiet: boolean,
+ *     loadOptions?: AnyRecord,
+ *     liftOptions: AnyRecord,
+ *   },
+ *   world: {
+ *     factories: string,
+ *     scenarios: string,
+ *   },
+ *   datastore: {
+ *     mode: 'managed' | 'inherit' | string,
+ *     identity: string,
+ *     adapter: string,
+ *     root: string,
+ *     isolation: 'worker' | 'run' | string,
+ *   },
+ *   browser: {
+ *     enabled: boolean,
+ *     type: string,
+ *     projects: string[],
+ *     defaultProject: string,
+ *     baseUrl?: string,
+ *     launchOptions: AnyRecord,
+ *   },
+ *   mail: {
+ *     capture: boolean,
+ *     layout: string,
+ *     deliver?: boolean,
+ *     mode?: 'capture' | 'passthrough' | string,
+ *   },
+ *   request: {
+ *     transport: SoundingTransport,
+ *     baseUrl?: string,
+ *   },
+ *   auth: {
+ *     defaultActor: string,
+ *     modelIdentity: string | null,
+ *     sessionKey: string | null,
+ *     worldCollection: string | null,
+ *     password: {
+ *       loginPath: string,
+ *       pagePath: string,
+ *       pageQuery: AnyRecord,
+ *       form: {
+ *         email: string,
+ *         password: string,
+ *         rememberMe: string,
+ *         returnUrl: string,
+ *       },
+ *       selectors: AnyRecord,
+ *     },
+ *   },
+ * }} SoundingConfig
+ *
+ * @typedef {Partial<SoundingConfig> & {
+ *   datastore?: SoundingConfig['datastore'] | 'inherit' | 'managed',
+ * }} SoundingUserConfig
+ *
+ * @typedef {{
+ *   mode: string,
+ *   identity: string,
+ *   config: AnyRecord,
+ * }} SoundingDatastoreState
+ *
+ * @typedef {{
+ *   bootedAt: string,
+ *   mode: string,
+ *   config: SoundingConfig,
+ *   datastore: SoundingDatastoreState | null,
+ *   mail: {
+ *     captureEnabled: boolean,
+ *     captureInstalled: boolean,
+ *   },
+ *   world: {
+ *     loadedFiles: string[],
+ *   },
+ * }} SoundingRuntimeState
+ *
+ * @typedef {{
+ *   sails: SoundingSailsApp,
+ *   bootedAt: string,
+ *   mode: string,
+ *   config: SoundingConfig,
+ *   datastore: SoundingDatastoreState | null,
+ *   mail: {
+ *     captureEnabled: boolean,
+ *     captureInstalled: boolean,
+ *   },
+ *   helpers: SoundingHelperRunner,
+ *   mailbox: SoundingMailbox,
+ *   world: SoundingWorldEngine,
+ *   request: SoundingRequestClient,
+ *   visit: SoundingVisitClient,
+ *   browser: SoundingBrowserManager,
+ *   auth: SoundingAuthHelpers,
+ *   login: SoundingLoginHelpers,
+ * }} SoundingBootResult
+ *
+ * @typedef {{
+ *   readonly config: SoundingConfig,
+ *   readonly appPath: string,
+ *   readonly mailbox: SoundingMailbox,
+ *   readonly world: SoundingWorldEngine,
+ *   readonly helpers: SoundingHelperRunner,
+ *   readonly helper: SoundingHelperRunner,
+ *   readonly request: SoundingRequestClient,
+ *   readonly visit: SoundingVisitClient,
+ *   readonly browser: SoundingBrowserManager,
+ *   readonly auth: SoundingAuthHelpers,
+ *   configure(): SoundingDatastoreState,
+ *   readonly datastore: SoundingDatastoreState | null,
+ *   boot(options?: { mode?: string }): Promise<SoundingBootResult>,
+ *   lower(): Promise<void>,
+ *   readonly state: SoundingRuntimeState | null,
+ * }} SoundingRuntime
+ *
+ * @typedef {{
+ *   appPath?: string,
+ *   environment?: string,
+ *   liftOptions?: AnyRecord,
+ *   SailsConstructor?: new (...args: any[]) => SoundingSailsApp,
+ * }} SoundingAppManagerOptions
+ *
+ * @typedef {{
+ *   load(): Promise<SoundingSailsApp>,
+ *   lift(): Promise<SoundingSailsApp>,
+ *   runtime(options?: { http?: boolean }): Promise<SoundingRuntime>,
+ *   lower(): Promise<void>,
+ *   resolveConfig(): SoundingConfig,
+ * }} SoundingAppManager
+ *
+ * @typedef {SoundingRequestOptions & {
+ *   transport?: SoundingTransport,
+ *   browser?: boolean | SoundingBrowserOpenOptions,
+ * }} SoundingTestOptions
+ *
+ * @typedef {AnyRecord & {
+ *   t: AnyRecord,
+ *   expect: SoundingExpect,
+ *   sails: SoundingSailsApp,
+ *   request: SoundingRequestClient,
+ *   visit: SoundingVisitClient,
+ *   auth: SoundingAuthHelpers,
+ *   login: SoundingLoginHelpers,
+ *   world: SoundingWorldEngine,
+ *   mailbox: SoundingMailbox,
+ *   browser?: AnyRecord,
+ *   browserContext?: AnyRecord,
+ *   page?: SoundingPage,
+ *   get: SoundingRequestClient['get'],
+ *   head: SoundingRequestClient['head'],
+ *   post: SoundingRequestClient['post'],
+ *   put: SoundingRequestClient['put'],
+ *   patch: SoundingRequestClient['patch'],
+ *   del: SoundingRequestClient['delete'],
+ * }} SoundingTrialContext
+ *
+ * @typedef {(context: SoundingTrialContext) => any | Promise<any>} SoundingTrialHandler
+ *
+ * @typedef {{
+ *   (title: string, handler: SoundingTrialHandler): unknown;
+ *   (title: string, options: SoundingTestOptions, handler: SoundingTrialHandler): unknown;
+ * }} SoundingTrialRegistrar
+ *
+ * @typedef {SoundingTrialRegistrar & {
+ *   skip(...args: any[]): unknown,
+ *   todo(...args: any[]): unknown,
+ *   only?: (...args: any[]) => unknown,
+ *   helper: SoundingTrialRegistrar,
+ *   endpoint: SoundingTrialRegistrar,
+ * }} SoundingTest
+ *
+ * @typedef {{
+ *   defaults: { sounding: SoundingConfig },
+ *   configure(): void,
+ *   initialize(done: (error?: Error) => void): void,
+ *   [key: string]: any,
+ * }} SoundingSailsHook
+ */
+
+module.exports = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "sounding",
+  "version": "0.0.4",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sounding",
+      "version": "0.0.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.9.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "typecheck": "tsc -p jsconfig.json --noEmit"
   },
   "sails": {
     "isHook": true,
@@ -35,5 +36,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^6.0.3"
   }
 }

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+const {
+  createExpect,
+  createRequestClient,
+  createVisitClient,
+  test,
+} = require('../index')
+
+const request = createRequestClient({
+  sails: {
+    config: {
+      sounding: {},
+    },
+    router: {
+      route() {},
+    },
+  },
+})
+
+request
+  .as({ id: 1, teamId: 2 })
+  .withHeaders({ accept: 'application/json' })
+  .using('virtual')
+  .get('/account')
+  .then((response) => {
+    createExpect(response).toHaveStatus(200)
+    return response.json()
+  })
+
+// @ts-expect-error Sounding only supports virtual and http transports.
+request.using('ftp')
+
+const visit = createVisitClient({ request })
+visit('/dashboard', {
+  component: 'dashboard/index',
+  only: ['notifications'],
+})
+
+test('trial callback context is typed from JSDoc', async ({ get, expect, request }) => {
+  const response = await get('/health')
+  expect(response).toHaveStatus(200)
+
+  // @ts-expect-error Trial request clients only support virtual and http transports.
+  request.using('ftp')
+})


### PR DESCRIPTION
## Summary
- add shared JSDoc typedefs for Sounding's public JavaScript API surface
- annotate runtime, test, request, visit, auth, world, mailbox, browser, and config helpers
- add JS-project typechecking via jsconfig plus a public API smoke file

## Verification
- npm run typecheck
- npm test
- npm pack --dry-run
- packed tarball consumer smoke check with tsc -p jsconfig.json --noEmit

Closes #20