### PR TITLE
feat: expose virtual response session snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The canonical Sails-native surface is:
 - `await auth.login.withPassword('creator@example.com', page, { password: 'secret123' })` inside browser trials
 - `await auth.request.withPassword('creator@example.com', { password: 'secret123' })` inside request trials
 - request helpers default to Sails virtual requests powered by `sails.request()`
+- virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
 - Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
 - a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`
 - any trial can also scope a request client with `sails.sounding.request.using('http')`

--- a/lib/create-request-client.js
+++ b/lib/create-request-client.js
@@ -139,6 +139,7 @@ function normalizeBodyValue(value) {
  *   url?: string,
  *   redirected?: boolean,
  *   responseBody?: any,
+ *   session?: AnyRecord,
  * }} input
  * @returns {SoundingResponse}
  */
@@ -150,6 +151,7 @@ function normalizeResponse({
   url,
   redirected = false,
   responseBody,
+  session,
 }) {
   const normalizedHeaders = new Headers(headers)
   const contentType = normalizedHeaders.get('content-type') || ''
@@ -171,6 +173,7 @@ function normalizeResponse({
     statusText,
     url,
     redirected,
+    session,
     headers: normalizedHeaders,
     body,
     data,
@@ -373,6 +376,32 @@ function replaceObjectContents(target, source) {
 }
 
 /**
+ * @param {any} value
+ * @returns {any}
+ */
+function cloneSessionValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(cloneSessionValue)
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, cloneSessionValue(nested)])
+    )
+  }
+
+  return value
+}
+
+/**
+ * @param {AnyRecord} session
+ * @returns {AnyRecord}
+ */
+function cloneSessionSnapshot(session) {
+  return cloneSessionValue(session)
+}
+
+/**
  * Sails' virtual router deep-copies the partial request before routing it.
  * Track the routed request so session mutations made by real route handlers
  * can flow back into Sounding's shared virtual session object.
@@ -462,6 +491,7 @@ function createVirtualTransport({ sails }) {
                   url: target,
                   redirected: status >= 300 && status < 400,
                   responseBody,
+                  session: cloneSessionSnapshot(session),
                 })
               )
             } catch (error) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -43,6 +43,7 @@
  *   statusText: string,
  *   url?: string,
  *   redirected: boolean,
+ *   session?: AnyRecord,
  *   headers: Headers,
  *   body: string,
  *   data: any,

--- a/test/fixture-app.integration.test.js
+++ b/test/fixture-app.integration.test.js
@@ -56,6 +56,10 @@ test('createAppManager exercises a real Sails fixture app through the Sounding r
   })
   assert.equal(login.status, 302)
   assert.equal(login.header('location'), '/dashboard')
+  assert.deepEqual(login.session.user, {
+    email: 'ada@example.com',
+  })
+  assert.deepEqual(login.session.__soundingFlashStore.info, ['Welcome ada@example.com'])
 
   const me = await booted.request.get('/me')
   assert.equal(me.status, 200)
@@ -120,6 +124,7 @@ test('createAppManager can lift the real fixture app for HTTP request trials', a
   const health = await booted.request.using('http').get('/api/health')
   assert.equal(health.status, 200)
   assert.equal(health.data.ok, true)
+  assert.equal(health.session, undefined)
 
   await runtime.lower()
 })

--- a/test/request-client.test.js
+++ b/test/request-client.test.js
@@ -97,6 +97,59 @@ test('createRequestClient can attach an actor session for virtual policy checks'
   assert.deepEqual(calls[0].session.__soundingFlashStore, {})
 })
 
+test('createRequestClient exposes final virtual session snapshots on responses', async () => {
+  const sails = {
+    router: {
+      route(req, res) {
+        if (req.method === 'POST' && req.url === '/login') {
+          req.session.userId = 7
+          req.session.returnTo = '/dashboard'
+          req.flash('success', 'Welcome back')
+          res._clientRes.statusCode = 302
+          res._clientRes.headers = {
+            location: '/dashboard',
+          }
+          res._clientRes.end('')
+          return
+        }
+
+        if (req.method === 'POST' && req.url === '/logout') {
+          delete req.session.userId
+          req.session.loggedOut = true
+          res._clientRes.statusCode = 204
+          res._clientRes.end('')
+          return
+        }
+
+        res._clientRes.statusCode = 404
+        res._clientRes.end('')
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+
+  const request = createRequestClient({ sails })
+  const login = await request.post('/login', {
+    email: 'reader@example.com',
+  })
+
+  assert.equal(login.session.userId, 7)
+  assert.equal(login.session.returnTo, '/dashboard')
+  assert.deepEqual(login.session.__soundingFlashStore.success, ['Welcome back'])
+
+  const originalLoginSnapshot = login.session
+  const logout = await request.post('/logout')
+
+  assert.equal(logout.session.userId, undefined)
+  assert.equal(logout.session.returnTo, '/dashboard')
+  assert.equal(logout.session.loggedOut, true)
+  assert.notEqual(logout.session, originalLoginSnapshot)
+  assert.equal(login.session.userId, 7)
+  assert.equal(login.session.loggedOut, undefined)
+})
+
 test('createRequestClient.as uses creatorId when Creator auth is detected', async () => {
   const calls = []
   const sails = {
@@ -607,6 +660,7 @@ test('createRequestClient can use explicit HTTP transport when parity matters mo
     assert.equal(request.transport, 'http')
     createExpect(response).toHaveStatus(200)
     createExpect(response).toHaveJsonPath('ok', true)
+    assert.equal(response.session, undefined)
     assert.deepEqual(await response.json(), { ok: true })
   } finally {
     await close(server)


### PR DESCRIPTION
Closes #16

## Summary
- Expose final virtual `req.session` snapshots as `response.session`.
- Keep HTTP responses honest by leaving `response.session` undefined.
- Document the transport-specific behavior and cover snapshot semantics in tests.

## Verification
- npm run typecheck
- npm test