### PR TITLE
feat: add failure diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The canonical Sails-native surface is:
 - request helpers default to Sails virtual requests powered by `sails.request()`
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
 - request assertions can check auth/session state with `expect(response).toHaveSession('userId', user.id)` and flash messages with `expect(response).toHaveFlash('info', /welcome/i)`
+- failed response assertions include concise request/response diagnostics; set `SOUNDING_DIAGNOSTICS=verbose` for full response excerpts
 - Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
 - mail assertions can check captured emails with `expect(mailbox).toHaveSentMail({ to, subject })` and `expect(mailbox.latest()).toHaveCtaUrl(/magic-link/)`
 - a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`

--- a/lib/create-auth-helpers.js
+++ b/lib/create-auth-helpers.js
@@ -33,6 +33,14 @@ function looksLikeEmail(value) {
 }
 
 /**
+ * @param {string[]} values
+ * @returns {string}
+ */
+function formatAvailable(values) {
+  return values.length ? values.join(', ') : 'none'
+}
+
+/**
  * @param {{
  *   sails?: SoundingSailsApp,
  *   world: SoundingWorldEngine,
@@ -67,6 +75,26 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
       world.current?.creators?.[alias] ||
       null
     )
+  }
+
+  /**
+   * @returns {string[]}
+   */
+  function availableWorldActors() {
+    const auth = getAuthConfig()
+    const aliases = new Set()
+
+    for (const collection of [auth.worldCollection, 'users', 'creators']) {
+      const entries = world.current?.[collection]
+
+      if (entries && typeof entries === 'object' && !Array.isArray(entries)) {
+        for (const alias of Object.keys(entries)) {
+          aliases.add(alias)
+        }
+      }
+    }
+
+    return Array.from(aliases).sort()
   }
 
   /**
@@ -132,8 +160,10 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
     }
 
     let candidate = actorOrEmail
+    let unresolvedAlias = null
 
     if (typeof candidate === 'string' && !looksLikeEmail(candidate)) {
+      unresolvedAlias = candidate
       candidate = resolveWorldActor(candidate) || candidate
     }
 
@@ -149,12 +179,25 @@ function createAuthHelpers({ sails, world, mailbox, request }) {
         : candidate?.email || null
 
     if (!email) {
+      const details = {
+        actor: candidate,
+      }
+
+      if (unresolvedAlias && candidate === unresolvedAlias) {
+        const availableActors = availableWorldActors()
+        details.availableActors = availableActors
+
+        throw createSoundingError({
+          code: 'E_SOUNDING_AUTH_EMAIL_UNRESOLVED',
+          message: `Sounding auth helpers could not resolve an email address for actor \`${candidate}\`. Available actors: ${formatAvailable(availableActors)}.`,
+          details,
+        })
+      }
+
       throw createSoundingError({
         code: 'E_SOUNDING_AUTH_EMAIL_UNRESOLVED',
         message: `Sounding auth helpers could not resolve an email address for actor \`${candidate}\`.`,
-        details: {
-          actor: candidate,
-        },
+        details,
       })
     }
 

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -305,6 +305,139 @@ function summarizeMailMessages(messages) {
 }
 
 /**
+ * @param {any} headers
+ * @returns {Array<[string, string]>}
+ */
+function getHeaderEntries(headers) {
+  if (!headers) {
+    return []
+  }
+
+  if (typeof headers.forEach === 'function') {
+    const entries = []
+    headers.forEach((value, key) => {
+      entries.push([key, value])
+    })
+    return entries
+  }
+
+  return Object.entries(headers).map(([key, value]) => [key, String(value)])
+}
+
+/**
+ * @param {any} headers
+ * @returns {string}
+ */
+function summarizeHeaders(headers) {
+  const entries = getHeaderEntries(headers)
+  const limit = usesVerboseDiagnostics() ? entries.length : 6
+  const visibleEntries = entries.slice(0, limit).map(([key, value]) => `${key}: ${value}`)
+
+  if (entries.length > visibleEntries.length) {
+    visibleEntries.push(`... ${entries.length - visibleEntries.length} more`)
+  }
+
+  return visibleEntries.join(', ')
+}
+
+/**
+ * @param {string} value
+ * @param {number} maxLength
+ * @returns {string}
+ */
+function truncate(value, maxLength) {
+  if (value.length <= maxLength) {
+    return value
+  }
+
+  return `${value.slice(0, maxLength)}...`
+}
+
+/**
+ * @param {any} actual
+ * @returns {string}
+ */
+function summarizeResponseBody(actual) {
+  const body = actual?.body || (actual?.data === undefined ? '' : describeExpected(actual.data))
+  const limit = usesVerboseDiagnostics() ? Infinity : 500
+  return truncate(String(body).replace(/\s+/g, ' ').trim(), limit)
+}
+
+/**
+ * @returns {boolean}
+ */
+function usesVerboseDiagnostics() {
+  return process.env.SOUNDING_DIAGNOSTICS === 'verbose'
+}
+
+/**
+ * @param {any} actual
+ * @returns {string}
+ */
+function formatResponseDiagnostics(actual) {
+  const request = actual?.request
+  const hasResponseContext =
+    Boolean(request) || actual?.status !== undefined || actual?.url !== undefined
+
+  if (!hasResponseContext) {
+    return ''
+  }
+
+  const lines = []
+
+  if (request) {
+    const transport = request.transport ? ` (${request.transport})` : ''
+    const url = request.url && request.url !== request.target ? ` -> ${request.url}` : ''
+    lines.push(`Request: ${request.method} ${request.target}${transport}${url}`)
+  } else if (actual?.url) {
+    lines.push(`URL: ${actual.url}`)
+  }
+
+  if (actual?.status !== undefined) {
+    const statusText = actual.statusText ? ` ${actual.statusText}` : ''
+    lines.push(`Response: ${actual.status}${statusText}`)
+  }
+
+  const headers = summarizeHeaders(actual?.headers)
+  if (headers) {
+    lines.push(`Headers: ${headers}`)
+  }
+
+  const body = summarizeResponseBody(actual)
+  if (body) {
+    lines.push(`Body: ${body}`)
+  }
+
+  if (lines.length === 0) {
+    return ''
+  }
+
+  return `\n\nSounding response diagnostics:\n${lines.map((line) => `- ${line}`).join('\n')}`
+}
+
+/**
+ * @param {string} message
+ * @param {any} actual
+ */
+function failWithResponseDiagnostics(message, actual) {
+  assert.fail(`${message}${formatResponseDiagnostics(actual)}`)
+}
+
+/**
+ * @param {any} value
+ * @param {any} expected
+ * @param {string} message
+ * @param {any} actual
+ */
+function assertDeepEqualWithResponseDiagnostics(value, expected, message, actual) {
+  try {
+    assert.deepStrictEqual(value, expected)
+  } catch (_error) {
+    failWithResponseDiagnostics(message, actual)
+  }
+}
+
+/**
  * @param {any} actual
  * @param {{ fallback?: (actual: any) => any }} [options]
  * @returns {SoundingExpectation | any}
@@ -359,27 +492,46 @@ function createExpect(actual, { fallback } = {}) {
     },
 
     toHaveStatus(expected) {
-      assert.strictEqual(actual?.status, expected)
+      if (actual?.status !== expected) {
+        failWithResponseDiagnostics(
+          `Expected response status ${expected}, received ${describeExpected(actual?.status)}.`,
+          actual
+        )
+      }
     },
 
     toHaveHeader(name, expected) {
       const header = getHeader(actual, name)
-      assert.notStrictEqual(header, null)
-      assert.notStrictEqual(header, undefined)
+      if (header === null || header === undefined) {
+        failWithResponseDiagnostics(`Expected response header \`${name}\` to be present.`, actual)
+      }
 
-      if (expected !== undefined) {
-        assert.strictEqual(header, expected)
+      if (expected !== undefined && header !== expected) {
+        failWithResponseDiagnostics(
+          `Expected response header \`${name}\` to equal ${describeExpected(expected)}, received ${describeExpected(header)}.`,
+          actual
+        )
       }
     },
 
     toRedirectTo(expected) {
       const location = getHeader(actual, 'location')
-      assert.strictEqual(location, expected)
+      if (location !== expected) {
+        failWithResponseDiagnostics(
+          `Expected response to redirect to ${describeExpected(expected)}, received ${describeExpected(location)}.`,
+          actual
+        )
+      }
     },
 
     toHaveJsonPath(path, expected) {
       const value = getPath(resolveStructuredValue(actual), path)
-      assert.deepStrictEqual(value, expected)
+      assertDeepEqualWithResponseDiagnostics(
+        value,
+        expected,
+        `Expected JSON path ${formatExpectation(path, expected)}, received ${describeExpected(value)}.`,
+        actual
+      )
     },
 
     toHaveSentCount(expected) {
@@ -446,36 +598,68 @@ function createExpect(actual, { fallback } = {}) {
 
     toBeInertiaPage(component) {
       const value = resolveStructuredValue(actual)
-      assert.strictEqual(value?.component, component)
+      if (value?.component !== component) {
+        failWithResponseDiagnostics(
+          `Expected Inertia component ${describeExpected(component)}, received ${describeExpected(value?.component)}.`,
+          actual
+        )
+      }
     },
 
     toHaveProp(path, expected) {
       const value = getPath(resolveStructuredValue(actual)?.props, path)
-      assert.deepStrictEqual(value, expected)
+      assertDeepEqualWithResponseDiagnostics(
+        value,
+        expected,
+        `Expected Inertia prop ${formatExpectation(path, expected)}, received ${describeExpected(value)}.`,
+        actual
+      )
     },
 
     toMatchProp(path, expected) {
       const value = getPath(resolveStructuredValue(actual)?.props, path)
 
       if (expected instanceof RegExp) {
-        assert.match(String(value), expected)
+        if (!expected.test(String(value))) {
+          failWithResponseDiagnostics(
+            `Expected Inertia prop ${formatExpectation(path, expected)}, received ${describeExpected(value)}.`,
+            actual
+          )
+        }
         return
       }
 
-      assert.ok(String(value).includes(String(expected)))
+      if (!String(value).includes(String(expected))) {
+        failWithResponseDiagnostics(
+          `Expected Inertia prop \`${path}\` to include ${describeExpected(expected)}, received ${describeExpected(value)}.`,
+          actual
+        )
+      }
     },
 
     toHaveSharedProp(path, expected) {
       const value = getPath(resolveStructuredValue(actual)?.props, path)
-      assert.deepStrictEqual(value, expected)
+      assertDeepEqualWithResponseDiagnostics(
+        value,
+        expected,
+        `Expected shared prop ${formatExpectation(path, expected)}, received ${describeExpected(value)}.`,
+        actual
+      )
     },
 
     toHaveValidationError(path, expected) {
       const value = getPath(resolveStructuredValue(actual)?.props?.errors, path)
-      assert.notStrictEqual(value, undefined)
+      if (value === undefined) {
+        failWithResponseDiagnostics(`Expected validation error \`${path}\` to be present.`, actual)
+      }
 
       if (expected !== undefined) {
-        assert.deepStrictEqual(value, expected)
+        assertDeepEqualWithResponseDiagnostics(
+          value,
+          expected,
+          `Expected validation error ${formatExpectation(path, expected)}, received ${describeExpected(value)}.`,
+          actual
+        )
       }
     },
 

--- a/lib/create-request-client.js
+++ b/lib/create-request-client.js
@@ -140,6 +140,12 @@ function normalizeBodyValue(value) {
  *   redirected?: boolean,
  *   responseBody?: any,
  *   session?: AnyRecord,
+ *   request?: {
+ *     method: string,
+ *     target: string,
+ *     transport: SoundingTransport | 'socket',
+ *     url?: string,
+ *   },
  * }} input
  * @returns {SoundingResponse}
  */
