### PR TITLE
Auto-load trial worlds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The canonical Sails-native surface is:
 - `get('/api/issues')` or `sails.sounding.request.get('/api/issues')` inside endpoint-style trials
 - `await auth.login.withPassword('creator@example.com', page, { password: 'secret123' })` inside browser trials
 - `await auth.request.withPassword('creator@example.com', { password: 'secret123' })` inside request trials
+- `test('...', { world: 'signed-in-user' }, async ({ request }) => {})` can auto-load named worlds before the handler runs
 - `request.as('owner')` and `visit.as('owner')` can resolve actor aliases from the current world
 - request helpers default to Sails virtual requests powered by `sails.request()`
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
@@ -29,7 +30,7 @@ The canonical Sails-native surface is:
 Sounding also owns its own built-in world engine, so the same package can:
 - define factories under `tests/factories`
 - define scenarios under `tests/scenarios`
-- load named worlds for endpoint and browser trials
+- auto-load named worlds for endpoint, Inertia, socket, and browser trials
 - capture outgoing mail by wrapping `sails.helpers.mail.send` and storing normalized messages in `sails.sounding.mailbox`
 
 The default configuration story is intentionally calm:

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -75,6 +75,60 @@ function bindRequestMethod(request, method) {
 }
 
 /**
+ * @param {SoundingTestOptions['world']} worldOption
+ * @returns {{ name: string, context: Record<string, any> } | null}
+ */
+function normalizeWorldOption(worldOption) {
+  if (worldOption === undefined) {
+    return null
+  }
+
+  if (typeof worldOption === 'string') {
+    return {
+      name: worldOption.trim(),
+      context: {},
+    }
+  }
+
+  return {
+    name: worldOption.name.trim(),
+    context: worldOption.context || {},
+  }
+}
+
+/**
+ * @param {unknown} error
+ * @param {{ world?: { name: string, context: Record<string, any> } }} metadata
+ * @returns {unknown}
+ */
+function decorateTrialError(error, metadata) {
+  if (!metadata.world || !error || typeof error !== 'object') {
+    return error
+  }
+
+  const target = /** @type {Record<string, any>} */ (error)
+  const existingSounding =
+    target.sounding && typeof target.sounding === 'object' ? target.sounding : {}
+  const existingDetails =
+    target.details && typeof target.details === 'object' ? target.details : null
+
+  target.sounding = {
+    ...existingSounding,
+    world: metadata.world,
+  }
+
+  if (existingDetails) {
+    target.details = {
+      ...existingDetails,
+      world: metadata.world.name,
+      worldContext: metadata.world.context,
+    }
+  }
+
+  return error
+}
+
+/**
  * @template T
  * @param {() => Promise<T>} handler
  * @returns {Promise<T>}
@@ -121,77 +175,87 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
   const sounding = resolved.sounding
   const booted = await sounding.boot({ mode })
   const sails = booted.sails || {}
-
-  sails.sounding ||= sounding
-  sails.hooks ||= {}
-  sails.hooks.sounding ||= sounding
-  sails.helpers ||= sounding.helpers
-
-  const request = options.transport ? sounding.request.using(options.transport) : sounding.request
-  const visit = options.transport ? sounding.visit.using(options.transport) : sounding.visit
-  const socketOptions =
-    options.socket && typeof options.socket === 'object' ? options.socket : {}
-  const sockets =
-    options.socket && typeof options.socket === 'object'
-      ? {
-          connect(connectOptions = {}) {
-            return sounding.sockets.connect({
-              ...socketOptions,
-              ...connectOptions,
-            })
-          },
-          as(actor) {
-            return {
-              connect(connectOptions = {}) {
-                return sounding.sockets.as(actor).connect({
-                  ...socketOptions,
-                  ...connectOptions,
-                })
-              },
-            }
-          },
-          closeAll() {
-            return sounding.sockets.closeAll()
-          },
-        }
-      : sounding.sockets
-
-  let browserSession = null
-  if (options.browser) {
-    browserSession = await sounding.browser.open(options.browser === true ? {} : options.browser)
-  }
-
-  /** @type {SoundingExpect} */
-  const expect = browserSession?.expect
-    ? createExpect.withFallback(browserSession.expect)
-    : /** @type {SoundingExpect} */ (createExpect)
-
-  /** @type {SoundingTrialContext} */
-  const context = {
-    ...nodeContext,
-    t: nodeContext,
-    expect,
-    sails,
-    request,
-    visit,
-    sockets,
-    auth: sounding.auth,
-    login: sounding.auth?.login,
-    world: sounding.world,
-    mailbox: sounding.mailbox,
-    browser: browserSession?.browser,
-    browserContext: browserSession?.context,
-    page: browserSession?.page,
-    get: /** @type {any} */ (bindRequestMethod(request, 'get')),
-    head: /** @type {any} */ (bindRequestMethod(request, 'head')),
-    post: /** @type {any} */ (bindRequestMethod(request, 'post')),
-    put: /** @type {any} */ (bindRequestMethod(request, 'put')),
-    patch: /** @type {any} */ (bindRequestMethod(request, 'patch')),
-    del: /** @type {any} */ (bindRequestMethod(request, 'delete')),
+  const worldOption = normalizeWorldOption(options.world)
+  const trialMetadata = {
+    ...(worldOption ? { world: worldOption } : {}),
   }
 
   try {
+    if (worldOption) {
+      await sounding.world.use(worldOption.name, worldOption.context)
+    }
+
+    sails.sounding ||= sounding
+    sails.hooks ||= {}
+    sails.hooks.sounding ||= sounding
+    sails.helpers ||= sounding.helpers
+
+    const request = options.transport ? sounding.request.using(options.transport) : sounding.request
+    const visit = options.transport ? sounding.visit.using(options.transport) : sounding.visit
+    const socketOptions =
+      options.socket && typeof options.socket === 'object' ? options.socket : {}
+    const sockets =
+      options.socket && typeof options.socket === 'object'
+        ? {
+            connect(connectOptions = {}) {
+              return sounding.sockets.connect({
+                ...socketOptions,
+                ...connectOptions,
+              })
+            },
+            as(actor) {
+              return {
+                connect(connectOptions = {}) {
+                  return sounding.sockets.as(actor).connect({
+                    ...socketOptions,
+                    ...connectOptions,
+                  })
+                },
+              }
+            },
+            closeAll() {
+              return sounding.sockets.closeAll()
+            },
+          }
+        : sounding.sockets
+
+    let browserSession = null
+    if (options.browser) {
+      browserSession = await sounding.browser.open(options.browser === true ? {} : options.browser)
+    }
+
+    /** @type {SoundingExpect} */
+    const expect = browserSession?.expect
+      ? createExpect.withFallback(browserSession.expect)
+      : /** @type {SoundingExpect} */ (createExpect)
+
+    /** @type {SoundingTrialContext} */
+    const context = {
+      ...nodeContext,
+      t: nodeContext,
+      expect,
+      sails,
+      request,
+      visit,
+      sockets,
+      auth: sounding.auth,
+      login: sounding.auth?.login,
+      world: sounding.world,
+      mailbox: sounding.mailbox,
+      browser: browserSession?.browser,
+      browserContext: browserSession?.context,
+      page: browserSession?.page,
+      get: /** @type {any} */ (bindRequestMethod(request, 'get')),
+      head: /** @type {any} */ (bindRequestMethod(request, 'head')),
+      post: /** @type {any} */ (bindRequestMethod(request, 'post')),
+      put: /** @type {any} */ (bindRequestMethod(request, 'put')),
+      patch: /** @type {any} */ (bindRequestMethod(request, 'patch')),
+      del: /** @type {any} */ (bindRequestMethod(request, 'delete')),
+    }
+
     return await handler(context)
+  } catch (error) {
+    throw decorateTrialError(error, trialMetadata)
   } finally {
     await resolved.teardown()
   }

--- a/lib/types.js
+++ b/lib/types.js
@@ -520,10 +520,16 @@
  *   resolveConfig(): SoundingConfig,
  * }} SoundingAppManager
  *
