### PR TITLE
feat: add mail assertion helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The canonical Sails-native surface is:
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
 - request assertions can check auth/session state with `expect(response).toHaveSession('userId', user.id)` and flash messages with `expect(response).toHaveFlash('info', /welcome/i)`
 - Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
+- mail assertions can check captured emails with `expect(mailbox).toHaveSentMail({ to, subject })` and `expect(mailbox.latest()).toHaveCtaUrl(/magic-link/)`
 - a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`
 - any trial can also scope a request client with `sails.sounding.request.using('http')`
 

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -33,6 +33,36 @@ function getHeader(actual, name) {
 
 /**
  * @param {any} actual
+ * @returns {boolean}
+ */
+function isMailbox(actual) {
+  return Boolean(
+    actual &&
+      typeof actual === 'object' &&
+      typeof actual.all === 'function' &&
+      typeof actual.latest === 'function'
+  )
+}
+
+/**
+ * @param {any} actual
+ * @returns {boolean}
+ */
+function isMailMessage(actual) {
+  return Boolean(
+    actual &&
+      typeof actual === 'object' &&
+      !Array.isArray(actual) &&
+      ('to' in actual ||
+        'subject' in actual ||
+        'template' in actual ||
+        'ctaUrl' in actual ||
+        'status' in actual)
+  )
+}
+
+/**
+ * @param {any} actual
  * @returns {any}
  */
 function resolveStructuredValue(actual) {
@@ -49,6 +79,10 @@ function resolveStructuredValue(actual) {
  */
 function shouldUseFallback(actual) {
   if (typeof actual?.receive === 'function' && typeof actual?.events === 'function') {
+    return false
+  }
+
+  if (isMailbox(actual) || isMailMessage(actual)) {
     return false
   }
 
@@ -164,7 +198,17 @@ function describeExpected(value) {
     return value.name ? `[Function: ${value.name}]` : '[Function]'
   }
 
-  return JSON.stringify(value)
+  return JSON.stringify(value, (_key, nested) => {
+    if (nested instanceof RegExp) {
+      return String(nested)
+    }
+
+    if (typeof nested === 'function') {
+      return nested.name ? `[Function: ${nested.name}]` : '[Function]'
+    }
+
+    return nested
+  })
 }
 
 /**
@@ -178,6 +222,86 @@ function formatExpectation(path, expected) {
   }
 
   return `\`${path}\` to match ${describeExpected(expected)}`
