### PR TITLE
Resolve request actor aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The canonical Sails-native surface is:
 - `get('/api/issues')` or `sails.sounding.request.get('/api/issues')` inside endpoint-style trials
 - `await auth.login.withPassword('creator@example.com', page, { password: 'secret123' })` inside browser trials
 - `await auth.request.withPassword('creator@example.com', { password: 'secret123' })` inside request trials
+- `request.as('owner')` and `visit.as('owner')` can resolve actor aliases from the current world
 - request helpers default to Sails virtual requests powered by `sails.request()`
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
 - request assertions can check auth/session state with `expect(response).toHaveSession('userId', user.id)` and flash messages with `expect(response).toHaveFlash('info', /welcome/i)`

--- a/lib/create-request-client.js
+++ b/lib/create-request-client.js
@@ -4,11 +4,13 @@ const { resolveAuthConfig } = require('./resolve-auth-config')
 const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingActor} SoundingActor */
 /** @typedef {import('./types').SoundingRequestClient} SoundingRequestClient */
 /** @typedef {import('./types').SoundingRequestOptions} SoundingRequestOptions */
 /** @typedef {import('./types').SoundingResponse} SoundingResponse */
 /** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
 /** @typedef {import('./types').SoundingTransport} SoundingTransport */
+/** @typedef {import('./types').SoundingWorldEngine} SoundingWorldEngine */
 
 /**
  * @param {string} value
@@ -291,6 +293,156 @@ function normalizePayload(method, payload) {
   }
 
   return payload
+}
+
+/**
+ * @param {any} value
+ * @returns {string}
+ */
+function normalizeEmail(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+}
+
+/**
+ * @param {any} value
+ * @returns {value is string}
+ */
+function looksLikeEmail(value) {
+  return typeof value === 'string' && value.includes('@')
+}
+
+/**
+ * @param {string[]} values
+ * @returns {string}
+ */
+function formatAvailable(values) {
+  return values.length ? values.join(', ') : 'none'
+}
+
+/**
+ * @param {{ world?: SoundingWorldEngine, sails?: SoundingSailsApp, getConfig?: () => AnyRecord }} input
+ * @returns {string[]}
+ */
+function availableWorldActors({ world, sails, getConfig }) {
+  const auth = resolveAuthConfig({ sails, getConfig })
+  const aliases = new Set()
+
+  for (const collection of [auth.worldCollection, 'users', 'creators']) {
+    const entries = world?.current?.[collection]
+
+    if (entries && typeof entries === 'object' && !Array.isArray(entries)) {
+      for (const alias of Object.keys(entries)) {
+        aliases.add(alias)
+      }
+    }
+  }
+
+  return Array.from(aliases).sort()
+}
+
+/**
+ * @param {{ actor: string, world?: SoundingWorldEngine, sails?: SoundingSailsApp, getConfig?: () => AnyRecord }} input
+ * @returns {SoundingActor | null}
+ */
+function resolveWorldActor({ actor, world, sails, getConfig }) {
+  const auth = resolveAuthConfig({ sails, getConfig })
+
+  return (
+    world?.current?.[auth.worldCollection]?.[actor] ||
+    world?.current?.users?.[actor] ||
+    world?.current?.creators?.[actor] ||
+    world?.current?.[actor] ||
+    null
+  )
+}
+
+/**
+ * @param {{ actor: string, world?: SoundingWorldEngine, sails?: SoundingSailsApp, getConfig?: () => AnyRecord, email?: string, modelIdentity?: string }} input
+ * @returns {Error}
+ */
+function createRequestActorUnresolvedError({
+  actor,
+  world,
+  sails,
+  getConfig,
+  email,
+  modelIdentity,
+}) {
+  const availableActors = availableWorldActors({ world, sails, getConfig })
+  const availableMessage = `Available actors: ${formatAvailable(availableActors)}.`
+  const emailMessage = email ? ` Could not find ${modelIdentity || 'actor'} with email \`${email}\`.` : ''
+
+  return createSoundingError({
+    code: 'E_SOUNDING_REQUEST_ACTOR_UNRESOLVED',
+    message: `Sounding request.as() could not resolve actor \`${actor}\`. ${availableMessage}${emailMessage}`,
+    details: {
+      actor,
+      availableActors,
+      ...(email ? { email } : {}),
+      ...(modelIdentity ? { modelIdentity } : {}),
+    },
+  })
+}
+
+/**
+ * @param {{ actor: string, sails?: SoundingSailsApp, getConfig?: () => AnyRecord, world?: SoundingWorldEngine }} input
+ * @returns {Promise<SoundingActor>}
+ */
+async function resolveEmailActor({ actor, sails, getConfig, world }) {
+  const auth = resolveAuthConfig({ sails, getConfig })
+  const email = normalizeEmail(actor)
+
+  if (!auth.model?.findOne) {
+    throw createRequestActorUnresolvedError({
+      actor,
+      world,
+      sails,
+      getConfig,
+      email,
+      modelIdentity: auth.modelIdentity,
+    })
+  }
+
+  const resolvedActor = await auth.model.findOne({ email })
+
+  if (!resolvedActor) {
+    throw createRequestActorUnresolvedError({
+      actor,
+      world,
+      sails,
+      getConfig,
+      email,
+      modelIdentity: auth.modelIdentity,
+    })
+  }
+
+  return resolvedActor
+}
+
+/**
+ * @param {SoundingActor} actor
+ * @returns {HeadersInit | AnyRecord}
+ */
+function resolveActorHeaders(actor) {
+  return actor.headers || actor.sounding?.headers || {}
+}
+
+/**
+ * @param {SoundingActor} actor
+ * @param {AnyRecord} auth
+ * @returns {AnyRecord}
+ */
+function resolveActorSession(actor, auth) {
+  return (
+    actor.session ||
+    actor.sounding?.session || {
+      ...(actor.id ? { [auth.sessionKey]: actor.id } : {}),
+      ...(actor.team ? { teamId: actor.team } : {}),
+      ...(actor.teamId ? { teamId: actor.teamId } : {}),
+    }
+  )
 }
 
 /**
@@ -674,6 +826,8 @@ function createHttpTransport({
  *   defaultHeaders?: HeadersInit | AnyRecord,
  *   defaultSession?: AnyRecord,
  *   transportOverride?: SoundingTransport,
+ *   world?: SoundingWorldEngine,
+ *   defaultActor?: string,
  * }} [options]
  * @returns {SoundingRequestClient}
  */
