### PR TITLE
feat: validate Sounding test arguments

### DIFF
--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -1,6 +1,7 @@
 const nodeTest = require('node:test')
 const { createAppManager } = require('./create-app-manager')
 const { createExpect } = require('./create-expect')
+const { normalizeTestArgs, splitTestOptions } = require('./validate-test-args')
 
 /** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
 /** @typedef {import('./types').SoundingExpect} SoundingExpect */
@@ -32,28 +33,6 @@ function ensureDefaultAppManagerCleanup() {
   })
 
   defaultCleanupRegistered = true
-}
-
-/**
- * @param {string} title
- * @param {SoundingTestOptions | SoundingTrialHandler} optionsOrHandler
- * @param {SoundingTrialHandler} [maybeHandler]
- * @returns {{ title: string, options: SoundingTestOptions, handler: SoundingTrialHandler }}
- */
-function normalizeTestArgs(title, optionsOrHandler, maybeHandler) {
-  if (typeof optionsOrHandler === 'function') {
-    return {
-      title,
-      options: {},
-      handler: optionsOrHandler,
-    }
-  }
-
-  return {
-    title,
-    options: optionsOrHandler || {},
-    handler: maybeHandler,
-  }
 }
 
 /**
@@ -93,29 +72,6 @@ async function resolveRuntimeFromGlobals(options = {}) {
  */
 function bindRequestMethod(request, method) {
   return typeof request?.[method] === 'function' ? request[method].bind(request) : undefined
-}
-
-/**
- * @param {SoundingTestOptions} [options]
- * @returns {{ nodeOptions: Record<string, any>, trialOptions: SoundingTestOptions }}
- */
-function splitTestOptions(options = {}) {
-  const {
-    transport,
-    browser,
-    ...nodeOptions
-  } = options
-
-  return {
-    nodeOptions: {
-      concurrency: false,
-      ...nodeOptions,
-    },
-    trialOptions: {
-      transport,
-      browser,
-    },
-  }
 }
 
 /**
@@ -219,10 +175,15 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
  * @param {string} mode
  * @returns {SoundingTrialRegistrar}
  */
