### PR TITLE
feat: add session and flash assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The canonical Sails-native surface is:
 - `await auth.request.withPassword('creator@example.com', { password: 'secret123' })` inside request trials
 - request helpers default to Sails virtual requests powered by `sails.request()`
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
+- request assertions can check auth/session state with `expect(response).toHaveSession('userId', user.id)` and flash messages with `expect(response).toHaveFlash('info', /welcome/i)`
 - Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
 - a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`
 - any trial can also scope a request client with `sails.sounding.request.using('http')`

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -1,5 +1,7 @@
 const assert = require('node:assert/strict')
 
+const { createSoundingError } = require('./create-error')
+
 /** @typedef {import('./types').SoundingExpect} SoundingExpect */
 /** @typedef {import('./types').SoundingExpectation} SoundingExpectation */
 
@@ -109,6 +111,76 @@ function assertPartialMatch(actual, expected, message) {
 }
 
 /**
+ * @returns {Error}
+ */
+function createResponseSessionUnavailableError() {
+  return createSoundingError({
+    code: 'E_SOUNDING_RESPONSE_SESSION_UNAVAILABLE',
+    name: 'SoundingExpectationError',
+    message:
+      'Sounding session assertions require a virtual request response. HTTP responses do not expose server-side session state, so use the virtual transport or assert cookies, headers, and follow-up behavior instead.',
+  })
+}
+
+/**
+ * @param {any} actual
+ * @returns {any}
+ */
+function resolveResponseSession(actual) {
+  if (actual?.session && typeof actual.session === 'object' && !Array.isArray(actual.session)) {
+    return actual.session
+  }
+
+  throw createResponseSessionUnavailableError()
+}
+
+/**
+ * @param {any[]} messages
+ * @param {any} expected
+ * @returns {boolean}
+ */
+function flashMessagesMatch(messages, expected) {
+  if (expected === undefined) {
+    return messages.length > 0
+  }
+
+  if (Array.isArray(expected)) {
+    return partiallyMatches(messages, expected)
+  }
+
+  return messages.some((message) => partiallyMatches(message, expected))
+}
+
+/**
+ * @param {any} value
+ * @returns {string}
+ */
+function describeExpected(value) {
+  if (value instanceof RegExp) {
+    return String(value)
+  }
+
+  if (typeof value === 'function') {
+    return value.name ? `[Function: ${value.name}]` : '[Function]'
+  }
+
+  return JSON.stringify(value)
+}
+
+/**
+ * @param {string} path
+ * @param {any} expected
+ * @returns {string}
+ */
+function formatExpectation(path, expected) {
+  if (expected === undefined) {
+    return `\`${path}\` to be present`
+  }
+
+  return `\`${path}\` to match ${describeExpected(expected)}`
+}
+
+/**
  * @param {any} actual
  * @param {{ fallback?: (actual: any) => any }} [options]
  * @returns {SoundingExpectation | any}
@@ -186,6 +258,34 @@ function createExpect(actual, { fallback } = {}) {
       assert.deepStrictEqual(value, expected)
     },
 
+    toHaveSession(path, expected) {
+      const session = resolveResponseSession(actual)
+      const value = getPath(session, path)
+
+      if (expected === undefined) {
+        assert.notStrictEqual(value, undefined, `Expected session ${formatExpectation(path)}.`)
+        return
+      }
+
+      assertPartialMatch(
+        value,
+        expected,
+        `Expected session ${formatExpectation(path, expected)}, received ${describeExpected(value)}.`
+      )
+    },
+
+    toHaveFlash(type, expected) {
+      const session = resolveResponseSession(actual)
+      const messages = session.__soundingFlashStore?.[type] || []
+
+      assert.ok(
+        flashMessagesMatch(messages, expected),
+        expected === undefined
+          ? `Expected flash \`${type}\` to be present.`
+          : `Expected flash \`${type}\` to match ${describeExpected(expected)}, received ${describeExpected(messages)}.`
+      )
+    },
+
     toBeInertiaPage(component) {
       const value = resolveStructuredValue(actual)
       assert.strictEqual(value?.component, component)
@@ -251,6 +351,33 @@ function createExpect(actual, { fallback } = {}) {
     },
 
     not: {
+      toHaveSession(path, expected) {
+        const session = resolveResponseSession(actual)
+        const value = getPath(session, path)
+
+        if (expected === undefined) {
+          assert.strictEqual(value, undefined, `Expected session not to include \`${path}\`.`)
+          return
+        }
+
+        assert.ok(
+          !partiallyMatches(value, expected),
+          `Expected session \`${path}\` not to match ${describeExpected(expected)}.`
+        )
+      },
+
+      toHaveFlash(type, expected) {
+        const session = resolveResponseSession(actual)
+        const messages = session.__soundingFlashStore?.[type] || []
+
+        assert.ok(
+          !flashMessagesMatch(messages, expected),
+          expected === undefined
+            ? `Expected flash \`${type}\` not to be present.`
+            : `Expected flash \`${type}\` not to match ${describeExpected(expected)}.`
+        )
+      },
+
       async toReceive(event, expected, options = {}) {
         if (typeof actual?.receive !== 'function') {
           throw new TypeError('Sounding expect().not.toReceive() requires a Sounding socket client.')

--- a/lib/types.js
+++ b/lib/types.js
@@ -126,6 +126,8 @@
  *   toHaveHeader(name: string, expected?: string): void,
  *   toRedirectTo(expected: string): void,
  *   toHaveJsonPath(path: string, expected: any): void,
+ *   toHaveSession(path: string, expected?: any): void,
+ *   toHaveFlash(type: string, expected?: any): void,
  *   toBeInertiaPage(component: string): void,
  *   toHaveProp(path: string, expected: any): void,
  *   toMatchProp(path: string, expected: string | RegExp): void,
@@ -134,6 +136,8 @@
  *   toReceive(event: string, expected?: any, options?: { timeout?: number }): Promise<void>,
  *   toHaveReceived(event: string, expected?: any): void,
  *   not: {
+ *     toHaveSession(path: string, expected?: any): void,
+ *     toHaveFlash(type: string, expected?: any): void,
  *     toReceive(event: string, expected?: any, options?: { timeout?: number }): Promise<void>,
  *   },
  *   [key: string]: any,

--- a/test/request-client.test.js
+++ b/test/request-client.test.js
@@ -138,6 +138,11 @@ test('createRequestClient exposes final virtual session snapshots on responses',
   assert.equal(login.session.userId, 7)
   assert.equal(login.session.returnTo, '/dashboard')
   assert.deepEqual(login.session.__soundingFlashStore.success, ['Welcome back'])
+  createExpect(login).toHaveSession('userId', 7)
+  createExpect(login).toHaveSession('returnTo', '/dashboard')
+  createExpect(login).toHaveFlash('success', /welcome/i)
+  createExpect(login).not.toHaveSession('loggedOut')
+  createExpect(login).not.toHaveFlash('error')
 
   const originalLoginSnapshot = login.session
   const logout = await request.post('/logout')
@@ -148,6 +153,9 @@ test('createRequestClient exposes final virtual session snapshots on responses',
   assert.notEqual(logout.session, originalLoginSnapshot)
   assert.equal(login.session.userId, 7)
   assert.equal(login.session.loggedOut, undefined)
+  createExpect(logout).not.toHaveSession('userId')
+  createExpect(logout).toHaveSession('loggedOut', true)
+  createExpect(logout).not.toHaveFlash('success', /signed in/i)
 })
 
 test('createRequestClient.as uses creatorId when Creator auth is detected', async () => {
@@ -262,6 +270,7 @@ test('auth.request.withPassword preserves creator sessions through the shared re
 
   createExpect(login.response).toHaveStatus(302)
   createExpect(login.response).toRedirectTo('/invoices')
+  createExpect(login.response).toHaveSession('creatorId', 9)
   createExpect(response).toHaveStatus(200)
   createExpect(response).toHaveJsonPath('creatorId', 9)
   assert.deepEqual(calls[0].body, {
@@ -661,6 +670,17 @@ test('createRequestClient can use explicit HTTP transport when parity matters mo
     createExpect(response).toHaveStatus(200)
     createExpect(response).toHaveJsonPath('ok', true)
     assert.equal(response.session, undefined)
+    assert.throws(
+      () => {
+        createExpect(response).toHaveSession('userId')
+      },
+      (error) => {
+        assert.equal(error.code, 'E_SOUNDING_RESPONSE_SESSION_UNAVAILABLE')
+        assert.match(error.message, /virtual request response/)
+        assert.match(error.message, /HTTP responses/)
+        return true
+      }
+    )
     assert.deepEqual(await response.json(), { ok: true })
   } finally {
     await close(server)


### PR DESCRIPTION
Closes #31

## Summary
- Add `toHaveSession()` and `not.toHaveSession()` for virtual request responses.
- Add `toHaveFlash()` and `not.toHaveFlash()` for Sounding flash stores.
- Report a clear transport-specific error when session assertions are used on HTTP responses.

## Verification
- node --test test/request-client.test.js
- npm run typecheck
- npm test