### PR TITLE
feat: add stable Sounding error codes

### DIFF
--- a/lib/create-auth-helpers.js
+++ b/lib/create-auth-helpers.js
@@ -1,4 +1,5 @@
 const { resolveAuthConfig } = require('./resolve-auth-config')
+const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').SoundingActor} SoundingActor */
 /** @typedef {import('./types').SoundingAuthHelpers} SoundingAuthHelpers */
@@ -78,15 +79,20 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     const User = getAuthModel()
 
     if (auth.modelIdentity !== 'user') {
-      throw new Error(
-        `Sounding auth helpers could not auto-create a missing ${auth.modelIdentity} record.`
-      )
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_CREATE_UNSUPPORTED',
+        message: `Sounding auth helpers could not auto-create a missing ${auth.modelIdentity} record.`,
+        details: {
+          modelIdentity: auth.modelIdentity,
+        },
+      })
     }
 
     if (!sails?.helpers?.user?.signupWithTeam) {
-      throw new Error(
-        'Sounding auth helpers could not find `sails.helpers.user.signupWithTeam`.'
-      )
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_SIGNUP_HELPER_MISSING',
+        message: 'Sounding auth helpers could not find `sails.helpers.user.signupWithTeam`.',
+      })
     }
 
     const signupResult = await sails.helpers.user.signupWithTeam.with({
@@ -119,7 +125,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     const User = getAuthModel()
 
     if (!actorOrEmail) {
-      throw new Error('Sounding auth helpers require an actor or email address.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_ACTOR_REQUIRED',
+        message: 'Sounding auth helpers require an actor or email address.',
+      })
     }
 
     let candidate = actorOrEmail
@@ -140,9 +149,13 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
         : candidate?.email || null
 
     if (!email) {
-      throw new Error(
-        `Sounding auth helpers could not resolve an email address for actor \`${candidate}\`.`
-      )
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_EMAIL_UNRESOLVED',
+        message: `Sounding auth helpers could not resolve an email address for actor \`${candidate}\`.`,
+        details: {
+          actor: candidate,
+        },
+      })
     }
 
     const normalizedEmail = normalizeEmail(email)
@@ -156,9 +169,14 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     }
 
     if (!user) {
-      throw new Error(
-        `Sounding auth helpers could not find a ${auth.modelIdentity} for ${normalizedEmail}.`
-      )
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_MODEL_UNAVAILABLE',
+        message: `Sounding auth helpers could not find a ${auth.modelIdentity} for ${normalizedEmail}.`,
+        details: {
+          modelIdentity: auth.modelIdentity,
+          email: normalizedEmail,
+        },
+      })
     }
 
     return user
@@ -173,7 +191,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     const User = getAuthModel()
 
     if (!User?.updateOne) {
-      throw new Error('Sounding auth helpers require an auth model with updateOne().')
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_MODEL_UNAVAILABLE',
+        message: 'Sounding auth helpers require an auth model with updateOne().',
+      })
     }
 
     const user = await resolveActor(actorOrEmail, {
@@ -237,7 +258,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
    */
   async function loginWithPassword(actorOrEmail, page, options = {}) {
     if (!page || typeof page.goto !== 'function') {
-      throw new Error('Sounding password browser login requires a Playwright page.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_BROWSER_PAGE_REQUIRED',
+        message: 'Sounding password browser login requires a Playwright page.',
+      })
     }
 
     const auth = getAuthConfig()
@@ -248,7 +272,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     const email = normalizeEmail(actor?.email || actorOrEmail)
 
     if (!options.password) {
-      throw new Error('Sounding password login requires a `password` option.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_PASSWORD_REQUIRED',
+        message: 'Sounding password login requires a `password` option.',
+      })
     }
 
     const loginUrl = new URL(auth.password.pagePath, 'http://sounding.local')
@@ -294,7 +321,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     const email = normalizeEmail(actor?.email || actorOrEmail)
 
     if (!options.password) {
-      throw new Error('Sounding password request auth requires a `password` option.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_AUTH_PASSWORD_REQUIRED',
+        message: 'Sounding password request auth requires a `password` option.',
+      })
     }
 
     /** @type {Record<string, any>} */

--- a/lib/create-browser-manager.js
+++ b/lib/create-browser-manager.js
@@ -1,4 +1,5 @@
 const { resolveBaseUrl } = require('./create-request-client')