-function createTrialMethod(baseTest, runtime, mode) {
+function createTrialMethod(baseTest, runtime, mode, apiName = 'test') {
   const registerTrial = function registerTrial(title, optionsOrHandler, maybeHandler) {
-    const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler)
-    const { nodeOptions, trialOptions } = splitTestOptions(options)
+    const { options, handler } = normalizeTestArgs(
+      title,
+      optionsOrHandler,
+      maybeHandler,
+      apiName
+    )
+    const { nodeOptions, trialOptions } = splitTestOptions(options, apiName)
 
     return baseTest(title, nodeOptions, async (nodeContext) => {
       return runInTrialQueue(async () => {
@@ -248,8 +209,8 @@ function createTrialMethod(baseTest, runtime, mode) {
  */
 function createTestApi({ baseTest = nodeTest, runtime } = {}) {
   function soundingTest(title, optionsOrHandler, maybeHandler) {
-    const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler)
-    const { nodeOptions, trialOptions } = splitTestOptions(options)
+    const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler, 'test')
+    const { nodeOptions, trialOptions } = splitTestOptions(options, 'test')
 
     return baseTest(title, nodeOptions, async (nodeContext) => {
       return runInTrialQueue(async () => {
@@ -267,12 +228,12 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
   soundingTest.skip = (...args) => baseTest.skip?.(...args)
   soundingTest.todo = (...args) => baseTest.todo?.(...args)
   if (typeof baseTest.only === 'function') {
-    soundingTest.only = createTrialMethod(baseTest.only.bind(baseTest), runtime, 'trial')
+    soundingTest.only = createTrialMethod(baseTest.only.bind(baseTest), runtime, 'trial', 'test.only')
   }
 
   // Temporary compatibility aliases while the public docs move fully to `test()`.
-  soundingTest.helper = createTrialMethod(baseTest, runtime, 'helper')
-  soundingTest.endpoint = createTrialMethod(baseTest, runtime, 'endpoint')
+  soundingTest.helper = createTrialMethod(baseTest, runtime, 'helper', 'test.helper')
+  soundingTest.endpoint = createTrialMethod(baseTest, runtime, 'endpoint', 'test.endpoint')
 
   return soundingTest
 }

--- a/lib/validate-test-args.js
+++ b/lib/validate-test-args.js
@@ -1,0 +1,256 @@
+const { createSoundingError } = require('./create-error')
+
+/** @typedef {import('./types').SoundingTestOptions} SoundingTestOptions */
+/** @typedef {import('./types').SoundingTrialHandler} SoundingTrialHandler */
+
+const ALLOWED_TRANSPORTS = ['virtual', 'http']
+
+/**
+ * @param {any} value
+ * @returns {value is Record<string, any>}
+ */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @param {string} apiName
+ * @returns {string}
+ */
+function formatTrialSignature(apiName) {
+  return `${apiName}(name, [options], handler)`
+}
+
+/**
+ * @param {{
+ *   code: string,
+ *   message: string,
+ *   apiName: string,
+ *   value?: any,
+ *   path?: string,
+ *   allowed?: string[],
+ *   suggestion?: string,
+ * }} input
+ * @returns {Error}
+ */
+function createTestArgumentError(input) {
+  const { code, message, apiName, value, path, allowed, suggestion } = input
+  /** @type {Record<string, any>} */
+  const details = {
+    api: apiName,
+    signature: formatTrialSignature(apiName),
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'value')) {
+    details.value = value
+  }
+
+  if (path) {
+    details.path = path
+  }
+
+  if (allowed) {
+    details.allowed = allowed
+  }
+
+  if (suggestion) {
+    details.suggestion = suggestion
+  }
+
+  return createSoundingError({
+    code,
+    name: 'SoundingTestArgumentError',
+    message,
+    details,
+  })
+}
+
+/**
+ * @param {any} title
+ * @param {string} apiName
+ */
+function assertTrialTitle(title, apiName) {
+  if (typeof title === 'string' && title.trim()) {
+    return
+  }
+
+  throw createTestArgumentError({
+    code: 'E_SOUNDING_TEST_TITLE_REQUIRED',
+    message: `Sounding ${apiName} requires a non-empty trial name. Use \`${formatTrialSignature(apiName)}\`.`,
+    apiName,
+    value: title,
+    path: 'name',
+  })
+}
+
+/**
+ * @param {any} handler
+ * @param {string} apiName
+ */
+function assertTrialHandler(handler, apiName) {
+  if (typeof handler === 'function') {
+    return
+  }
+
+  throw createTestArgumentError({
+    code: 'E_SOUNDING_TEST_HANDLER_REQUIRED',
+    message: `Sounding ${apiName} requires a trial handler. Use \`${formatTrialSignature(apiName)}\`.`,
+    apiName,
+    value: handler,
+    path: 'handler',
+    suggestion: `Pass an async function as the final argument: \`${formatTrialSignature(apiName)}\`.`,
+  })
+}
+
+/**
+ * @param {any} options
+ * @param {string} apiName
+ */
+function assertBrowserOptions(options, apiName) {
+  if (
+    options.browser !== undefined &&
+    typeof options.browser !== 'boolean' &&
+    !isPlainObject(options.browser)
+  ) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser\` must be a boolean or browser options object.`,
+      apiName,
+      value: options.browser,
+      path: 'options.browser',
+      suggestion: 'Use `browser: true` or `browser: { project: "desktop" }`.',
+    })
+  }
+
+  if (!isPlainObject(options.browser)) {
+    return
+  }
+
+  if (options.browser.type !== undefined && typeof options.browser.type !== 'string') {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.type\` must be a string.`,
+      apiName,
+      value: options.browser.type,
+      path: 'options.browser.type',
+    })
+  }
+
+  if (options.browser.project !== undefined && typeof options.browser.project !== 'string') {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.project\` must be a string.`,
+      apiName,
+      value: options.browser.project,
+      path: 'options.browser.project',
+    })
+  }
+
+  if (options.browser.launchOptions !== undefined && !isPlainObject(options.browser.launchOptions)) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.launchOptions\` must be an object.`,
+      apiName,
+      value: options.browser.launchOptions,
+      path: 'options.browser.launchOptions',
+    })
+  }
+
+  if (options.browser.contextOptions !== undefined && !isPlainObject(options.browser.contextOptions)) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.contextOptions\` must be an object.`,
+      apiName,
+      value: options.browser.contextOptions,
+      path: 'options.browser.contextOptions',
+    })
+  }
+}
+
+/**
+ * @param {any} options
+ * @param {string} apiName
+ */
+function assertTrialOptions(options, apiName) {
+  if (!isPlainObject(options)) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} options must be an object when provided. Use \`${formatTrialSignature(apiName)}\`.`,
+      apiName,
+      value: options,
+      path: 'options',
+    })
+  }
+
+  if (options.transport !== undefined && !ALLOWED_TRANSPORTS.includes(options.transport)) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`transport\` must be either \`virtual\` or \`http\`.`,
+      apiName,
+      value: options.transport,
+      path: 'options.transport',
+      allowed: ALLOWED_TRANSPORTS,
+      suggestion: 'Use `virtual` for Sails-native in-process requests or `http` for real HTTP requests.',
+    })
+  }
+
+  assertBrowserOptions(options, apiName)
+}
+
+/**
+ * @param {any} title
+ * @param {SoundingTestOptions | SoundingTrialHandler} optionsOrHandler
+ * @param {SoundingTrialHandler} [maybeHandler]
+ * @param {string} [apiName]
+ * @returns {{ title: string, options: SoundingTestOptions, handler: SoundingTrialHandler }}
+ */
+function normalizeTestArgs(title, optionsOrHandler, maybeHandler, apiName = 'test') {
+  assertTrialTitle(title, apiName)
+
+  if (typeof optionsOrHandler === 'function') {
+    assertTrialHandler(optionsOrHandler, apiName)
+
+    return {
+      title,
+      options: {},
+      handler: optionsOrHandler,
+    }
+  }
+
+  const options = optionsOrHandler === undefined ? {} : optionsOrHandler
+  assertTrialOptions(options, apiName)
+  assertTrialHandler(maybeHandler, apiName)
+
+  return {
+    title,
+    options,
+    handler: maybeHandler,
+  }
+}
+
+/**
+ * @param {SoundingTestOptions} [options]
+ * @param {string} [apiName]
+ * @returns {{ nodeOptions: Record<string, any>, trialOptions: SoundingTestOptions }}
+ */
+function splitTestOptions(options = {}, apiName = 'test') {
+  assertTrialOptions(options, apiName)
+
+  const { transport, browser, ...nodeOptions } = options
+
+  return {
+    nodeOptions: {
+      concurrency: false,
+      ...nodeOptions,
+    },
+    trialOptions: {
+      transport,
+      browser,
+    },
+  }
+}
+
+module.exports = {
+  normalizeTestArgs,
+  splitTestOptions,
+}

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -321,6 +321,142 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
   ])
 })
 