+}
+
+/**
+ * @param {any} target
+ * @returns {any[]}
+ */
+function resolveMailboxMessages(target) {
+  if (isMailbox(target)) {
+    return target.all()
+  }
+
+  throw new TypeError('Sounding expect().toHaveSentMail() requires a Sounding mailbox.')
+}
+
+/**
+ * @param {any} target
+ * @returns {any}
+ */
+function resolveMailMessage(target) {
+  if (isMailMessage(target)) {
+    return target
+  }
+
+  throw new TypeError('Sounding expect().toHaveCtaUrl() requires a captured mail message.')
+}
+
+/**
+ * @param {any[]} actual
+ * @param {any} expected
+ * @returns {boolean}
+ */
+function listContainsPartial(actual, expected) {
+  if (Array.isArray(expected)) {
+    return partiallyMatches(actual, expected)
+  }
+
+  return actual.some((entry) => partiallyMatches(entry, expected))
+}
+
+/**
+ * @param {any} message
+ * @param {any} expected
+ * @returns {boolean}
+ */
+function mailMatches(message, expected = {}) {
+  if (typeof expected === 'function' || expected instanceof RegExp) {
+    return partiallyMatches(message, expected)
+  }
+
+  return Object.entries(expected).every(([key, value]) => {
+    const actualValue = getPath(message, key)
+
+    if (Array.isArray(actualValue)) {
+      return listContainsPartial(actualValue, value)
+    }
+
+    return partiallyMatches(actualValue, value)
+  })
+}
+
+/**
+ * @param {any} message
+ * @returns {any}
+ */
+function summarizeMailMessage(message) {
+  return {
+    to: message?.to,
+    subject: message?.subject,
+    template: message?.template,
+    status: message?.status,
+    ctaUrl: message?.ctaUrl,
+  }
+}
+
+/**
+ * @param {any[]} messages
+ * @returns {string}
+ */
+function summarizeMailMessages(messages) {
+  return describeExpected(messages.map(summarizeMailMessage))
 }
 
 /**
@@ -256,6 +380,40 @@ function createExpect(actual, { fallback } = {}) {
     toHaveJsonPath(path, expected) {
       const value = getPath(resolveStructuredValue(actual), path)
       assert.deepStrictEqual(value, expected)
+    },
+
+    toHaveSentCount(expected) {
+      const messages = resolveMailboxMessages(actual)
+      assert.strictEqual(
+        messages.length,
+        expected,
+        `Expected mailbox to have sent ${expected} message(s), received ${messages.length}. Captured mail: ${summarizeMailMessages(messages)}.`
+      )
+    },
+
+    toHaveSentMail(expected = {}) {
+      const messages = resolveMailboxMessages(actual)
+
+      assert.ok(
+        messages.some((message) => mailMatches(message, expected)),
+        `Expected mailbox to have sent mail matching ${describeExpected(expected)}. Captured mail: ${summarizeMailMessages(messages)}.`
+      )
+    },
+
+    toHaveCtaUrl(expected) {
+      const message = resolveMailMessage(actual)
+      const ctaUrl = message.ctaUrl
+
+      if (expected === undefined) {
+        assert.notStrictEqual(ctaUrl, undefined, 'Expected captured mail to have a CTA URL.')
+        return
+      }
+
+      assertPartialMatch(
+        ctaUrl,
+        expected,
+        `Expected captured mail CTA URL to match ${describeExpected(expected)}, received ${describeExpected(ctaUrl)}.`
+      )
     },
 
     toHaveSession(path, expected) {
@@ -351,6 +509,30 @@ function createExpect(actual, { fallback } = {}) {
     },
 
     not: {
+      toHaveSentMail(expected = {}) {
+        const messages = resolveMailboxMessages(actual)
+
+        assert.ok(
+          !messages.some((message) => mailMatches(message, expected)),
+          `Expected mailbox not to have sent mail matching ${describeExpected(expected)}. Captured mail: ${summarizeMailMessages(messages)}.`
+        )
+      },
+
+      toHaveCtaUrl(expected) {
+        const message = resolveMailMessage(actual)
+        const ctaUrl = message.ctaUrl
+
+        if (expected === undefined) {
+          assert.strictEqual(ctaUrl, undefined, 'Expected captured mail not to have a CTA URL.')
+          return
+        }
+
+        assert.ok(
+          !partiallyMatches(ctaUrl, expected),
+          `Expected captured mail CTA URL not to match ${describeExpected(expected)}.`
+        )
+      },
+
       toHaveSession(path, expected) {
         const session = resolveResponseSession(actual)
         const value = getPath(session, path)

--- a/lib/types.js
+++ b/lib/types.js
@@ -126,6 +126,9 @@
  *   toHaveHeader(name: string, expected?: string): void,
  *   toRedirectTo(expected: string): void,
  *   toHaveJsonPath(path: string, expected: any): void,
+ *   toHaveSentCount(expected: number): void,
+ *   toHaveSentMail(expected?: Partial<SoundingMailMessage> | ((message: SoundingMailMessage) => boolean)): void,
+ *   toHaveCtaUrl(expected?: string | RegExp): void,
  *   toHaveSession(path: string, expected?: any): void,
  *   toHaveFlash(type: string, expected?: any): void,
  *   toBeInertiaPage(component: string): void,
@@ -136,6 +139,8 @@
  *   toReceive(event: string, expected?: any, options?: { timeout?: number }): Promise<void>,
  *   toHaveReceived(event: string, expected?: any): void,
  *   not: {
+ *     toHaveSentMail(expected?: Partial<SoundingMailMessage> | ((message: SoundingMailMessage) => boolean)): void,
+ *     toHaveCtaUrl(expected?: string | RegExp): void,
  *     toHaveSession(path: string, expected?: any): void,
  *     toHaveFlash(type: string, expected?: any): void,
  *     toReceive(event: string, expected?: any, options?: { timeout?: number }): Promise<void>,

--- a/test/mail-capture.test.js
+++ b/test/mail-capture.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict')
 
 const { createRuntime } = require('../lib/create-runtime')
 const { buildCapturedMail, createMailCapture } = require('../lib/create-mail-capture')
+const { createExpect } = require('../lib/create-expect')
 
 function createRenderView(htmlBuilder) {
   return (viewPath, locals) => ({
@@ -54,6 +55,8 @@ test('buildCapturedMail renders the email preview and extracts links', async () 
   assert.deepEqual(message.links, ['https://example.com/magic-link/token-123'])
   assert.equal(message.layout, 'mail')
   assert.equal(previewLayout, '../layouts/mail')
+  createExpect(message).toHaveCtaUrl(/magic-link\/token-123/)
+  createExpect(message).not.toHaveCtaUrl(/reset-password/)
 })
 
 test('buildCapturedMail honors the configured preview layout for compatibility', async () => {
@@ -202,6 +205,33 @@ test('runtime boot installs in-memory mail capture and lower restores the origin
   assert.equal(runtime.mailbox.latest().subject, 'Sign in')
   assert.equal(runtime.mailbox.latest().ctaUrl, 'https://example.com/magic-link/kelvin')
   assert.equal(runtime.mailbox.latest().layout, 'mail')
+  createExpect(runtime.mailbox).toHaveSentCount(1)
+  createExpect(runtime.mailbox).toHaveSentMail({
+    to: 'reader@example.com',
+    subject: /sign in/i,
+    template: 'email-magic-link',
+    status: 'sent',
+    ctaUrl: /magic-link\/kelvin$/,
+    templateData: {
+      magicLink: /magic-link\/kelvin$/,
+    },
+  })
+  createExpect(runtime.mailbox.latest()).toHaveCtaUrl(/magic-link/)
+  createExpect(runtime.mailbox).not.toHaveSentMail({ subject: /reset password/i })
+
+  assert.throws(
+    () => {
+      createExpect(runtime.mailbox).toHaveSentMail({
+        to: 'missing@example.com',
+      })
+    },
+    (error) => {
+      assert.match(error.message, /missing@example\.com/)
+      assert.match(error.message, /reader@example\.com/)
+      assert.match(error.message, /Sign in/)
+      return true
+    }
+  )
 
   await runtime.lower()
 
@@ -310,6 +340,12 @@ test('runtime can capture failed mail sends when passthrough delivery is enabled
   assert.equal(runtime.mailbox.latest().status, 'failed')
   assert.equal(runtime.mailbox.latest().subject, 'Sign in')
   assert.equal(runtime.mailbox.latest().error.message, 'SMTP is down')
+  createExpect(runtime.mailbox).toHaveSentMail({
+    status: 'failed',
+    error: {
+      message: /SMTP is down/,
+    },
+  })
 
   await runtime.lower()
 })


### PR DESCRIPTION
## Summary
- add mailbox matchers for sent count and sent mail criteria
- add captured-message CTA URL matchers with negated forms
- cover recipient, subject, template, status, CTA URL, nested template data, failures, and failure summaries

## Verification
- npm run typecheck
- npm test
- git diff --check

Closes #30