@@ -684,14 +838,19 @@ function createRequestClient({
   defaultHeaders = {},
   defaultSession = {},
   transportOverride,
+  world,
+  defaultActor,
 } = {}) {
   let virtualTransport = null
   let httpTransport = null
+  let defaultActorContextPromise = null
 
   function resetDefaultSession() {
     for (const key of Reflect.ownKeys(defaultSession)) {
       Reflect.deleteProperty(defaultSession, key)
     }
+
+    defaultActorContextPromise = null
   }
 
   function getVirtualTransport() {
@@ -708,20 +867,80 @@ function createRequestClient({
     return httpTransport
   }
 
+  /**
+   * @returns {Promise<{ headers: HeadersInit | AnyRecord, session: AnyRecord } | null>}
+   */
+  async function getDefaultActorContext() {
+    if (!defaultActor) {
+      return null
+    }
+
+    defaultActorContextPromise ||= resolveEmailActor({
+      actor: defaultActor,
+      sails,
+      getConfig,
+      world,
+    }).then((actor) => {
+      const auth = resolveAuthConfig({ sails, getConfig })
+
+      return {
+        headers: resolveActorHeaders(actor),
+        session: {
+          ...defaultSession,
+          ...resolveActorSession(actor, auth),
+        },
+      }
+    })
+
+    return defaultActorContextPromise
+  }
+
+  /**
+   * @param {SoundingActor} actor
+   * @returns {SoundingRequestClient}
+   */
+  function withActor(actor) {
+    const auth = resolveAuthConfig({ sails, getConfig })
+
+    return createRequestClient({
+      sails,
+      getConfig,
+      fetchImplementation,
+      defaultHeaders: {
+        ...defaultHeaders,
+        ...resolveActorHeaders(actor),
+      },
+      defaultSession: {
+        ...defaultSession,
+        ...resolveActorSession(actor, auth),
+      },
+      transportOverride,
+      world,
+    })
+  }
+
   async function send(method, target, payloadOrOptions, maybeOptions) {
     const hasPayload = !['GET', 'HEAD'].includes(method)
     const payload = hasPayload ? payloadOrOptions : undefined
     const options = (hasPayload ? maybeOptions : payloadOrOptions) || {}
+    const defaultActorContext = await getDefaultActorContext()
+    const baseHeaders = defaultActorContext
+      ? {
+          ...defaultHeaders,
+          ...defaultActorContext.headers,
+        }
+      : defaultHeaders
+    const baseSession = defaultActorContext?.session || defaultSession
     const headers = {
-      ...defaultHeaders,
+      ...baseHeaders,
       ...(options.headers || {}),
     }
     const session = options.session
       ? {
-          ...defaultSession,
+          ...baseSession,
           ...options.session,
         }
-      : defaultSession
+      : baseSession
     const transport = resolveTransport({
       sails,
       getConfig,
@@ -803,6 +1022,8 @@ function createRequestClient({
         },
         defaultSession,
         transportOverride,
+        world,
+        defaultActor,
       })
     },
 
@@ -817,6 +1038,8 @@ function createRequestClient({
           ...session,
         },
         transportOverride,
+        world,
+        defaultActor,
       })
     },
 
@@ -828,6 +1051,8 @@ function createRequestClient({
         defaultHeaders,
         defaultSession,
         transportOverride: transport,
+        world,
+        defaultActor,
       })
     },
 
@@ -836,16 +1061,35 @@ function createRequestClient({
         return this
       }
 
-      const auth = resolveAuthConfig({ sails, getConfig })
-      const actorHeaders = actor.headers || actor.sounding?.headers || {}
-      const actorSession = actor.session ||
-        actor.sounding?.session || {
-          ...(actor.id ? { [auth.sessionKey]: actor.id } : {}),
-          ...(actor.team ? { teamId: actor.team } : {}),
-          ...(actor.teamId ? { teamId: actor.teamId } : {}),
+      if (typeof actor === 'string') {
+        if (looksLikeEmail(actor)) {
+          return createRequestClient({
+            sails,
+            getConfig,
+            fetchImplementation,
+            defaultHeaders,
+            defaultSession,
+            transportOverride,
+            world,
+            defaultActor: actor,
+          })
         }
 
-      return this.withHeaders(actorHeaders).withSession(actorSession)
+        const resolvedActor = resolveWorldActor({ actor, world, sails, getConfig })
+
+        if (!resolvedActor) {
+          throw createRequestActorUnresolvedError({
+            actor,
+            world,
+            sails,
+            getConfig,
+          })
+        }
+
+        return withActor(resolvedActor)
+      }
+
+      return withActor(actor)
     },
   }
 }