+test('test() reports malformed trial arguments with stable codes', () => {
+  const baseRegistrations = []
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest })
+
+  assert.throws(
+    () => {
+      soundingTest()
+    },
+    (error) => {
+      assert.equal(error.name, 'SoundingTestArgumentError')
+      assert.equal(error.code, 'E_SOUNDING_TEST_TITLE_REQUIRED')
+      assert.equal(error.path, 'name')
+      assert.equal(error.signature, 'test(name, [options], handler)')
+      assert.match(error.message, /requires a non-empty trial name/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest('missing handler', { browser: true })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_HANDLER_REQUIRED')
+      assert.equal(error.path, 'handler')
+      assert.equal(error.signature, 'test(name, [options], handler)')
+      assert.match(error.message, /requires a trial handler/)
+      assert.match(error.suggestion, /async function/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest('bad options', 'http', async () => {})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options')
+      assert.equal(error.value, 'http')
+      assert.match(error.message, /options must be an object/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest('bad transport', { transport: 'socket' }, async () => {})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.transport')
+      assert.equal(error.value, 'socket')
+      assert.deepEqual(error.allowed, ['virtual', 'http'])
+      assert.match(error.suggestion, /Use `virtual`/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest('bad browser', { browser: 'mobile' }, async () => {})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.browser')
+      assert.equal(error.value, 'mobile')
+      assert.match(error.suggestion, /browser: true/)
+      return true
+    }
+  )
+
+  assert.equal(baseRegistrations.length, 0)
+})
+
+test('test.only() reports malformed focused trial arguments with stable codes', () => {
+  const onlyRegistrations = []
+  const baseTest = () => {
+    throw new Error('base test should not be used')
+  }
+  baseTest.only = (title, options, handler) => {
+    onlyRegistrations.push({ title, options, handler })
+    return { title, only: true }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest })
+
+  assert.throws(
+    () => {
+      soundingTest.only('focused without handler')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_HANDLER_REQUIRED')
+      assert.equal(error.api, 'test.only')
+      assert.equal(error.signature, 'test.only(name, [options], handler)')
+      assert.match(error.message, /test\.only/)
+      return true
+    }
+  )
+
+  assert.equal(onlyRegistrations.length, 0)
+})
+
+test('test.skip() and test.todo() preserve Node-compatible pass-through forms', () => {
+  const skipped = []
+  const todos = []
+  const baseTest = () => {
+    throw new Error('base test should not be used')
+  }
+  baseTest.skip = (...args) => {
+    skipped.push(args)
+    return { skipped: true }
+  }
+  baseTest.todo = (...args) => {
+    todos.push(args)
+    return { todo: true }
+  }
+
+  const soundingTest = createTestApi({ baseTest })
+  const skipResult = soundingTest.skip('skip for later')
+  const todoResult = soundingTest.todo('document later')
+
+  assert.deepEqual(skipResult, { skipped: true })
+  assert.deepEqual(todoResult, { todo: true })
+  assert.deepEqual(skipped, [['skip for later']])
+  assert.deepEqual(todos, [['document later']])
+})
 
 test('test() exposes visit for Inertia-style trials', async () => {
   const calls = []


### PR DESCRIPTION
Closes #26

Docs companion: sailscastshq/docs.sailscasts.com#75

## Summary
- validate public `test()` and `test.only()` trial call signatures before registering with Node test
- report malformed names, handlers, options, transport, and browser options with stable Sounding error codes
- keep `test.skip()` and `test.todo()` as Node-compatible pass-through helpers

## Validation
- npm run typecheck
- npm test