+ * @typedef {string | {
+ *   name: string,
+ *   context?: AnyRecord,
+ * }} SoundingTrialWorldOption
+ *
  * @typedef {SoundingRequestOptions & {
  *   transport?: SoundingTransport,
  *   browser?: boolean | SoundingBrowserOpenOptions,
  *   socket?: boolean | SoundingSocketConnectOptions,
+ *   world?: SoundingTrialWorldOption,
  * }} SoundingTestOptions
  *
  * @typedef {AnyRecord & {

--- a/lib/validate-test-args.js
+++ b/lib/validate-test-args.js
@@ -216,6 +216,64 @@ function assertSocketOptions(options, apiName) {
  * @param {any} options
  * @param {string} apiName
  */
+function assertWorldOptions(options, apiName) {
+  if (options.world === undefined) {
+    return
+  }
+
+  if (typeof options.world === 'string') {
+    if (options.world.trim()) {
+      return
+    }
+
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`world\` must name a world scenario.`,
+      apiName,
+      value: options.world,
+      path: 'options.world',
+      suggestion: 'Use `world: "signed-in-user"` to auto-load a named scenario.',
+    })
+  }
+
+  if (!isPlainObject(options.world)) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`world\` must be a scenario name or world options object.`,
+      apiName,
+      value: options.world,
+      path: 'options.world',
+      suggestion: 'Use `world: "signed-in-user"` or `world: { name: "signed-in-user" }`.',
+    })
+  }
+
+  if (typeof options.world.name !== 'string' || !options.world.name.trim()) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`world.name\` must be a non-empty scenario name.`,
+      apiName,
+      value: options.world.name,
+      path: 'options.world.name',
+      suggestion: 'Use `world: { name: "signed-in-user" }`.',
+    })
+  }
+
+  if (options.world.context !== undefined && !isPlainObject(options.world.context)) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`world.context\` must be an object when provided.`,
+      apiName,
+      value: options.world.context,
+      path: 'options.world.context',
+      suggestion: 'Use `world: { name: "signed-in-user", context: { ... } }`.',
+    })
+  }
+}
+
+/**
+ * @param {any} options
+ * @param {string} apiName
+ */
 function assertTrialOptions(options, apiName) {
   if (!isPlainObject(options)) {
     throw createTestArgumentError({
@@ -241,6 +299,7 @@ function assertTrialOptions(options, apiName) {
 
   assertBrowserOptions(options, apiName)
   assertSocketOptions(options, apiName)
+  assertWorldOptions(options, apiName)
 }
 
 /**
@@ -282,7 +341,7 @@ function normalizeTestArgs(title, optionsOrHandler, maybeHandler, apiName = 'tes
 function splitTestOptions(options = {}, apiName = 'test') {
   assertTrialOptions(options, apiName)
 
-  const { transport, browser, socket, ...nodeOptions } = options
+  const { transport, browser, socket, world, ...nodeOptions } = options
 
   return {
     nodeOptions: {
@@ -293,6 +352,7 @@ function splitTestOptions(options = {}, apiName = 'test') {
       transport,
       browser,
       socket,
+      world,
     },
   }
 }

--- a/skills/sounding/SKILL.md
+++ b/skills/sounding/SKILL.md
@@ -25,14 +25,16 @@ Typical triggers:
 - Prefer Sounding's public surface:
   - `const { test } = require('sounding')`
   - `test('...', async ({ sails, get, visit, auth, login, page, expect }) => {})`
+  - `test('...', { world: 'signed-in-user' }, async ({ request, world }) => {})`
   - `request.as(actor)`
+  - `request.as('owner')` or `visit.as('owner')` after a world has loaded actor aliases
   - `auth.request.withPassword(...)`
   - `login.withPassword(...)`
   - `login.as(...)`
 - Treat hook activation as explicit and test-first. By default, Sounding only enables its Sails hook in the environments listed under `sounding.environments`, which starts as `['test']`.
 - Use the app's real auth flow when auth behavior matters. If `/login` or `/magic-link` is the behavior, do not replace it with fake session plumbing.
 - Use `request` for JSON and endpoint behavior, `visit()` for Inertia contracts, and browser trials only when the DOM or navigation is the behavior under test.
-- Treat worlds and actors as product language, not just setup helpers.
+- Treat worlds and actors as product language, not just setup helpers. Prefer `{ world: 'scenario-name' }` when a trial has one obvious setup scenario, and use manual `await world.use()` only when the trial needs dynamic setup or multiple worlds.
 
 ## Read next
 

--- a/test/fixture-app.integration.test.js
+++ b/test/fixture-app.integration.test.js
@@ -4,6 +4,7 @@ const net = require('node:net')
 const path = require('node:path')
 
 const { createAppManager } = require('../lib/create-app-manager')
+const { createTestApi } = require('../lib/create-test-api')
 
 const fixtureAppPath = path.join(__dirname, 'fixtures', 'sails-app')
 
@@ -131,4 +132,41 @@ test('createAppManager can lift the real fixture app for HTTP request trials', a
   assert.equal(health.session, undefined)
 
   await runtime.lower()
+})
+
+test('test() auto-loads fixture worlds before request trials', async (t) => {
+  const manager = createAppManager({
+    appPath: fixtureAppPath,
+  })
+  const registrations = []
+
+  t.after(async () => {
+    await manager.lower()
+  })
+
+  const runtime = await manager.runtime()
+  const soundingTest = createTestApi({
+    runtime,
+    baseTest(title, options, handler) {
+      registrations.push({ title, options, handler })
+      return { title }
+    },
+  })
+
+  soundingTest(
+    'member can inspect the current profile',
+    { world: 'signed-in-user' },
+    async ({ request, world, expect }) => {
+      const response = await request.as('member').get('/me')
+
+      expect(response).toHaveStatus(200)
+      expect(response).toHaveJsonPath('email', world.current.users.member.email)
+    }
+  )
+
+  assert.deepEqual(registrations[0].options, {
+    concurrency: false,
+  })
+
+  await registrations[0].handler({})
 })

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -213,6 +213,101 @@ test('test() can override transport for the whole trial', async () => {
   ])
 })
 
+test('test() can auto-load a world before the trial handler', async () => {
+  const calls = []
+  const baseRegistrations = []
+  const currentWorld = {
+    users: {
+      subscriber: {
+        id: 42,
+        email: 'subscriber@example.com',
+      },
+    },
+  }
+  const runtime = {
+    helpers: {},
+    world: {
+      current: null,
+      async use(name, context) {
+        calls.push(['world:use', name, context])
+        this.current = currentWorld
+        return currentWorld
+      },
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+      as(actor) {
+        calls.push(['request:as', actor])
+        return {
+          async get(target) {
+            calls.push(['request:get', target])
+            return {
+              status: 200,
+              data: {
+                actor,
+              },
+              header: () => null,
+            }
+          },
+        }
+      },
+    },
+    visit: {
+      transport: 'virtual',
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest(
+    'subscriber can read the issue',
+    { world: { name: 'issue-access', context: { issue: 'first' } }, timeout: 500 },
+    async ({ request, world, expect }) => {
+      assert.equal(world.current, currentWorld)
+
+      const response = await request.as('subscriber').get('/issues/first')
+
+      expect(response).toHaveStatus(200)
+      expect(response).toHaveJsonPath('actor', 'subscriber')
+    }
+  )
+
+  assert.deepEqual(baseRegistrations[0].options, {
+    concurrency: false,
+    timeout: 500,
+  })
+
+  await baseRegistrations[0].handler({})
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['world:use', 'issue-access', { issue: 'first' }],
+    ['request:as', 'subscriber'],
+    ['request:get', '/issues/first'],
+    ['lower'],
+  ])
+})
+
 test('test() exposes socket helpers for socket-capable trials', async () => {
   const calls = []
   const baseRegistrations = []
@@ -296,7 +391,10 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
   const runtime = {
     helpers: {},
     world: {
-      use: async () => ({}),
+      async use(name, context) {
+        calls.push(['world:use', name, context])
+        return {}
+      },
     },
     mailbox: {
       latest: () => null,
@@ -367,7 +465,12 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
 
   soundingTest.only(
     'focused http browser trial',
-    { transport: 'http', browser: { project: 'desktop' }, timeout: 500 },
+    {
+      transport: 'http',
+      world: 'focused-dashboard',
+      browser: { project: 'desktop' },
+      timeout: 500,
+    },
     async ({ sails, get, request, visit, page, expect }) => {
       const response = await get('/health')
 
@@ -390,6 +493,7 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
   await onlyRegistrations[0].handler({})
   assert.deepEqual(calls, [
     ['boot', 'trial'],
+    ['world:use', 'focused-dashboard', {}],
     ['using', 'http'],
     ['visit:using', 'http'],
     ['browser:open', { project: 'desktop' }],
@@ -489,7 +593,114 @@ test('test() reports malformed trial arguments with stable codes', () => {
     }
   )
 
+  assert.throws(
+    () => {
+      soundingTest('bad world', { world: true }, async () => {})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.world')
+      assert.equal(error.value, true)
+      assert.match(error.suggestion, /world: "signed-in-user"/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest('bad world name', { world: { name: '' } }, async () => {})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.world.name')
+      assert.equal(error.value, '')
+      assert.match(error.message, /world.name/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest(
+        'bad world context',
+        { world: { name: 'signed-in-user', context: 'admin' } },
+        async () => {}
+      )
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.world.context')
+      assert.equal(error.value, 'admin')
+      assert.match(error.message, /world.context/)
+      return true
+    }
+  )
+
   assert.equal(baseRegistrations.length, 0)
+})
+
+test('test() annotates trial failures with auto-loaded world metadata', async () => {
+  const baseRegistrations = []
+  const runtime = {
+    helpers: {},
+    world: {
+      current: null,
+      async use(name) {
+        this.current = {
+          users: {
+            subscriber: {
+              id: 42,
+            },
+          },
+        }
+        return this.current
+      },
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: {
+      transport: 'virtual',
+    },
+    async boot() {
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {},
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('subscriber cannot read the issue', { world: 'issue-access' }, async () => {
+    throw new Error('expected failure')
+  })
+
+  await assert.rejects(
+    () => baseRegistrations[0].handler({}),
+    (error) => {
+      assert.equal(error.message, 'expected failure')
+      assert.deepEqual(error.sounding, {
+        world: {
+          name: 'issue-access',
+          context: {},
+        },
+      })
+      return true
+    }
+  )
 })
 
 test('test.only() reports malformed focused trial arguments with stable codes', () => {

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -73,3 +73,16 @@ test('trial callback context is typed from JSDoc', async ({ get, expect, request
   // @ts-expect-error Trial request clients only support virtual and http transports.
   request.using('ftp')
 })
+
+test(
+  'world-backed trial context is typed from JSDoc',
+  { world: { name: 'signed-in-user', context: { role: 'member' } } },
+  async ({ request, world, expect }) => {
+    const response = await request.as('member').get('/me')
+
+    expect(response).toHaveStatus(200)
+    expect(response).toHaveJsonPath('email', world.current.users.member.email)
+  }
+)
+
+test('world string options are typed from JSDoc', { world: 'signed-in-user' }, async () => {})


### PR DESCRIPTION
Closes #27

## Summary
- add a world trial option that auto-loads named scenarios before the handler runs
- support both world: scenario-name and world: { name, context }
- keep world out of Node test options, including test.only()
- annotate trial failures with error.sounding.world metadata
- update README, public JSDoc, type smoke coverage, and the Sounding skill guidance

## Validation
- node --test test/test-api.test.js
- node --test test/fixture-app.integration.test.js
- npm run typecheck
- npm test