### PR TITLE
Improve world builder ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Sounding also owns its own built-in world engine, so the same package can:
 - define factories under `tests/factories`
 - define scenarios under `tests/scenarios`
 - auto-load named worlds for endpoint, Inertia, socket, and browser trials
+- compose world records with fluent builders like `await create('user').trait('admin').with({ email })`
+- merge repeated builder `.with()` calls, with `.withOnly()` available when you want to use only the next overrides
 - capture outgoing mail by wrapping `sails.helpers.mail.send` and storing normalized messages in `sails.sounding.mailbox`
 
 The default configuration story is intentionally calm:

--- a/lib/create-world-engine.js
+++ b/lib/create-world-engine.js
@@ -19,7 +19,10 @@ const { createSoundingError } = require('./create-error')
  */
 function mergeValue(base, patch) {
   if (typeof patch === 'function') {
-    return patch(base)
+    return {
+      ...base,
+      ...(patch(base) || {}),
+    }
   }
 
   return {
@@ -84,6 +87,14 @@ function createThenableBuilder(executor, initialOverrides = {}) {
     },
 
     with(overrides = {}) {
+      state.overrides = {
+        ...state.overrides,
+        ...overrides,
+      }
+      return builder
+    },
+
+    withOnly(overrides = {}) {
       state.overrides = overrides
       return builder
     },
@@ -315,7 +326,14 @@ function createWorldEngine({ sails }) {
     },
 
     create(name, overrides = {}, options = {}) {
-      return createOne(name, overrides, options)
+      return createThenableBuilder(
+        (nextOverrides, nextOptions) =>
+          createOne(name, nextOverrides, {
+            ...options,
+            traits: [...(options.traits || []), ...(nextOptions.traits || [])],
+          }),
+        overrides
+      )
     },
 
     async createMany(name, count, overrides = {}, options = {}) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -269,6 +269,7 @@
  *   trait(name: string): SoundingBuilder,
  *   traits(names?: string[]): SoundingBuilder,
  *   with(overrides?: AnyRecord): SoundingBuilder,
+ *   withOnly(overrides?: AnyRecord): SoundingBuilder,
  *   value(): any,
  *   catch(onRejected?: ((reason: any) => any) | null): Promise<any>,
  *   finally(onFinally?: (() => void) | null): Promise<any>,
@@ -294,7 +295,7 @@
  * @typedef {{
  *   build(name: string, overrides?: AnyRecord, options?: { traits?: string[] }): AnyRecord,
  *   buildMany(name: string, count: number, overrides?: AnyRecord, options?: { traits?: string[] }): Promise<AnyRecord[]>,
- *   create(name: string, overrides?: AnyRecord, options?: { traits?: string[] }): Promise<AnyRecord>,
+ *   create(name: string, overrides?: AnyRecord, options?: { traits?: string[] }): SoundingBuilder,
  *   createMany(name: string, count: number, overrides?: AnyRecord, options?: { traits?: string[] }): Promise<AnyRecord[]>,
  *   defineFactory(name: string, definition: AnyRecord | ((helpers: SoundingFactoryHelpers) => AnyRecord)): SoundingFactoryRegistration,
  *   defineFactory(definition: SoundingFactoryDefinition): SoundingFactoryRegistration,

--- a/skills/sounding/SKILL.md
+++ b/skills/sounding/SKILL.md
@@ -31,10 +31,41 @@ Typical triggers:
   - `auth.request.withPassword(...)`
   - `login.withPassword(...)`
   - `login.as(...)`
+- Prefer fluent world builders when setup is record-shaped:
+  - inside scenarios: `await create('user').trait('admin').with({ email })`
+  - top-level persisted records: `await world.create('user').trait('admin').with({ email })`
+  - repeated `.with()` calls merge overrides; use `.withOnly()` only when you intentionally want to use only the next overrides
 - Treat hook activation as explicit and test-first. By default, Sounding only enables its Sails hook in the environments listed under `sounding.environments`, which starts as `['test']`.
 - Use the app's real auth flow when auth behavior matters. If `/login` or `/magic-link` is the behavior, do not replace it with fake session plumbing.
 - Use `request` for JSON and endpoint behavior, `visit()` for Inertia contracts, and browser trials only when the DOM or navigation is the behavior under test.
 - Treat worlds and actors as product language, not just setup helpers. Prefer `{ world: 'scenario-name' }` when a trial has one obvious setup scenario, and use manual `await world.use()` only when the trial needs dynamic setup or multiple worlds.
+- Function-based trait patches merge into the base record. Return only the fields the trait changes unless the trait genuinely needs to derive values from the base.
+- Prefer Sounding factories over repeated inline model creation. If more than one test file creates the same kind of record by hand, add or reuse a `tests/factories` factory.
+- Use `sequence()` in factories for deterministic unique emails, slugs, tokens, invoice numbers, and similar values. Do not keep reintroducing `Date.now()` plus random helpers in test bodies.
+- Use traits for meaningful variants such as `admin`, `subscriber`, `unverified`, or `published`. Use scenarios when the setup is a business situation, not just a record shape.
+- Remember the top-level shape: `world.create('user').trait('admin')` is fluent and persisted; `world.build('user', {}, { traits: ['admin'] })` returns an immediate preview object.
+
+## Factory Pattern
+
+When repeated setup appears, move the primitive record shape into a factory first:
+
+```js
+// tests/factories/creator.js
+module.exports = ({ defineFactory }) =>
+  defineFactory('creator', ({ sequence }) => ({
+    email: sequence('creator-email', (n) => `creator-${n}@example.com`),
+    fullName: 'Test Creator',
+    emailStatus: 'verified'
+  })).trait('unverified', {
+    emailStatus: 'unverified'
+  })
+```
+
+Then trials and scenarios should speak in product terms:
+
+```js
+const creator = await create('creator').trait('unverified')
+```
 
 ## Read next
 

--- a/test/world-loader.test.js
+++ b/test/world-loader.test.js
@@ -47,6 +47,115 @@ test('loadWorldFiles discovers factory and scenario definitions from tests/', as
   assert.match(current.users.subscriber.email, /^user\d+@example.com$/)
 })
 
+test('createWorldEngine builders merge overrides and keep withOnly available', async () => {
+  const world = createWorldEngine({ sails: {} })
+
+  world.defineFactory('user', ({ sequence }) => ({
+    email: sequence('user', (number) => `user${number}@example.com`),
+    fullName: 'Test User',
+    role: 'reader',
+  }))
+
+  world.defineScenario('team-access', async ({ create }) => {
+    const member = await create('user')
+      .with({ email: 'member@example.com' })
+      .with({ role: 'member' })
+
+    const replacement = await create('user')
+      .with({ email: 'ignored@example.com' })
+      .withOnly({ role: 'admin' })
+
+    return {
+      users: {
+        member,
+        replacement,
+      },
+    }
+  })
+
+  const current = await world.use('team-access')
+
+  assert.deepEqual(current.users.member, {
+    email: 'member@example.com',
+    fullName: 'Test User',
+    role: 'member',
+  })
+  assert.deepEqual(current.users.replacement, {
+    email: 'user2@example.com',
+    fullName: 'Test User',
+    role: 'admin',
+  })
+})
+
+test('createWorldEngine function traits merge into the base record', () => {
+  const world = createWorldEngine({ sails: {} })
+
+  world.defineFactory('user', {
+    email: 'reader@example.com',
+    fullName: 'Reader Example',
+    role: 'reader',
+  }).trait('verified', (user) => ({
+    emailVerificationCode: `${user.role}-verified`,
+    emailVerifiedAt: '2026-06-15T00:00:00.000Z',
+  }))
+
+  const user = world.build('user', {}, { traits: ['verified'] })
+
+  assert.deepEqual(user, {
+    email: 'reader@example.com',
+    fullName: 'Reader Example',
+    role: 'reader',
+    emailVerificationCode: 'reader-verified',
+    emailVerifiedAt: '2026-06-15T00:00:00.000Z',
+  })
+})
+
+test('createWorldEngine supports fluent traits on top-level create', async () => {
+  const created = []
+  const world = createWorldEngine({
+    sails: {
+      models: {
+        user: {
+          create(value) {
+            return {
+              fetch() {
+                const record = {
+                  id: created.length + 1,
+                  ...value,
+                }
+
+                created.push(record)
+                return record
+              },
+            }
+          },
+        },
+      },
+    },
+  })
+
+  world.defineFactory('user', {
+    email: 'reader@example.com',
+    fullName: 'Reader Example',
+    role: 'reader',
+  }).trait('admin', {
+    role: 'admin',
+  })
+
+  const admin = await world
+    .create('user')
+    .trait('admin')
+    .with({ email: 'admin@example.com' })
+
+  assert.deepEqual(admin, {
+    id: 1,
+    email: 'admin@example.com',
+    fullName: 'Reader Example',
+    role: 'admin',
+  })
+  assert.deepEqual(created, [admin])
+})
+
 test('createWorldEngine reports unknown world entries with stable codes', async () => {
   const world = createWorldEngine({ sails: {} })
   world.defineFactory('account', {

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -3,6 +3,7 @@
 const {
   createExpect,
   createRequestClient,
+  createWorldEngine,
   createSocketManager,
   createVisitClient,
   test,
@@ -37,6 +38,21 @@ visit('/dashboard', {
   component: 'dashboard/index',
   only: ['notifications'],
 })
+
+const worldEngine = createWorldEngine({ sails: { models: {} } })
+worldEngine.defineFactory('user', {
+  email: 'reader@example.com',
+  role: 'reader',
+}).trait('admin', {
+  role: 'admin',
+})
+
+worldEngine
+  .create('user')
+  .trait('admin')
+  .with({ email: 'admin@example.com' })
+  .withOnly({ fullName: 'Admin Example' })
+  .then((user) => user)
 
 const sockets = createSocketManager({
   sails: {


### PR DESCRIPTION
Closes #29

## Summary
- make builder .with() calls merge override objects
- add .withOnly() for the intentional only-these-overrides case
- merge function trait patches into the base record
- make top-level world.create() support the fluent trait/with builder shape while preserving await world.create(...)
- update README, JSDoc types, type smoke coverage, and the Sounding skill guidance

## Validation
- node --test test/world-loader.test.js
- npm run typecheck
- npm test