--- a/lib/create-runtime.js
+++ b/lib/create-runtime.js
@@ -117,6 +117,7 @@ function createRuntime(sails) {
   const request = createRequestClient({
     sails,
     getConfig: () => resolveConfig(sails),
+    world,
   })
   const visit = createVisitClient({ request })
   const sockets = createSocketManager({

--- a/lib/create-visit-client.js
+++ b/lib/create-visit-client.js
@@ -132,6 +132,7 @@ function createVisitClient({ request }) {
     client.delete(target, payload, buildRequestOptions(options))
   visit.del = visit.delete
   visit.using = (transport) => createVisitClient({ request: request.using(transport) })
+  visit.as = (actor) => createVisitClient({ request: request.as(actor) })
 
   Object.defineProperty(visit, 'transport', {
     enumerable: true,

--- a/lib/types.js
+++ b/lib/types.js
@@ -71,7 +71,7 @@
  *   withHeaders(headers?: HeadersInit | AnyRecord): SoundingRequestClient,
  *   withSession(session?: AnyRecord): SoundingRequestClient,
  *   using(transport: SoundingTransport): SoundingRequestClient,
- *   as(actor?: SoundingActor | null): SoundingRequestClient,
+ *   as(actor?: SoundingActor | string | null): SoundingRequestClient,
  * }} SoundingRequestClient
  *
  * @typedef {SoundingRequestOptions & {
@@ -94,6 +94,7 @@
  *   delete(target: string, payload?: any, options?: SoundingVisitOptions): Promise<SoundingResponse>;
  *   del(target: string, payload?: any, options?: SoundingVisitOptions): Promise<SoundingResponse>;
  *   using(transport: SoundingTransport): SoundingVisitClient;
+ *   as(actor?: SoundingActor | string | null): SoundingVisitClient;
  * }} SoundingVisitClient
  *
  * @typedef {{

--- a/test/fixture-app.integration.test.js
+++ b/test/fixture-app.integration.test.js
@@ -91,6 +91,10 @@ test('createAppManager exercises a real Sails fixture app through the Sounding r
   assert.equal(actorResponse.status, 200)
   assert.equal(actorResponse.data.email, world.users.member.email)
 
+  const aliasResponse = await booted.request.as('member').get('/me')
+  assert.equal(aliasResponse.status, 200)
+  assert.equal(aliasResponse.data.email, world.users.member.email)
+
   const helperResult = await booted.helpers.sendWelcomeEmail({
     email: 'ada@example.com',
   })

--- a/test/request-client.test.js
+++ b/test/request-client.test.js
@@ -192,6 +192,164 @@ test('createRequestClient can attach an actor session for virtual policy checks'
   assert.deepEqual(calls[0].session.__soundingFlashStore, {})
 })
 
+test('createRequestClient.as resolves User world actor aliases', async () => {
+  const calls = []
+  const sails = {
+    router: {
+      route(req, res) {
+        calls.push(req)
+        res._clientRes.statusCode = 200
+        res._clientRes.headers = {
+          'content-type': 'application/json',
+        }
+        res._clientRes.end(JSON.stringify({ userId: req.session.userId }))
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+  const world = {
+    current: {
+      users: {
+        owner: {
+          id: 24,
+          email: 'owner@example.com',
+        },
+      },
+    },
+  }
+
+  const request = createRequestClient({ sails, world })
+  const response = await request.as('owner').get('/dashboard')
+
+  assert.equal(calls[0].session.userId, 24)
+  createExpect(response).toHaveJsonPath('userId', 24)
+})
+
+test('createRequestClient.as resolves Creator world actor aliases', async () => {
+  const calls = []
+  const sails = {
+    models: {
+      creator: {},
+    },
+    router: {
+      route(req, res) {
+        calls.push(req)
+        res._clientRes.statusCode = 200
+        res._clientRes.headers = {
+          'content-type': 'application/json',
+        }
+        res._clientRes.end(JSON.stringify({ creatorId: req.session.creatorId }))
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+  const world = {
+    current: {
+      creators: {
+        owner: {
+          id: 9,
+          email: 'creator@example.com',
+        },
+      },
+    },
+  }
+
+  const request = createRequestClient({ sails, world })
+  const response = await request.as('owner').get('/invoices')
+
+  assert.equal(calls[0].session.creatorId, 9)
+  assert.equal(calls[0].session.userId, undefined)
+  createExpect(response).toHaveJsonPath('creatorId', 9)
+})
+
+test('createRequestClient.as resolves email strings through the auth model', async () => {
+  const calls = []
+  const sails = {
+    models: {
+      user: {
+        async findOne(criteria) {
+          if (criteria.email === 'reader@example.com') {
+            return {
+              id: 7,
+              email: 'reader@example.com',
+            }
+          }
+
+          return null
+        },
+      },
+    },
+    router: {
+      route(req, res) {
+        calls.push(req)
+        res._clientRes.statusCode = 200
+        res._clientRes.headers = {
+          'content-type': 'application/json',
+        }
+        res._clientRes.end(JSON.stringify({ userId: req.session.userId }))
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+
+  const request = createRequestClient({ sails })
+  const response = await request.as('reader@example.com').get('/me')
+
+  assert.equal(calls[0].session.userId, 7)
+  createExpect(response).toHaveJsonPath('userId', 7)
+})
+
+test('createRequestClient.as reports unresolved aliases with available world actors', async () => {
+  const sails = {
+    router: {
+      route(_req, res) {
+        res._clientRes.statusCode = 200
+        res._clientRes.end('')
+      },
+    },
+    config: {
+      sounding: {},
+    },
+  }
+  const world = {
+    current: {
+      users: {
+        reader: {
+          id: 7,
+          email: 'reader@example.com',
+        },
+      },
+      creators: {
+        owner: {
+          id: 9,
+          email: 'owner@example.com',
+        },
+      },
+    },
+  }
+
+  const request = createRequestClient({ sails, world })
+
+  await assert.rejects(
+    async () => {
+      await request.as('editor').get('/dashboard')
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_REQUEST_ACTOR_UNRESOLVED')
+      assert.equal(error.actor, 'editor')
+      assert.deepEqual(error.availableActors, ['owner', 'reader'])
+      assert.match(error.message, /Available actors: owner, reader/)
+      return true
+    }
+  )
+})
+
 test('createRequestClient exposes final virtual session snapshots on responses', async () => {
   const sails = {
     router: {

--- a/test/visit-client.test.js
+++ b/test/visit-client.test.js
@@ -117,6 +117,50 @@ test('createVisitClient exposes post and transport scoping', async () => {
   assert.deepEqual(calls[3], ['withHeaders:scoped', DEFAULT_HEADERS])
 })
 
+test('createVisitClient can scope visits to actor aliases', async () => {
+  const calls = []
+  const request = {
+    transport: 'virtual',
+    as(actor) {
+      calls.push(['as', actor])
+      return this
+    },
+    withHeaders(headers) {
+      calls.push(['withHeaders', headers])
+      return {
+        transport: 'virtual',
+        get: async (target, options = {}) => {
+          calls.push(['get', target, options])
+          return {
+            status: 200,
+            data: {
+              component: 'dashboard/index',
+              props: {},
+            },
+            header: () => null,
+          }
+        },
+        head: async () => null,
+        post: async () => null,
+        put: async () => null,
+        patch: async () => null,
+        delete: async () => null,
+      }
+    },
+  }
+
+  const visit = createVisitClient({ request })
+  const page = await visit.as('owner')('/dashboard')
+
+  createExpect(page).toBeInertiaPage('dashboard/index')
+  assert.deepEqual(calls, [
+    ['withHeaders', DEFAULT_HEADERS],
+    ['as', 'owner'],
+    ['withHeaders', DEFAULT_HEADERS],
+    ['get', '/dashboard', {}],
+  ])
+})
+
 
 test('createVisitClient can express partial reload headers cleanly', async () => {
   const calls = []


### PR DESCRIPTION
Closes #28

## Summary
- let request.as() resolve actor aliases from the current world
- let request.as() resolve email strings through the configured auth model
- add visit.as() so Inertia contract trials can reuse the same actor ergonomics
- document the public surface in the README and cover unresolved actor diagnostics

## Validation
- npm run typecheck
- npm test