@@ -152,6 +158,7 @@ function normalizeResponse({
   redirected = false,
   responseBody,
   session,
+  request,
 }) {
   const normalizedHeaders = new Headers(headers)
   const contentType = normalizedHeaders.get('content-type') || ''
@@ -172,6 +179,7 @@ function normalizeResponse({
     status,
     statusText,
     url,
+    request,
     redirected,
     session,
     headers: normalizedHeaders,
@@ -465,6 +473,7 @@ function createVirtualTransport({ sails }) {
       return new Promise((resolve, reject) => {
         const session = options.session || defaultSessionState()
         const sessionTracker = createVirtualSessionTracker({ sails, session })
+        const virtualUrl = normalizeVirtualUrl(method, target, normalizePayload(method, payload))
         /** @type {MockClientResponse & { body?: any, headers?: AnyRecord, statusCode?: number, statusMessage?: string }} */
         const clientRes = new MockClientResponse()
 
@@ -492,6 +501,12 @@ function createVirtualTransport({ sails }) {
                   redirected: status >= 300 && status < 400,
                   responseBody,
                   session: cloneSessionSnapshot(session),
+                  request: {
+                    method,
+                    target,
+                    transport: 'virtual',
+                    url: virtualUrl,
+                  },
                 })
               )
             } catch (error) {
@@ -509,7 +524,7 @@ function createVirtualTransport({ sails }) {
           sails.router.route(
             {
               method,
-              url: normalizeVirtualUrl(method, target, normalizePayload(method, payload)),
+              url: virtualUrl,
               _soundingRequestId: sessionTracker.requestId,
               body: ['GET', 'HEAD', 'DELETE'].includes(method)
                 ? undefined
@@ -614,14 +629,15 @@ function createHttpTransport({
       })
 
       const { body, headers: finalHeaders } = normalizeBodyAndHeaders(method, payload, headers)
+      const url = resolveUrl({
+        sails,
+        getConfig,
+        target,
+        baseUrl: options.baseUrl,
+      })
 
       const response = await fetchImplementation(
-        resolveUrl({
-          sails,
-          getConfig,
-          target,
-          baseUrl: options.baseUrl,
-        }),
+        url,
         {
           method,
           redirect: options.redirect || 'manual',
@@ -639,6 +655,12 @@ function createHttpTransport({
         url: response.url,
         redirected: response.redirected,
         responseBody: await response.text(),
+        request: {
+          method,
+          target,
+          transport: 'http',
+          url,
+        },
       })
     },
   }

--- a/lib/create-socket-manager.js
+++ b/lib/create-socket-manager.js
@@ -156,11 +156,12 @@ function normalizeEventPayload(args) {
 
 /**
  * @param {any} jwr
+ * @param {string} method
  * @param {string} target
  * @param {any} body
  * @returns {SoundingResponse}
  */
-function normalizeJwrResponse(jwr, target, body) {
+function normalizeJwrResponse(jwr, method, target, body) {
   const status = jwr?.statusCode === undefined ? 200 : jwr.statusCode
   const headers = jwr?.headers || {}
   const responseBody = jwr?.body === undefined ? body : jwr.body
@@ -173,6 +174,12 @@ function normalizeJwrResponse(jwr, target, body) {
     url: target,
     redirected: status >= 300 && status < 400,
     responseBody,
+    request: {
+      method: method.toUpperCase(),
+      target,
+      transport: 'socket',
+      url: target,
+    },
   })
 }
 
@@ -376,7 +383,7 @@ function wrapSocket(socket, { timeout, defaultHeaders = {} }) {
         socket.emit(method, requestOptions, (jwr) => {
           clearTimeout(timer)
           const body = jwr?.body
-          resolve(normalizeJwrResponse(jwr, target, body))
+          resolve(normalizeJwrResponse(jwr, method, target, body))
         })
       } catch (error) {
         clearTimeout(timer)

--- a/lib/create-world-engine.js
+++ b/lib/create-world-engine.js
@@ -109,6 +109,14 @@ function createThenableBuilder(executor, initialOverrides = {}) {
 }
 
 /**
+ * @param {string[]} values
+ * @returns {string}
+ */
+function formatAvailable(values) {
+  return values.length ? values.join(', ') : 'none'
+}
+
+/**
  * @param {{ sails?: SoundingSailsApp }} input
  * @returns {SoundingWorldEngine}
  */
@@ -131,11 +139,13 @@ function createWorldEngine({ sails }) {
     const entry = factories.get(name)
 
     if (!entry) {
+      const availableFactories = Array.from(factories.keys()).sort()
       throw createSoundingError({
         code: 'E_SOUNDING_WORLD_FACTORY_UNKNOWN',
-        message: `Unknown Sounding factory: ${name}`,
+        message: `Unknown Sounding factory: ${name}. Available factories: ${formatAvailable(availableFactories)}.`,
         details: {
           factory: name,
+          availableFactories,
         },
       })
     }
@@ -159,12 +169,14 @@ function createWorldEngine({ sails }) {
 
     for (const traitName of options.traits || []) {
       if (!entry.traits.has(traitName)) {
+        const availableTraits = Array.from(entry.traits.keys()).sort()
         throw createSoundingError({
           code: 'E_SOUNDING_WORLD_TRAIT_UNKNOWN',
-          message: `Unknown Sounding trait \`${traitName}\` for factory \`${name}\``,
+          message: `Unknown Sounding trait \`${traitName}\` for factory \`${name}\`. Available traits for \`${name}\`: ${formatAvailable(availableTraits)}.`,
           details: {
             factory: name,
             trait: traitName,
+            availableTraits,
           },
         })
       }
@@ -258,11 +270,13 @@ function createWorldEngine({ sails }) {
     const definition = scenarios.get(name)
 
     if (!definition) {
+      const availableScenarios = Array.from(scenarios.keys()).sort()
       throw createSoundingError({
         code: 'E_SOUNDING_WORLD_SCENARIO_UNKNOWN',
-        message: `Unknown Sounding scenario: ${name}`,
+        message: `Unknown Sounding scenario: ${name}. Available scenarios: ${formatAvailable(availableScenarios)}.`,
         details: {
           scenario: name,
+          availableScenarios,
         },
       })
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -42,6 +42,12 @@
  *   status: number,
  *   statusText: string,
  *   url?: string,
+ *   request?: {
+ *     method: string,
+ *     target: string,
+ *     transport: SoundingTransport | 'socket',
+ *     url?: string,
+ *   },
  *   redirected: boolean,
  *   session?: AnyRecord,
  *   headers: Headers,

--- a/test/browser-auth.test.js
+++ b/test/browser-auth.test.js
@@ -248,6 +248,49 @@ test('createAuthHelpers reports auth input errors with stable codes', async () =
   )
 })
 
+test('createAuthHelpers lists available world actors for unresolved aliases', async () => {
+  const auth = createAuthHelpers({
+    sails: {},
+    world: {
+      current: {
+        users: {
+          reader: {
+            id: 1,
+            email: 'reader@example.com',
+          },
+        },
+        creators: {
+          owner: {
+            id: 2,
+            email: 'owner@example.com',
+          },
+        },
+      },
+    },
+    mailbox: {
+      latest() {
+        return null
+      },
+    },
+    request: {
+      post: async () => ({ status: 302 }),
+    },
+  })
+
+  await assert.rejects(
+    async () => {
+      await auth.resolveActor('editor', { createIfMissing: false })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_AUTH_EMAIL_UNRESOLVED')
+      assert.equal(error.actor, 'editor')
+      assert.deepEqual(error.availableActors, ['owner', 'reader'])
+      assert.match(error.message, /Available actors: owner, reader/)
+      return true
+    }
+  )
+})
+
 test('createAuthHelpers can log in with password through the real browser form', async () => {
   const calls = []
   const page = {

--- a/test/request-client.test.js
+++ b/test/request-client.test.js
@@ -66,9 +66,104 @@ test('createRequestClient defaults to the Sails-native virtual transport', async
   assert.equal(calls[0].data, undefined)
   assert.deepEqual(calls[0].session.__soundingFlashStore, {})
   assert.equal(typeof calls[0].flash, 'function')
+  assert.deepEqual(response.request, {
+    method: 'GET',
+    target: '/health',
+    transport: 'virtual',
+    url: '/health',
+  })
   createExpect(response).toHaveStatus(200)
   createExpect(response).toHaveJsonPath('ok', true)
   assert.deepEqual(await response.json(), { ok: true })
+})
+
+test('request assertion failures include concise response diagnostics', () => {
+  const response = normalizeResponse({
+    raw: {},
+    status: 500,
+    statusText: 'Server Error',
+    headers: {
+      'content-type': 'application/json',
+      'x-request-id': 'req_123',
+    },
+    url: '/health',
+    responseBody: JSON.stringify({
+      message: 'Database unavailable',
+      detail: 'Connection pool exhausted',
+    }),
+    request: {
+      method: 'GET',
+      target: '/health',
+      transport: 'virtual',
+      url: '/health',
+    },
+  })
+
+  assert.throws(
+    () => {
+      createExpect(response).toHaveStatus(200)
+    },
+    (error) => {
+      assert.match(error.message, /Expected response status 200, received 500/)
+      assert.match(error.message, /Request: GET \/health \(virtual\)/)
+      assert.match(error.message, /Response: 500 Server Error/)
+      assert.match(error.message, /Headers: content-type: application\/json, x-request-id: req_123/)
+      assert.match(error.message, /Body: \{"message":"Database unavailable"/)
+      return true
+    }
+  )
+})
+
+test('request diagnostics expand response excerpts when verbose output is enabled', () => {
+  const originalDiagnostics = process.env.SOUNDING_DIAGNOSTICS
+  const longBody = `${'x'.repeat(520)}TAIL`
+  const response = normalizeResponse({
+    raw: {},
+    status: 500,
+    headers: {
+      'content-type': 'text/plain',
+    },
+    url: '/verbose',
+    responseBody: longBody,
+    request: {
+      method: 'GET',
+      target: '/verbose',
+      transport: 'virtual',
+      url: '/verbose',
+    },
+  })
+
+  try {
+    delete process.env.SOUNDING_DIAGNOSTICS
+    assert.throws(
+      () => {
+        createExpect(response).toHaveStatus(200)
+      },
+      (error) => {
+        assert.match(error.message, /Body: x{500}\.\.\./)
+        assert.doesNotMatch(error.message, /TAIL/)
+        return true
+      }
+    )
+
+    process.env.SOUNDING_DIAGNOSTICS = 'verbose'
+    assert.throws(
+      () => {
+        createExpect(response).toHaveStatus(200)
+      },
+      (error) => {
+        assert.match(error.message, /TAIL/)
+        assert.doesNotMatch(error.message, /Body: x{500}\.\.\./)
+        return true
+      }
+    )
+  } finally {
+    if (originalDiagnostics === undefined) {
+      delete process.env.SOUNDING_DIAGNOSTICS
+    } else {
+      process.env.SOUNDING_DIAGNOSTICS = originalDiagnostics
+    }
+  }
 })
 
 test('createRequestClient can attach an actor session for virtual policy checks', async () => {

--- a/test/socket-manager.test.js
+++ b/test/socket-manager.test.js
@@ -51,6 +51,12 @@ test('createSocketManager exercises Sails socket requests and room broadcasts', 
 
   const health = await member.get('/api/socket-health')
   assert.equal(health.status, 200)
+  assert.deepEqual(health.request, {
+    method: 'GET',
+    target: '/api/socket-health',
+    transport: 'socket',
+    url: '/api/socket-health',
+  })
   assert.equal(health.data.ok, true)
   assert.equal(health.data.isSocket, true)
   assert.equal(health.data.socketId, member.id)

--- a/test/world-loader.test.js
+++ b/test/world-loader.test.js
@@ -49,6 +49,10 @@ test('loadWorldFiles discovers factory and scenario definitions from tests/', as
 
 test('createWorldEngine reports unknown world entries with stable codes', async () => {
   const world = createWorldEngine({ sails: {} })
+  world.defineFactory('account', {
+    name: 'Acme',
+  })
+  world.defineScenario('signed-in-user', async () => ({}))
 
   assert.throws(
     () => {
@@ -57,12 +61,16 @@ test('createWorldEngine reports unknown world entries with stable codes', async 
     (error) => {
       assert.equal(error.code, 'E_SOUNDING_WORLD_FACTORY_UNKNOWN')
       assert.equal(error.factory, 'user')
+      assert.deepEqual(error.availableFactories, ['account'])
+      assert.match(error.message, /Available factories: account/)
       return true
     }
   )
 
   world.defineFactory('user', {
     email: 'reader@example.com',
+  }).trait('verified', {
+    verified: true,
   })
 
   assert.throws(
@@ -73,6 +81,8 @@ test('createWorldEngine reports unknown world entries with stable codes', async 
       assert.equal(error.code, 'E_SOUNDING_WORLD_TRAIT_UNKNOWN')
       assert.equal(error.factory, 'user')
       assert.equal(error.trait, 'admin')
+      assert.deepEqual(error.availableTraits, ['verified'])
+      assert.match(error.message, /Available traits for `user`: verified/)
       return true
     }
   )
@@ -84,6 +94,8 @@ test('createWorldEngine reports unknown world entries with stable codes', async 
     (error) => {
       assert.equal(error.code, 'E_SOUNDING_WORLD_SCENARIO_UNKNOWN')
       assert.equal(error.scenario, 'missing-dashboard')
+      assert.deepEqual(error.availableScenarios, ['signed-in-user'])
+      assert.match(error.message, /Available scenarios: signed-in-user/)
       return true
     }
   )


### PR DESCRIPTION
## Summary
- add request metadata to virtual, HTTP, and socket responses
- append concise response diagnostics to failed response, Inertia, and validation assertions
- list available worlds, traits, scenarios, and actor aliases in resolution failures
- add verbose response excerpts through SOUNDING_DIAGNOSTICS=verbose

## Verification
- npm run typecheck
- npm test
- git diff --check

Closes #33