### PR TITLE
fix: add actionable dependency diagnostics

### DIFF
--- a/lib/create-app-manager.js
+++ b/lib/create-app-manager.js
@@ -5,6 +5,7 @@ const { getDefaultConfig } = require('./default-config')
 const { mergeConfig } = require('./merge-config')
 const { normalizeUserConfig } = require('./normalize-config')
 const { buildManagedSqlitePath, resolveManagedRoot } = require('./resolve-datastore')
+const { loadDependencyFromApp, resolveDependencyFromApp } = require('./resolve-dependency')
 const { validateConfig } = require('./validate-config')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
@@ -13,15 +14,6 @@ const { validateConfig } = require('./validate-config')
 /** @typedef {import('./types').SoundingConfig} SoundingConfig */
 /** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
 /** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
-
-/**
- * @param {string} appPath
- * @param {string} moduleId
- * @returns {any}
- */
-function resolveModuleFromApp(appPath, moduleId) {
-  return require(require.resolve(moduleId, { paths: [appPath, process.cwd(), __dirname] }))
-}
 
 /**
  * @param {string} appPath
@@ -44,14 +36,60 @@ function loadAppSoundingConfig(appPath) {
 }
 
 /**
+ * @param {string} appPath
+ * @param {{ resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string }} [options]
+ * @returns {any}
+ */
+function defaultLoadSails(appPath, options = {}) {
+  return loadDependencyFromApp({
+    appPath,
+    moduleId: 'sails',
+    purpose: 'load your Sails app',
+    install: 'npm install sails',
+    resolveImplementation: options.resolveImplementation,
+  })
+}
+
+/**
  * @param {SoundingConfig} config
  * @param {string} appPath
+ * @param {{ resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string }} [options]
+ * @returns {void}
+ */
+function assertManagedDatastoreDependency(config, appPath, options = {}) {
+  if (config.datastore?.mode !== 'managed') {
+    return
+  }
+
+  const adapter = config.datastore.adapter || 'sails-sqlite'
+
+  if (adapter !== 'sails-sqlite') {
+    return
+  }
+
+  resolveDependencyFromApp({
+    appPath,
+    moduleId: adapter,
+    purpose: 'run managed datastore trials',
+    install: 'npm install -D sails-sqlite',
+    suggestion:
+      'Or set `sounding.datastore` to `inherit` or configure an external datastore if this app should reuse its own test database.',
+    resolveImplementation: options.resolveImplementation,
+  })
+}
+
+/**
+ * @param {SoundingConfig} config
+ * @param {string} appPath
+ * @param {{ resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string }} [options]
  * @returns {AnyRecord}
  */