+const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingBrowserManager} SoundingBrowserManager */
@@ -84,7 +85,10 @@ function createBrowserManager({
     const config = typeof getConfig === 'function' ? getConfig() : sails?.config?.sounding || {}
 
     if (config.browser?.enabled === false) {
-      throw new Error('Sounding browser support is disabled in `config/sounding.js`.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_BROWSER_DISABLED',
+        message: 'Sounding browser support is disabled in `config/sounding.js`.',
+      })
     }
 
     const appPath = appPathResolver()
@@ -97,9 +101,13 @@ function createBrowserManager({
     const browserType = playwright?.[browserTypeName]
 
     if (!browserType?.launch) {
-      throw new Error(
-        `Sounding could not find a Playwright browser type named \`${browserTypeName}\`.`
-      )
+      throw createSoundingError({
+        code: 'E_SOUNDING_BROWSER_TYPE_UNAVAILABLE',
+        message: `Sounding could not find a Playwright browser type named \`${browserTypeName}\`.`,
+        details: {
+          browserType: browserTypeName,
+        },
+      })
     }
 
     const projectName =

--- a/lib/create-error.js
+++ b/lib/create-error.js
@@ -1,0 +1,35 @@
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+
+/**
+ * Sounding error codes are a lightweight diagnostic contract for tests,
+ * reporters, and docs. Keep messages human-readable, and use code/details for
+ * stable programmatic handling.
+ *
+ * @template {AnyRecord} TDetails
+ * @param {{
+ *   code: string,
+ *   message: string,
+ *   details?: TDetails,
+ *   cause?: unknown,
+ *   name?: string,
+ * }} input
+ * @returns {Error & { code: string, details: TDetails, [key: string]: any } & TDetails}
+ */
+function createSoundingError({ code, message, details, cause, name }) {
+  const resolvedDetails = /** @type {TDetails} */ (details || {})
+  const error = /** @type {Error & { code: string, details: TDetails, [key: string]: any } & TDetails} */ (
+    cause === undefined ? new Error(message) : new Error(message, { cause })
+  )
+
+  Object.assign(error, resolvedDetails)
+  error.name = name || 'SoundingError'
+  error.message = message
+  error.code = code
+  error.details = /** @type {TDetails} */ ({ ...resolvedDetails })
+
+  return error
+}
+
+module.exports = {
+  createSoundingError,
+}

--- a/lib/create-helper-runner.js
+++ b/lib/create-helper-runner.js
@@ -1,3 +1,5 @@
+const { createSoundingError } = require('./create-error')
+
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingHelperRunner} SoundingHelperRunner */
 /** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
@@ -27,7 +29,13 @@ function createHelperRunner({ sails }) {
     const helper = resolveHelper(sails, identity)
 
     if (!helper) {
-      throw new Error(`Unknown Sounding helper: ${identity}`)
+      throw createSoundingError({
+        code: 'E_SOUNDING_HELPER_UNKNOWN',
+        message: `Unknown Sounding helper: ${identity}`,
+        details: {
+          identity,
+        },
+      })
     }
 
     if (typeof helper.with === 'function') {
@@ -38,7 +46,13 @@ function createHelperRunner({ sails }) {
       return helper(inputs)
     }
 
-    throw new Error(`Sounding helper \`${identity}\` is not callable.`)
+    throw createSoundingError({
+      code: 'E_SOUNDING_HELPER_NOT_CALLABLE',
+      message: `Sounding helper \`${identity}\` is not callable.`,
+      details: {
+        identity,
+      },
+    })
   }
 
   /**

--- a/lib/create-mail-capture.js
+++ b/lib/create-mail-capture.js
@@ -1,5 +1,6 @@
 const path = require('node:path')
 const url = require('node:url')
+const { createSoundingError } = require('./create-error')
 
 const DEFAULT_MAIL_LAYOUT = 'mail'
 
@@ -338,7 +339,10 @@ function createMailCapture({ sails, mailbox, getConfig }) {
       return sendHelper.with.bind(sendHelper)
     }
 
-    throw new Error('Sounding could not invoke `sails.helpers.mail.send`.')
+    throw createSoundingError({
+      code: 'E_SOUNDING_MAIL_SEND_UNAVAILABLE',
+      message: 'Sounding could not invoke `sails.helpers.mail.send`.',
+    })
   }
 
   function resolveWithInvoker(sendHelper) {
@@ -350,7 +354,10 @@ function createMailCapture({ sails, mailbox, getConfig }) {
       return sendHelper.bind(sendHelper)
     }
 
-    throw new Error('Sounding could not invoke `sails.helpers.mail.send.with()`.')
+    throw createSoundingError({
+      code: 'E_SOUNDING_MAIL_SEND_WITH_UNAVAILABLE',
+      message: 'Sounding could not invoke `sails.helpers.mail.send.with()`.',
+    })
   }
 
   async function captureSuccessfulSend(inputs = {}) {

--- a/lib/create-request-client.js
+++ b/lib/create-request-client.js
@@ -1,6 +1,7 @@
 const { Transform } = require('node:stream')
 const QS = require('node:querystring')
 const { resolveAuthConfig } = require('./resolve-auth-config')
+const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingRequestClient} SoundingRequestClient */
@@ -63,19 +64,27 @@ function shouldParseJson({ contentType, body }) {
  */
 function createJsonParseError({ error, status, contentType, url, body }) {
   const fromUrl = url ? ` from ${url}` : ''
-  return Object.assign(
-    new Error(`Sounding could not parse JSON response${fromUrl} (status ${status}).`, {
-      cause: error,
-    }),
-    {
-      name: 'SoundingJsonParseError',
-      code: 'E_SOUNDING_JSON_PARSE',
+  return createSoundingError({
+    code: 'E_SOUNDING_JSON_PARSE',
+    message: `Sounding could not parse JSON response${fromUrl} (status ${status}).`,
+    details: {
       status,
       url,
       contentType,
       body,
-    }
-  )
+    },
+    cause: error,
+    name: 'SoundingJsonParseError',
+  })
+}
+
+function createVirtualResponseStreamError(error) {
+  return createSoundingError({
+    code: 'E_SOUNDING_VIRTUAL_RESPONSE_STREAM',
+    message: 'Sounding virtual response stream failed.',
+    cause: error,
+    name: 'SoundingVirtualResponseStreamError',
+  })
 }
 
 /**
@@ -223,9 +232,11 @@ function resolveBaseUrl({ sails, getConfig, override }) {
     return `http://127.0.0.1:${sails.config.port}`
   }
 
-  throw new Error(
-    'Sounding could not resolve a base URL for HTTP request trials. Configure `sounding.request.baseUrl`, `sounding.browser.baseUrl`, or lift Sails with the HTTP hook.'
-  )
+  throw createSoundingError({
+    code: 'E_SOUNDING_BASE_URL_UNRESOLVED',
+    message:
+      'Sounding could not resolve a base URL for HTTP request trials. Configure `sounding.request.baseUrl`, `sounding.browser.baseUrl`, or lift Sails with the HTTP hook.',
+  })
 }
 
 /**
@@ -345,9 +356,11 @@ class MockClientResponse extends Transform {
  */
 function createVirtualTransport({ sails }) {
   if (typeof sails?.router?.route !== 'function') {
-    throw new Error(
-      'Sounding could not find `sails.router.route()`. Virtual request transport requires a loaded Sails app.'
-    )
+    throw createSoundingError({
+      code: 'E_SOUNDING_VIRTUAL_TRANSPORT_UNAVAILABLE',
+      message:
+        'Sounding could not find `sails.router.route()`. Virtual request transport requires a loaded Sails app.',
+    })
   }
 
   return {
@@ -387,7 +400,7 @@ function createVirtualTransport({ sails }) {
           })
 
           clientRes.on('error', (error) => {
-            reject(error || new Error('Error on virtual response stream'))
+            reject(createVirtualResponseStreamError(error))
           })
 
           sails.router.route(
@@ -482,7 +495,10 @@ function createHttpTransport({
   fetchImplementation = globalThis.fetch,
 }) {
   if (typeof fetchImplementation !== 'function') {
-    throw new Error('Sounding could not find a fetch implementation for HTTP request trials.')
+    throw createSoundingError({
+      code: 'E_SOUNDING_HTTP_FETCH_UNAVAILABLE',
+      message: 'Sounding could not find a fetch implementation for HTTP request trials.',
+    })
   }
 
   return {
@@ -603,7 +619,13 @@ function createRequestClient({
       return getHttpTransport().send(method, target, payload, transportOptions)
     }
 
-    throw new Error(`Unknown Sounding request transport: ${transport}`)
+    throw createSoundingError({
+      code: 'E_SOUNDING_UNKNOWN_TRANSPORT',
+      message: `Unknown Sounding request transport: ${transport}`,
+      details: {
+        transport,
+      },
+    })
   }
 
   return {

--- a/lib/create-runtime.js
+++ b/lib/create-runtime.js
@@ -13,6 +13,7 @@ const { getDefaultConfig } = require('./default-config')
 const { mergeConfig } = require('./merge-config')
 const { normalizeUserConfig } = require('./normalize-config')
 const { resolveDatastore } = require('./resolve-datastore')
+const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').SoundingBootResult} SoundingBootResult */
 /** @typedef {import('./types').SoundingConfig} SoundingConfig */
@@ -76,12 +77,27 @@ async function runCleanupSteps(steps) {
   const resources = failures.map((failure) => failure.resource).join(', ')
   const errors = failures.map(
     (failure) =>
-      new Error(`${failure.resource}: ${formatCleanupError(failure.error)}`, {
+      createSoundingError({
+        code: 'E_SOUNDING_CLEANUP_RESOURCE_FAILED',
+        message: `${failure.resource}: ${formatCleanupError(failure.error)}`,
+        details: {
+          resource: failure.resource,
+        },
         cause: failure.error,
       })
   )
 
-  throw new AggregateError(errors, `Sounding cleanup failed for ${resources}.`)
+  const error = /** @type {AggregateError & { code: string, resources: string[], details: { resources: string[] } }} */ (
+    new AggregateError(errors, `Sounding cleanup failed for ${resources}.`)
+  )
+  error.name = 'SoundingCleanupError'
+  error.code = 'E_SOUNDING_CLEANUP_FAILED'
+  error.resources = failures.map((failure) => failure.resource)
+  error.details = {
+    resources: error.resources,
+  }
+
+  throw error
 }
 
 /**

--- a/lib/create-visit-client.js
+++ b/lib/create-visit-client.js
@@ -1,3 +1,5 @@
+const { createSoundingError } = require('./create-error')
+
 const DEFAULT_HEADERS = {
   'x-inertia': 'true',
   'x-requested-with': 'XMLHttpRequest',
@@ -38,7 +40,13 @@ function buildVisitHeaders(options = {}) {
 
   if (options.only?.length) {
     if (!options.component) {
-      throw new Error('Sounding visit() requires `component` when using `only`.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_VISIT_COMPONENT_REQUIRED',
+        message: 'Sounding visit() requires `component` when using `only`.',
+        details: {
+          partialReload: 'only',
+        },
+      })
     }
 
     headers['x-inertia-partial-component'] = options.component
@@ -47,7 +55,13 @@ function buildVisitHeaders(options = {}) {
 
   if (options.except?.length) {
     if (!options.component) {
-      throw new Error('Sounding visit() requires `component` when using `except`.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_VISIT_COMPONENT_REQUIRED',
+        message: 'Sounding visit() requires `component` when using `except`.',
+        details: {
+          partialReload: 'except',
+        },
+      })
     }
 
     headers['x-inertia-partial-component'] = options.component

--- a/lib/create-world-engine.js
+++ b/lib/create-world-engine.js
@@ -2,6 +2,7 @@ const {
   isFactoryDefinition,
   isScenarioDefinition,
 } = require('./define-world')
+const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingBuilder} SoundingBuilder */
@@ -130,7 +131,13 @@ function createWorldEngine({ sails }) {
     const entry = factories.get(name)
 
     if (!entry) {
-      throw new Error(`Unknown Sounding factory: ${name}`)
+      throw createSoundingError({
+        code: 'E_SOUNDING_WORLD_FACTORY_UNKNOWN',
+        message: `Unknown Sounding factory: ${name}`,
+        details: {
+          factory: name,
+        },
+      })
     }
 
     return entry
@@ -152,7 +159,14 @@ function createWorldEngine({ sails }) {
 
     for (const traitName of options.traits || []) {
       if (!entry.traits.has(traitName)) {
-        throw new Error(`Unknown Sounding trait \`${traitName}\` for factory \`${name}\``)
+        throw createSoundingError({
+          code: 'E_SOUNDING_WORLD_TRAIT_UNKNOWN',
+          message: `Unknown Sounding trait \`${traitName}\` for factory \`${name}\``,
+          details: {
+            factory: name,
+            trait: traitName,
+          },
+        })
       }
 
       value = mergeValue(value, entry.traits.get(traitName))
@@ -244,7 +258,13 @@ function createWorldEngine({ sails }) {
     const definition = scenarios.get(name)
 
     if (!definition) {
-      throw new Error(`Unknown Sounding scenario: ${name}`)
+      throw createSoundingError({
+        code: 'E_SOUNDING_WORLD_SCENARIO_UNKNOWN',
+        message: `Unknown Sounding scenario: ${name}`,
+        details: {
+          scenario: name,
+        },
+      })
     }
 
     currentWorld = await definition({
@@ -304,7 +324,10 @@ function createWorldEngine({ sails }) {
         return defineScenario(definition)
       }
 
-      throw new Error('Sounding could not register an unknown world definition.')
+      throw createSoundingError({
+        code: 'E_SOUNDING_WORLD_DEFINITION_UNKNOWN',
+        message: 'Sounding could not register an unknown world definition.',
+      })
     },
 
     get current() {

--- a/lib/create-world-loader.js
+++ b/lib/create-world-loader.js
@@ -8,6 +8,7 @@ const {
   isFactoryDefinition,
   isScenarioDefinition,
 } = require('./define-world')
+const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingConfig} SoundingConfig */
@@ -103,9 +104,13 @@ async function registerExport(value, api, source) {
     return
   }
 
-  throw new Error(
-    `Sounding could not understand the world definition exported from ${source}.`
-  )
+  throw createSoundingError({
+    code: 'E_SOUNDING_WORLD_DEFINITION_UNKNOWN',
+    message: `Sounding could not understand the world definition exported from ${source}.`,
+    details: {
+      source,
+    },
+  })
 }
 
 /**

--- a/lib/resolve-datastore.js
+++ b/lib/resolve-datastore.js
@@ -1,4 +1,5 @@
 const path = require('node:path')
+const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingConfig} SoundingConfig */
@@ -66,9 +67,14 @@ function resolveDatastore({ sails, soundingConfig }) {
     const configuredDatastore = datastores[identity]
 
     if (!configuredDatastore) {
-      throw new Error(
-        `Sounding could not find datastore \`${identity}\` in sails.config.datastores for mode \`${mode}\`.`
-      )
+      throw createSoundingError({
+        code: 'E_SOUNDING_DATASTORE_CONFIG_MISSING',
+        message: `Sounding could not find datastore \`${identity}\` in sails.config.datastores for mode \`${mode}\`.`,
+        details: {
+          mode,
+          identity,
+        },
+      })
     }
 
     return {
@@ -83,9 +89,13 @@ function resolveDatastore({ sails, soundingConfig }) {
     const adapter = datastoreConfig.adapter || 'sails-sqlite'
 
     if (adapter !== 'sails-sqlite') {
-      throw new Error(
-        `Sounding only supports managed adapter \`sails-sqlite\` in v0.0.1. Received \`${adapter}\`.`
-      )
+      throw createSoundingError({
+        code: 'E_SOUNDING_DATASTORE_ADAPTER_UNSUPPORTED',
+        message: `Sounding only supports managed adapter \`sails-sqlite\` in v0.0.1. Received \`${adapter}\`.`,
+        details: {
+          adapter,
+        },
+      })
     }
 
     const filePath = buildManagedSqlitePath({
@@ -114,7 +124,13 @@ function resolveDatastore({ sails, soundingConfig }) {
     }
   }
 
-  throw new Error(`Unknown Sounding datastore mode: ${mode}`)
+  throw createSoundingError({
+    code: 'E_SOUNDING_DATASTORE_MODE_UNKNOWN',
+    message: `Unknown Sounding datastore mode: ${mode}`,
+    details: {
+      mode,
+    },
+  })
 }
 
 module.exports = {

--- a/test/browser-auth.test.js
+++ b/test/browser-auth.test.js
@@ -73,6 +73,53 @@ test('createBrowserManager opens a browser session with the configured base URL'
   ])
 })
 
+test('createBrowserManager reports browser setup errors with stable codes', async () => {
+  const disabled = createBrowserManager({
+    sails: {
+      config: {
+        sounding: {
+          browser: {
+            enabled: false,
+          },
+        },
+      },
+    },
+  })
+
+  await assert.rejects(
+    async () => {
+      await disabled.open()
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_BROWSER_DISABLED')
+      return true
+    }
+  )
+
+  const missingType = createBrowserManager({
+    sails: {
+      config: {
+        appPath: '/tmp/app',
+        port: 3333,
+      },
+    },
+    loadPlaywright: async () => ({
+      devices: {},
+    }),
+  })
+
+  await assert.rejects(
+    async () => {
+      await missingType.open({ type: 'webkit' })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_BROWSER_TYPE_UNAVAILABLE')
+      assert.equal(error.browserType, 'webkit')
+      return true
+    }
+  )
+})
+
 test('createAuthHelpers can issue magic links and log a browser page in as an actor', async () => {
   const updates = []
   const page = {
@@ -157,6 +204,48 @@ test('createAuthHelpers can issue magic links and log a browser page in as an ac
 
   await auth.login.as('reader', page)
   assert.deepEqual(page.visits, ['/magic-link/token-123'])
+})
+
+test('createAuthHelpers reports auth input errors with stable codes', async () => {
+  const auth = createAuthHelpers({
+    sails: {},
+    world: {
+      current: {},
+    },
+    mailbox: {
+      latest() {
+        return null
+      },
+    },
+    request: {
+      post: async () => ({ status: 302 }),
+    },
+  })
+
+  await assert.rejects(
+    async () => {
+      await auth.resolveActor(null)
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_AUTH_ACTOR_REQUIRED')
+      return true
+    }
+  )
+
+  await assert.rejects(
+    async () => {
+      await auth.resolveActor({ id: 1 }, { createIfMissing: false })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_AUTH_EMAIL_UNRESOLVED')
+      assert.deepEqual(error.details, {
+        actor: {
+          id: 1,
+        },
+      })
+      return true
+    }
+  )
 })
 
 test('createAuthHelpers can log in with password through the real browser form', async () => {

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,0 +1,69 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createSoundingError } = require('../lib/create-error')
+
+test('createSoundingError adds stable code and structured details', () => {
+  const cause = new SyntaxError('Unexpected end of JSON input')
+  const error = createSoundingError({
+    code: 'E_SOUNDING_EXAMPLE',
+    message: 'Sounding example failed.',
+    details: {
+      resource: 'example',
+      status: 500,
+    },
+    cause,
+  })
+
+  assert.equal(error.name, 'SoundingError')
+  assert.equal(error.code, 'E_SOUNDING_EXAMPLE')
+  assert.equal(error.message, 'Sounding example failed.')
+  assert.equal(error.resource, 'example')
+  assert.equal(error.status, 500)
+  assert.deepEqual(error.details, {
+    resource: 'example',
+    status: 500,
+  })
+  assert.equal(error.cause, cause)
+})
+
+test('createSoundingError can preserve a domain-specific error name', () => {
+  const error = createSoundingError({
+    code: 'E_SOUNDING_JSON_PARSE',
+    message: 'Sounding could not parse JSON response.',
+    name: 'SoundingJsonParseError',
+  })
+
+  assert.equal(error.name, 'SoundingJsonParseError')
+  assert.equal(error.code, 'E_SOUNDING_JSON_PARSE')
+})
+
+test('createSoundingError keeps canonical fields stable when details collide', () => {
+  const error = createSoundingError({
+    code: 'E_SOUNDING_EXAMPLE',
+    message: 'Sounding example failed.',
+    details: {
+      code: 'E_USER_DETAIL',
+      name: 'UserDetailError',
+      message: 'User detail message.',
+      details: {
+        nested: true,
+      },
+      resource: 'example',
+    },
+  })
+
+  assert.equal(error.name, 'SoundingError')
+  assert.equal(error.code, 'E_SOUNDING_EXAMPLE')
+  assert.equal(error.message, 'Sounding example failed.')
+  assert.equal(error.resource, 'example')
+  assert.deepEqual(error.details, {
+    code: 'E_USER_DETAIL',
+    name: 'UserDetailError',
+    message: 'User detail message.',
+    details: {
+      nested: true,
+    },
+    resource: 'example',
+  })
+})

--- a/test/mail-capture.test.js
+++ b/test/mail-capture.test.js
@@ -2,7 +2,7 @@ const test = require('node:test')
 const assert = require('node:assert/strict')
 
 const { createRuntime } = require('../lib/create-runtime')
-const { buildCapturedMail } = require('../lib/create-mail-capture')
+const { buildCapturedMail, createMailCapture } = require('../lib/create-mail-capture')
 
 function createRenderView(htmlBuilder) {
   return (viewPath, locals) => ({
@@ -99,6 +99,47 @@ test('buildCapturedMail keeps explicit layout overrides in preview metadata', as
 
   assert.equal(message.layout, false)
   assert.equal(previewLayout, false)
+})
+
+test('runtime mail capture reports uninvokable send helpers with a stable code', async () => {
+  const sails = {
+    config: {
+      sounding: {
+        mail: {
+          deliver: true,
+        },
+      },
+    },
+    helpers: {
+      mail: {
+        send: {},
+      },
+    },
+  }
+  const mailbox = {
+    capture() {},
+  }
+  const capture = createMailCapture({
+    sails,
+    mailbox,
+    getConfig: () => sails.config.sounding,
+  })
+
+  capture.install()
+
+  try {
+    await assert.rejects(
+      async () => {
+        await sails.helpers.mail.send({ to: 'reader@example.com' })
+      },
+      (error) => {
+        assert.equal(error.code, 'E_SOUNDING_MAIL_SEND_UNAVAILABLE')
+        return true
+      }
+    )
+  } finally {
+    capture.uninstall()
+  }
 })
 
 test('runtime boot installs in-memory mail capture and lower restores the original helper', async () => {

--- a/test/request-client.test.js
+++ b/test/request-client.test.js
@@ -473,6 +473,76 @@ test('createRequestClient rejects invalid HTTP JSON with response context', asyn
   }
 })
 
+test('createRequestClient reports missing virtual transport with a stable code', async () => {
+  const request = createRequestClient({
+    sails: {
+      config: {
+        sounding: {},
+      },
+    },
+  })
+
+  await assert.rejects(
+    async () => {
+      await request.get('/health')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_VIRTUAL_TRANSPORT_UNAVAILABLE')
+      assert.match(error.message, /sails\.router\.route/)
+      return true
+    }
+  )
+})
+
+test('createRequestClient reports unresolved HTTP base URL with a stable code', async () => {
+  const request = createRequestClient({
+    sails: {
+      config: {
+        sounding: {
+          request: {
+            transport: 'http',
+          },
+        },
+      },
+    },
+  })
+
+  await assert.rejects(
+    async () => {
+      await request.get('/health')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_BASE_URL_UNRESOLVED')
+      assert.match(error.message, /could not resolve a base URL/)
+      return true
+    }
+  )
+})
+
+test('createRequestClient reports unknown transports with a stable code', async () => {
+  const request = createRequestClient({
+    sails: {
+      config: {
+        sounding: {},
+      },
+    },
+  }).using('custom-transport')
+
+  await assert.rejects(
+    async () => {
+      await request.get('/health')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_UNKNOWN_TRANSPORT')
+      assert.equal(error.transport, 'custom-transport')
+      assert.deepEqual(error.details, {
+        transport: 'custom-transport',
+      })
+      return true
+    }
+  )
+})
+
 test('createRequestClient can follow the Sails-native redirect matcher contract over virtual transport', async () => {
   const sails = {
     router: {

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 const soundingHook = require('../index')
 const { createRuntime, resolveConfig } = require('../lib/create-runtime')
 const { getDefaultConfig } = require('../lib/default-config')
-const { buildManagedSqlitePath } = require('../lib/resolve-datastore')
+const { buildManagedSqlitePath, resolveDatastore } = require('../lib/resolve-datastore')
 
 function createMailSend() {
   const send = async () => ({})
@@ -76,6 +76,77 @@ test('Sounding normalizes shorthand and legacy datastore config shapes', () => {
   assert.equal(legacyManaged.datastore.isolation, 'run')
 })
 
+test('resolveDatastore reports configuration errors with stable codes', () => {
+  assert.throws(
+    () => {
+      resolveDatastore({
+        sails: {
+          config: {
+            datastores: {},
+          },
+        },
+        soundingConfig: {
+          datastore: {
+            mode: 'inherit',
+            identity: 'archive',
+          },
+        },
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_DATASTORE_CONFIG_MISSING')
+      assert.equal(error.mode, 'inherit')
+      assert.equal(error.identity, 'archive')
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      resolveDatastore({
+        sails: {
+          config: {
+            datastores: {},
+          },
+        },
+        soundingConfig: {
+          datastore: {
+            mode: 'managed',
+            adapter: 'sails-postgresql',
+          },
+        },
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_DATASTORE_ADAPTER_UNSUPPORTED')
+      assert.equal(error.adapter, 'sails-postgresql')
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      resolveDatastore({
+        sails: {
+          config: {
+            datastores: {},
+          },
+        },
+        soundingConfig: {
+          datastore: {
+            mode: 'custom',
+          },
+        },
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_DATASTORE_MODE_UNKNOWN')
+      assert.equal(error.mode, 'custom')
+      return true
+    }
+  )
+})
+
 test('createRuntime manages a temporary datastore by default', async () => {
   const sails = {
     config: {
@@ -136,6 +207,43 @@ test('createRuntime manages a temporary datastore by default', async () => {
   await runtime.lower()
   assert.equal(runtime.mailbox.all().length, 0)
   assert.equal(runtime.world.factories.length, 0)
+})
+
+test('createRuntime helper runner reports lookup errors with stable codes', async () => {
+  const runtime = createRuntime({
+    config: {},
+    models: {},
+    helpers: {
+      user: {
+        signupWithTeam: {},
+      },
+    },
+  })
+
+  await assert.rejects(
+    async () => {
+      await runtime.helpers('user.missing')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_HELPER_UNKNOWN')
+      assert.equal(error.identity, 'user.missing')
+      assert.deepEqual(error.details, {
+        identity: 'user.missing',
+      })
+      return true
+    }
+  )
+
+  await assert.rejects(
+    async () => {
+      await runtime.helpers.user.signupWithTeam()
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_HELPER_NOT_CALLABLE')
+      assert.equal(error.identity, 'user.signupWithTeam')
+      return true
+    }
+  )
 })
 
 test('createRuntime.lower resets shared virtual request session state', async () => {
@@ -228,6 +336,10 @@ test('createRuntime.lower continues cleanup and reports browser close failures',
     }
   )
 
+  assert.equal(cleanupError.code, 'E_SOUNDING_CLEANUP_FAILED')
+  assert.deepEqual(cleanupError.resources, ['browser'])
+  assert.equal(cleanupError.errors[0].code, 'E_SOUNDING_CLEANUP_RESOURCE_FAILED')
+  assert.equal(cleanupError.errors[0].resource, 'browser')
   assert.equal(cleanupError.errors[0].message, 'browser: browser close failed')
   assert.equal(sails.helpers.mail.send, originalSend)
   assert.equal(runtime.mailbox.all().length, 0)
@@ -276,6 +388,10 @@ test('createRuntime.lower continues cleanup and reports mail capture uninstall f
     }
   )
 
+  assert.equal(cleanupError.code, 'E_SOUNDING_CLEANUP_FAILED')
+  assert.deepEqual(cleanupError.resources, ['mail capture'])
+  assert.equal(cleanupError.errors[0].code, 'E_SOUNDING_CLEANUP_RESOURCE_FAILED')
+  assert.equal(cleanupError.errors[0].resource, 'mail capture')
   assert.equal(cleanupError.errors[0].message, 'mail capture: mail restore failed')
   assert.equal(browserClosed, true)
   assert.equal(runtime.mailbox.all().length, 0)

--- a/test/visit-client.test.js
+++ b/test/visit-client.test.js
@@ -193,6 +193,11 @@ test('createVisitClient requires a component for partial reload selectors', asyn
     async () => {
       await visit('/dashboard', { only: ['notifications'] })
     },
-    /requires `component` when using `only`/
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_VISIT_COMPONENT_REQUIRED')
+      assert.equal(error.partialReload, 'only')
+      assert.match(error.message, /requires `component` when using `only`/)
+      return true
+    }
   )
 })

--- a/test/world-loader.test.js
+++ b/test/world-loader.test.js
@@ -46,3 +46,86 @@ test('loadWorldFiles discovers factory and scenario definitions from tests/', as
   assert.equal(current.users.subscriber.role, 'subscriber')
   assert.match(current.users.subscriber.email, /^user\d+@example.com$/)
 })
+
+test('createWorldEngine reports unknown world entries with stable codes', async () => {
+  const world = createWorldEngine({ sails: {} })
+
+  assert.throws(
+    () => {
+      world.build('user')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_WORLD_FACTORY_UNKNOWN')
+      assert.equal(error.factory, 'user')
+      return true
+    }
+  )
+
+  world.defineFactory('user', {
+    email: 'reader@example.com',
+  })
+
+  assert.throws(
+    () => {
+      world.build('user', {}, { traits: ['admin'] })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_WORLD_TRAIT_UNKNOWN')
+      assert.equal(error.factory, 'user')
+      assert.equal(error.trait, 'admin')
+      return true
+    }
+  )
+
+  await assert.rejects(
+    async () => {
+      await world.use('missing-dashboard')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_WORLD_SCENARIO_UNKNOWN')
+      assert.equal(error.scenario, 'missing-dashboard')
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      world.register({})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_WORLD_DEFINITION_UNKNOWN')
+      return true
+    }
+  )
+})
+
+test('loadWorldFiles reports unknown world file exports with a stable code', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-worlds-'))
+  const factoriesDir = path.join(tempRoot, 'tests', 'factories')
+
+  fs.mkdirSync(factoriesDir, { recursive: true })
+  const source = path.join(factoriesDir, 'invalid.js')
+  fs.writeFileSync(source, 'module.exports = 42\n')
+
+  const world = createWorldEngine({ sails: {} })
+
+  await assert.rejects(
+    async () => {
+      await loadWorldFiles({
+        world,
+        appPath: tempRoot,
+        config: {
+          world: {
+            factories: 'tests/factories',
+          },
+        },
+        sails: {},
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_WORLD_DEFINITION_UNKNOWN')
+      assert.equal(error.source, source)
+      return true
+    }
+  )
+})


### PR DESCRIPTION
Fixes #53

Summary:
- Adds a dependency-free internal createSoundingError helper with stable code/details/cause support.
- Adds stable E_SOUNDING_* codes across request, auth, browser, mail, helper, world, datastore, visit, and cleanup failures.
- Covers the helper contract and representative public-facing failures with focused tests.

Verification:
- npm run typecheck
- npm test
- git diff --check