-function buildManagedDatastoreOverrides(config, appPath) {
+function buildManagedDatastoreOverrides(config, appPath, options = {}) {
   if (config.datastore?.mode !== 'managed') {
     return {}
   }
+
+  assertManagedDatastoreDependency(config, appPath, options)
 
   const identity = config.datastore.identity || 'default'
 
@@ -182,6 +220,7 @@ function createAppManager({
   environment = 'test',
   liftOptions = {},
   SailsConstructor,
+  loadSails = defaultLoadSails,
 } = {}) {
   let loadedApp = null
   let liftedApp = null
@@ -203,7 +242,7 @@ function createAppManager({
       return SailsConstructor
     }
 
-    return resolveModuleFromApp(resolveAppPath(), 'sails').constructor
+    return loadSails(resolveAppPath()).constructor
   }
 
   function buildOptions(mode) {
@@ -366,6 +405,9 @@ function createAppManager({
 }
 
 module.exports = {
+  assertManagedDatastoreDependency,
+  buildManagedDatastoreOverrides,
   createAppManager,
+  defaultLoadSails,
   loadAppSoundingConfig,
 }

--- a/lib/create-browser-manager.js
+++ b/lib/create-browser-manager.js
@@ -1,5 +1,6 @@
 const { resolveBaseUrl } = require('./create-request-client')
 const { createSoundingError } = require('./create-error')
+const { loadDependencyFromApp } = require('./resolve-dependency')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingBrowserManager} SoundingBrowserManager */
@@ -9,27 +10,33 @@ const { createSoundingError } = require('./create-error')
 
 /**
  * @param {string} appPath
- * @param {string} moduleId
+ * @param {{ resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string }} [options]
  * @returns {any}
  */
-function resolveModuleFromApp(appPath, moduleId) {
-  return require(require.resolve(moduleId, { paths: [appPath, process.cwd(), __dirname] }))
+function defaultLoadPlaywright(appPath, options = {}) {
+  return loadDependencyFromApp({
+    appPath,
+    moduleId: 'playwright',
+    purpose: 'open browser trials',
+    install: 'npm install -D playwright',
+    resolveImplementation: options.resolveImplementation,
+  })
 }
 
 /**
  * @param {string} appPath
+ * @param {{ resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string }} [options]
  * @returns {any}
  */
-function defaultLoadPlaywright(appPath) {
-  return resolveModuleFromApp(appPath, 'playwright')
-}
-
-/**
- * @param {string} appPath
- * @returns {any}
- */
-function defaultLoadPlaywrightTest(appPath) {
-  return resolveModuleFromApp(appPath, '@playwright/test')
+function defaultLoadPlaywrightTest(appPath, options = {}) {
+  return loadDependencyFromApp({
+    appPath,
+    moduleId: '@playwright/test',
+    purpose: 'use Playwright expect fallback in browser trials',
+    install: 'npm install -D @playwright/test',
+    optional: true,
+    resolveImplementation: options.resolveImplementation,
+  })
 }
 
 /**
@@ -95,7 +102,16 @@ function createBrowserManager({
     const playwright = await loadPlaywright(appPath)
     const playwrightTest = await Promise.resolve()
       .then(() => loadPlaywrightTest(appPath))
-      .catch(() => null)
+      .catch((error) => {
+        if (
+          error?.code === 'E_SOUNDING_DEPENDENCY_MISSING' &&
+          error.dependency === '@playwright/test'
+        ) {
+          return null
+        }
+
+        throw error
+      })
 
     const browserTypeName = options.type || config.browser?.type || 'chromium'
     const browserType = playwright?.[browserTypeName]

--- a/lib/create-socket-manager.js
+++ b/lib/create-socket-manager.js
@@ -1,5 +1,6 @@
 const { normalizeResponse, resolveBaseUrl } = require('./create-request-client')
 const { createSoundingError } = require('./create-error')
+const { loadDependencyFromApp } = require('./resolve-dependency')
 const { resolveAuthConfig } = require('./resolve-auth-config')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
@@ -57,6 +58,49 @@ function resolveSocketConfig({ sails, getConfig }) {
     (typeof getConfig === 'function' ? getConfig() : null) || sails?.config?.sounding || {}
 
   return soundingConfig.sockets || {}
+}
+
+/**
+ * @param {string} appPath
+ * @param {{ resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string }} [options]
+ * @returns {any}
+ */
+function defaultLoadSocketIoClient(appPath, options = {}) {
+  return loadDependencyFromApp({
+    appPath,
+    moduleId: 'socket.io-client',
+    purpose: 'run websocket trials',
+    install: 'npm install -D socket.io-client',
+    resolveImplementation: options.resolveImplementation,
+  })
+}
+
+/**
+ * @param {SoundingSailsApp | undefined} sails
+ * @returns {boolean}
+ */
+function hasSailsSocketSupport(sails) {
+  return Boolean(sails?.hooks?.sockets && sails?.io && sails?.sockets)
+}
+
+/**
+ * @param {{ appPath?: string }} input
+ * @returns {Error}
+ */
+function createSocketHookUnavailableError({ appPath }) {
+  return createSoundingError({
+    code: 'E_SOUNDING_SOCKET_HOOK_UNAVAILABLE',
+    name: 'SoundingSocketError',
+    message:
+      'Sounding websocket helpers need Sails socket support. Install and enable `sails-hook-sockets`, then lift the app with the sockets hook enabled.',
+    details: {
+      dependency: 'sails-hook-sockets',
+      install: 'npm install sails-hook-sockets',
+      appPath,
+      suggestion:
+        'If your test config disables `hooks.sockets`, set it to `true` for websocket trials.',
+    },
+  })
 }
 
 /**
@@ -531,10 +575,22 @@ function resolveActor({ actor, world, sails, getConfig }) {
 }
 
 /**
- * @param {{ sails?: SoundingSailsApp, getConfig?: () => SoundingConfig, world?: SoundingWorldEngine }} input
+ * @param {{
+ *   sails?: SoundingSailsApp,
+ *   getConfig?: () => SoundingConfig,
+ *   world?: SoundingWorldEngine,
+ *   appPathResolver?: () => string,
+ *   loadSocketIoClient?: (appPath: string) => any,
+ * }} input
  * @returns {SoundingSocketManager}
  */
-function createSocketManager({ sails, getConfig, world } = {}) {
+function createSocketManager({
+  sails,
+  getConfig,
+  world,
+  appPathResolver = () => sails?.config?.appPath || process.cwd(),
+  loadSocketIoClient = defaultLoadSocketIoClient,
+} = {}) {
   /** @type {Set<SoundingSocketClient>} */
   const activeSockets = new Set()
 
@@ -554,12 +610,18 @@ function createSocketManager({ sails, getConfig, world } = {}) {
     }
 
     const timeout = options.timeout || config.timeout || 1000
+    const appPath = appPathResolver()
+    const socketClient = await loadSocketIoClient(appPath)
+
+    if (!hasSailsSocketSupport(sails)) {
+      throw createSocketHookUnavailableError({ appPath })
+    }
+
     const baseUrl = resolveBaseUrl({
       sails,
       getConfig,
       override: options.baseUrl || config.baseUrl,
     })
-    const socketClient = require('socket.io-client')
     const resolvedActor = resolveActor({ actor, world, sails, getConfig })
     const actorOptions = await resolveActorSocketOptions({
       sails,
@@ -630,5 +692,8 @@ function createSocketManager({ sails, getConfig, world } = {}) {
 }
 
 module.exports = {
+  createSocketHookUnavailableError,
   createSocketManager,
+  defaultLoadSocketIoClient,
+  hasSailsSocketSupport,
 }

--- a/lib/resolve-dependency.js
+++ b/lib/resolve-dependency.js
@@ -1,0 +1,145 @@
+const path = require('node:path')
+
+const { createSoundingError } = require('./create-error')
+
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+
+/**
+ * @param {unknown} error
+ * @returns {error is Error & { code: string }}
+ */
+function isMissingModuleError(error) {
+  return Boolean(
+    error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'MODULE_NOT_FOUND'
+  )
+}
+
+/**
+ * @param {{
+ *   moduleId: string,
+ *   dependency?: string,
+ *   purpose?: string,
+ *   install?: string,
+ *   suggestion?: string,
+ *   appPath?: string,
+ *   cause?: unknown,
+ * }} input
+ * @returns {Error}
+ */
+function createMissingDependencyError({
+  moduleId,
+  dependency = moduleId,
+  purpose,
+  install,
+  suggestion,
+  appPath,
+  cause,
+}) {
+  const reason = purpose ? ` Sounding needs it to ${purpose}.` : ''
+  const installHint = install ? ` Install it with: \`${install}\`.` : ''
+  const suggestionHint = suggestion ? ` ${suggestion}` : ''
+
+  return createSoundingError({
+    code: 'E_SOUNDING_DEPENDENCY_MISSING',
+    name: 'SoundingDependencyError',
+    message: `Sounding could not find dependency \`${dependency}\`.${reason}${installHint}${suggestionHint}`,
+    details: {
+      moduleId,
+      dependency,
+      purpose,
+      install,
+      suggestion,
+      appPath,
+    },
+    cause,
+  })
+}
+
+/**
+ * @param {{
+ *   appPath?: string,
+ *   moduleId: string,
+ *   dependency?: string,
+ *   purpose?: string,
+ *   install?: string,
+ *   suggestion?: string,
+ *   optional?: boolean,
+ *   resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string,
+ *   paths?: string[],
+ * }} input
+ * @returns {string | null}
+ */
+function resolveDependencyFromApp({
+  appPath = process.cwd(),
+  moduleId,
+  dependency = moduleId,
+  purpose,
+  install,
+  suggestion,
+  optional = false,
+  resolveImplementation = require.resolve,
+  paths,
+}) {
+  const resolvedAppPath = path.resolve(appPath)
+  const searchPaths = paths || [resolvedAppPath, process.cwd(), __dirname]
+
+  try {
+    return resolveImplementation(moduleId, { paths: searchPaths })
+  } catch (error) {
+    if (optional && isMissingModuleError(error)) {
+      return null
+    }
+
+    if (isMissingModuleError(error)) {
+      throw createMissingDependencyError({
+        moduleId,
+        dependency,
+        purpose,
+        install,
+        suggestion,
+        appPath: resolvedAppPath,
+        cause: error,
+      })
+    }
+
+    throw error
+  }
+}
+
+/**
+ * @param {{
+ *   appPath?: string,
+ *   moduleId: string,
+ *   dependency?: string,
+ *   purpose?: string,
+ *   install?: string,
+ *   suggestion?: string,
+ *   optional?: boolean,
+ *   resolveImplementation?: (moduleId: string, options?: { paths?: string[] }) => string,
+ *   requireImplementation?: (resolvedPath: string) => any,
+ *   paths?: string[],
+ * }} input
+ * @returns {any}
+ */
+function loadDependencyFromApp({
+  requireImplementation = require,
+  ...options
+}) {
+  const resolvedPath = resolveDependencyFromApp(options)
+
+  if (!resolvedPath) {
+    return null
+  }
+
+  return requireImplementation(resolvedPath)
+}
+
+module.exports = {
+  createMissingDependencyError,
+  isMissingModuleError,
+  loadDependencyFromApp,
+  resolveDependencyFromApp,
+}

--- a/lib/types.js
+++ b/lib/types.js
@@ -492,6 +492,7 @@
  *   environment?: string,
  *   liftOptions?: AnyRecord,
  *   SailsConstructor?: new (...args: any[]) => SoundingSailsApp,
+ *   loadSails?: (appPath: string) => any,
  * }} SoundingAppManagerOptions
  *
  * @typedef {{

--- a/test/dependency-detection.test.js
+++ b/test/dependency-detection.test.js
@@ -1,0 +1,247 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const {
+  assertManagedDatastoreDependency,
+  defaultLoadSails,
+} = require('../lib/create-app-manager')
+const {
+  createBrowserManager,
+  defaultLoadPlaywright,
+  defaultLoadPlaywrightTest,
+} = require('../lib/create-browser-manager')
+const {
+  createSocketManager,
+  defaultLoadSocketIoClient,
+  hasSailsSocketSupport,
+} = require('../lib/create-socket-manager')
+const { getDefaultConfig } = require('../lib/default-config')
+const { resolveDependencyFromApp } = require('../lib/resolve-dependency')
+
+/**
+ * @param {string} moduleId
+ * @returns {never}
+ */
+function missingResolver(moduleId) {
+  const error = new Error(`Cannot find module '${moduleId}'`)
+  error.code = 'MODULE_NOT_FOUND'
+  throw error
+}
+
+test('resolveDependencyFromApp turns missing app dependencies into Sounding setup errors', () => {
+  assert.throws(
+    () => {
+      resolveDependencyFromApp({
+        appPath: '/tmp/sounding-consumer',
+        moduleId: 'sails',
+        purpose: 'load your Sails app',
+        install: 'npm install sails',
+        resolveImplementation: missingResolver,
+      })
+    },
+    (error) => {
+      assert.equal(error.name, 'SoundingDependencyError')
+      assert.equal(error.code, 'E_SOUNDING_DEPENDENCY_MISSING')
+      assert.equal(error.dependency, 'sails')
+      assert.equal(error.moduleId, 'sails')
+      assert.equal(error.purpose, 'load your Sails app')
+      assert.equal(error.install, 'npm install sails')
+      assert.equal(error.appPath, path.resolve('/tmp/sounding-consumer'))
+      assert.match(error.message, /Sounding could not find dependency `sails`/)
+      assert.match(error.message, /npm install sails/)
+      return true
+    }
+  )
+})
+
+test('resolveDependencyFromApp lets optional dependencies degrade when absent', () => {
+  const resolved = resolveDependencyFromApp({
+    appPath: '/tmp/sounding-consumer',
+    moduleId: '@playwright/test',
+    optional: true,
+    resolveImplementation: missingResolver,
+  })
+
+  assert.equal(resolved, null)
+})
+
+test('resolveDependencyFromApp does not wrap non-resolution failures', () => {
+  const original = new Error('resolver permissions failed')
+  original.code = 'EACCES'
+
+  assert.throws(
+    () => {
+      resolveDependencyFromApp({
+        appPath: '/tmp/sounding-consumer',
+        moduleId: 'sails',
+        resolveImplementation() {
+          throw original
+        },
+      })
+    },
+    (error) => error === original
+  )
+})
+
+test('defaultLoadSails explains missing Sails app dependencies', () => {
+  assert.throws(
+    () => {
+      defaultLoadSails('/tmp/sounding-consumer', {
+        resolveImplementation: missingResolver,
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_DEPENDENCY_MISSING')
+      assert.equal(error.dependency, 'sails')
+      assert.match(error.message, /load your Sails app/)
+      return true
+    }
+  )
+})
+
+test('managed datastore setup explains missing sails-sqlite', () => {
+  const config = getDefaultConfig()
+
+  assert.throws(
+    () => {
+      assertManagedDatastoreDependency(config, '/tmp/sounding-consumer', {
+        resolveImplementation: missingResolver,
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_DEPENDENCY_MISSING')
+      assert.equal(error.dependency, 'sails-sqlite')
+      assert.equal(error.install, 'npm install -D sails-sqlite')
+      assert.match(error.message, /managed datastore trials/)
+      assert.match(error.message, /sounding\.datastore/)
+      return true
+    }
+  )
+})
+
+test('browser dependency loaders distinguish required and optional Playwright packages', () => {
+  assert.throws(
+    () => {
+      defaultLoadPlaywright('/tmp/sounding-consumer', {
+        resolveImplementation: missingResolver,
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_DEPENDENCY_MISSING')
+      assert.equal(error.dependency, 'playwright')
+      assert.equal(error.install, 'npm install -D playwright')
+      assert.match(error.message, /browser trials/)
+      return true
+    }
+  )
+
+  const optionalExpect = defaultLoadPlaywrightTest('/tmp/sounding-consumer', {
+    resolveImplementation: missingResolver,
+  })
+
+  assert.equal(optionalExpect, null)
+})
+
+test('createBrowserManager only swallows the optional @playwright/test missing dependency', async () => {
+  const original = new Error('broken expect loader')
+  const manager = createBrowserManager({
+    sails: {
+      config: {
+        appPath: '/tmp/sounding-consumer',
+        port: 1337,
+      },
+    },
+    loadPlaywright: async () => ({
+      chromium: {
+        launch: async () => {
+          throw new Error('should not launch before expect loader resolves')
+        },
+      },
+      devices: {},
+    }),
+    loadPlaywrightTest: async () => {
+      throw original
+    },
+  })
+
+  await assert.rejects(
+    async () => {
+      await manager.open()
+    },
+    (error) => error === original
+  )
+})
+
+test('socket dependency loader explains missing socket.io-client', () => {
+  assert.throws(
+    () => {
+      defaultLoadSocketIoClient('/tmp/sounding-consumer', {
+        resolveImplementation: missingResolver,
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_DEPENDENCY_MISSING')
+      assert.equal(error.dependency, 'socket.io-client')
+      assert.equal(error.install, 'npm install -D socket.io-client')
+      assert.match(error.message, /websocket trials/)
+      return true
+    }
+  )
+})
+
+test('createSocketManager reports missing or disabled Sails socket support before connecting', async () => {
+  assert.equal(
+    hasSailsSocketSupport({
+      hooks: { sockets: {} },
+      io: {},
+      sockets: {},
+    }),
+    true
+  )
+  assert.equal(hasSailsSocketSupport({ hooks: {} }), false)
+
+  const manager = createSocketManager({
+    sails: {
+      config: {
+        appPath: '/tmp/sounding-consumer',
+        port: 1337,
+      },
+      hooks: {
+        http: {
+          server: {
+            address: () => ({
+              address: '127.0.0.1',
+              port: 1337,
+            }),
+          },
+        },
+      },
+    },
+    getConfig: () => ({
+      sockets: {
+        enabled: true,
+        timeout: 10,
+      },
+    }),
+    loadSocketIoClient: async () => ({
+      io() {
+        throw new Error('should not connect without the Sails sockets hook')
+      },
+    }),
+  })
+
+  await assert.rejects(
+    async () => {
+      await manager.connect()
+    },
+    (error) => {
+      assert.equal(error.name, 'SoundingSocketError')
+      assert.equal(error.code, 'E_SOUNDING_SOCKET_HOOK_UNAVAILABLE')
+      assert.equal(error.dependency, 'sails-hook-sockets')
+      assert.equal(error.install, 'npm install sails-hook-sockets')
+      assert.match(error.message, /sails-hook-sockets/)
+      return true
+    }
+  )
+})


### PR DESCRIPTION
Closes #36

## Summary
- Add shared dependency resolution diagnostics for app-local dependencies.
- Surface actionable setup errors for Sails, managed datastore, browser, and websocket trials.
- Cover missing dependency branches with targeted tests.

## Verification
- npm run typecheck
- npm test