### PR TITLE
feat: capture browser failure artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The canonical Sails-native surface is:
 - `await auth.request.withPassword('creator@example.com', { password: 'secret123' })` inside request trials
 - `test('...', { world: 'signed-in-user' }, async ({ request }) => {})` can auto-load named worlds before the handler runs
 - `request.as('owner')` and `visit.as('owner')` can resolve actor aliases from the current world
+- failed browser trials capture the current URL and a full-page screenshot under `.tmp/sounding/artifacts`
 - request helpers default to Sails virtual requests powered by `sails.request()`
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
 - request assertions can check auth/session state with `expect(response).toHaveSession('userId', user.id)` and flash messages with `expect(response).toHaveFlash('info', /welcome/i)`
@@ -78,6 +79,7 @@ The default configuration story is intentionally calm:
 - managed SQLite artifacts live under `.tmp/db`
 - the default datastore identity is `default`
 - browser projects start with `desktop`
+- browser failure artifacts store screenshots and current URLs by default, while traces and videos are opt-in
 - mail capture previews use the `mail` layout by default, matching the current `sails-hook-mail` convention
 - apps with a different mail layout can set `sounding.mail.layout`, for example `layout-email`
 - `inherit` remains available when an app already has a serious test datastore story
@@ -91,6 +93,84 @@ module.exports.sounding = {
 ```
 
 If you intentionally want Sounding during another boot path, widen the list explicitly, for example `['test', 'console']` or `['test', 'production']`.
+
+## Browser failure artifacts
+
+Browser-capable trials should be easy to debug without turning every run into a heavyweight recording session.
+
+By default, a failed `{ browser: true }` trial writes:
+
+- `current-url.txt`
+- `screenshot.png`
+
+under a stable, readable directory:
+
+```txt
+.tmp/sounding/artifacts/<trial-name>/<browser-project>/
+```
+
+For a trial named `dashboard shows owner stats` on the default `desktop` project, that becomes:
+
+```txt
+.tmp/sounding/artifacts/dashboard-shows-owner-stats/desktop/
+```
+
+When a failure happens, Sounding appends the current URL and artifact paths to the thrown error so the terminal output points straight at the evidence.
+
+Traces and videos are intentionally off by default because they cost more disk and time. Turn them on for a whole app:
+
+```js
+module.exports.sounding = {
+  browser: {
+    artifacts: {
+      trace: true,
+      video: true
+    }
+  }
+}
+```
+
+Or scope them to one suspicious trial:
+
+```js
+test(
+  'checkout keeps the cart after refresh',
+  {
+    browser: {
+      artifacts: {
+        trace: true,
+        video: true
+      }
+    }
+  },
+  async ({ page, expect }) => {
+    await page.goto('/checkout')
+    await page.reload()
+
+    await expect(page.getByText('Your cart')).toBeVisible()
+  }
+)
+```
+
+Use `false` as a concise off switch:
+
+```js
+test('fast smoke flow', { browser: { artifacts: false } }, async ({ page }) => {
+  await page.goto('/health')
+})
+```
+
+For artifact settings, `true` means “keep this when the trial fails.” If you need an artifact on successful browser trials too, use `on` instead:
+
+```js
+module.exports.sounding = {
+  browser: {
+    artifacts: {
+      trace: 'on'
+    }
+  }
+}
+```
 
 This repository starts with docs-driven product research and the first hook/runtime scaffolding for that vision.
 

--- a/lib/create-browser-manager.js
+++ b/lib/create-browser-manager.js
@@ -1,12 +1,20 @@
+const fs = require('node:fs/promises')
+const path = require('node:path')
+
 const { resolveBaseUrl } = require('./create-request-client')
 const { createSoundingError } = require('./create-error')
 const { loadDependencyFromApp } = require('./resolve-dependency')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingBrowserArtifactMode} SoundingBrowserArtifactMode */
+/** @typedef {import('./types').SoundingBrowserArtifacts} SoundingBrowserArtifacts */
+/** @typedef {import('./types').SoundingBrowserResolvedArtifactsConfig} SoundingBrowserResolvedArtifactsConfig */
 /** @typedef {import('./types').SoundingBrowserManager} SoundingBrowserManager */
 /** @typedef {import('./types').SoundingBrowserOpenOptions} SoundingBrowserOpenOptions */
 /** @typedef {import('./types').SoundingBrowserSession} SoundingBrowserSession */
 /** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+const ARTIFACT_MODES = ['off', 'on', 'on-failure']
 
 /**
  * @param {string} appPath
@@ -59,6 +67,179 @@ function resolveProjectOptions(projectName, devices = {}) {
   }
 
   return {}
+}
+
+/**
+ * @param {any} value
+ * @param {SoundingBrowserArtifactMode} fallback
+ * @returns {SoundingBrowserArtifactMode}
+ */
+function normalizeArtifactMode(value, fallback) {
+  if (value === undefined) {
+    return fallback
+  }
+
+  if (value === true) {
+    return 'on-failure'
+  }
+
+  if (value === false || value === null) {
+    return 'off'
+  }
+
+  if (ARTIFACT_MODES.includes(value)) {
+    return value
+  }
+
+  return fallback
+}
+
+/**
+ * @param {SoundingBrowserArtifactMode} mode
+ * @returns {boolean}
+ */
+function recordsArtifact(mode) {
+  return mode === 'on' || mode === 'on-failure'
+}
+
+/**
+ * @param {SoundingBrowserArtifactMode} mode
+ * @returns {boolean}
+ */
+function capturesFailureArtifact(mode) {
+  return mode === 'on' || mode === 'on-failure'
+}
+
+/**
+ * @param {SoundingBrowserArtifactMode} mode
+ * @returns {boolean}
+ */
+function capturesSuccessArtifact(mode) {
+  return mode === 'on'
+}
+
+/**
+ * @param {any} value
+ * @returns {value is AnyRecord}
+ */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @param {AnyRecord | boolean | undefined} value
+ * @param {SoundingBrowserResolvedArtifactsConfig} fallback
+ * @returns {SoundingBrowserResolvedArtifactsConfig}
+ */
+function mergeArtifactsConfig(value, fallback) {
+  if (value === false) {
+    return {
+      ...fallback,
+      screenshot: 'off',
+      trace: 'off',
+      video: 'off',
+      currentUrl: false,
+    }
+  }
+
+  if (value === true || value === undefined || value === null) {
+    return fallback
+  }
+
+  if (!isPlainObject(value)) {
+    return fallback
+  }
+
+  return {
+    outputDir:
+      typeof value.outputDir === 'string' && value.outputDir.trim()
+        ? value.outputDir
+        : fallback.outputDir,
+    screenshot: normalizeArtifactMode(value.screenshot, fallback.screenshot),
+    trace: normalizeArtifactMode(value.trace, fallback.trace),
+    video: normalizeArtifactMode(value.video, fallback.video),
+    currentUrl:
+      typeof value.currentUrl === 'boolean' ? value.currentUrl : fallback.currentUrl,
+  }
+}
+
+/**
+ * @param {AnyRecord} config
+ * @param {SoundingBrowserOpenOptions} options
+ * @returns {SoundingBrowserResolvedArtifactsConfig}
+ */
+function resolveArtifactsConfig(config, options = {}) {
+  const defaults = /** @type {SoundingBrowserResolvedArtifactsConfig} */ ({
+    outputDir: '.tmp/sounding/artifacts',
+    screenshot: 'on-failure',
+    trace: 'off',
+    video: 'off',
+    currentUrl: true,
+  })
+  const globalArtifacts = mergeArtifactsConfig(config.browser?.artifacts, defaults)
+
+  return mergeArtifactsConfig(options.artifacts, globalArtifacts)
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function slugifyArtifactSegment(value) {
+  const slug = String(value || '')
+    .toLowerCase()
+    .replace(/['"`]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return slug || 'browser-trial'
+}
+
+/**
+ * @param {string} appPath
+ * @param {SoundingBrowserResolvedArtifactsConfig} artifacts
+ * @param {{ trialName?: string, projectName: string }} metadata
+ */
+function resolveArtifactPaths(appPath, artifacts, metadata) {
+  const outputRoot = path.isAbsolute(artifacts.outputDir)
+    ? artifacts.outputDir
+    : path.resolve(appPath, artifacts.outputDir)
+  const trialSlug = slugifyArtifactSegment(metadata.trialName || 'browser-trial')
+  const projectSlug = slugifyArtifactSegment(metadata.projectName || 'desktop')
+  const directory = path.join(outputRoot, trialSlug, projectSlug)
+
+  return {
+    outputRoot,
+    directory,
+    currentUrl: path.join(directory, 'current-url.txt'),
+    screenshot: path.join(directory, 'screenshot.png'),
+    trace: path.join(directory, 'trace.zip'),
+    video: path.join(directory, 'video.webm'),
+  }
+}
+
+/**
+ * @param {unknown} error
+ * @returns {string}
+ */
+function formatCaptureError(error) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+/**
+ * @param {SoundingBrowserArtifacts['errors']} errors
+ * @param {string} artifact
+ * @param {unknown} error
+ */
+function pushCaptureError(errors, artifact, error) {
+  errors.push({
+    artifact,
+    message: formatCaptureError(error),
+  })
 }
 
 /**
@@ -132,6 +313,21 @@ function createBrowserManager({
       config.browser?.projects?.[0] ||
       'desktop'
 
+    const artifacts = resolveArtifactsConfig(config, options)
+    const artifactPaths = resolveArtifactPaths(appPath, artifacts, {
+      trialName: options.trialName,
+      projectName,
+    })
+    const contextOptions = {
+      ...(options.contextOptions || {}),
+    }
+
+    if (recordsArtifact(artifacts.video) && contextOptions.recordVideo === undefined) {
+      contextOptions.recordVideo = {
+        dir: artifactPaths.directory,
+      }
+    }
+
     const browser = await browserType.launch({
       headless: true,
       ...(config.browser?.launchOptions || {}),
@@ -141,10 +337,174 @@ function createBrowserManager({
     const context = await browser.newContext({
       baseURL: resolveBaseUrl({ sails, getConfig }),
       ...resolveProjectOptions(projectName, playwright.devices || {}),
-      ...(options.contextOptions || {}),
+      ...contextOptions,
     })
 
     const page = await context.newPage()
+    let contextClosed = false
+    let traceStarted = false
+    let traceStopped = false
+    /** @type {SoundingBrowserArtifacts | null} */
+    let latestArtifacts = null
+
+    if (recordsArtifact(artifacts.trace) && context.tracing?.start) {
+      await context.tracing.start({
+        screenshots: true,
+        snapshots: true,
+        sources: true,
+      })
+      traceStarted = true
+    }
+
+    /**
+     * @param {SoundingBrowserArtifacts} collected
+     * @param {boolean} keepTrace
+     */
+    async function finalizeTrace(collected, keepTrace) {
+      if (!traceStarted || traceStopped || !context.tracing?.stop) {
+        return
+      }
+
+      try {
+        if (keepTrace) {
+          await fs.mkdir(artifactPaths.directory, { recursive: true })
+          await context.tracing.stop({ path: artifactPaths.trace })
+          collected.trace = artifactPaths.trace
+        } else {
+          await context.tracing.stop()
+        }
+
+        traceStopped = true
+      } catch (error) {
+        pushCaptureError(collected.errors, 'trace', error)
+      }
+    }
+
+    /**
+     * @param {SoundingBrowserArtifacts} collected
+     * @param {boolean} keepVideo
+     */
+    async function finalizeVideo(collected, keepVideo) {
+      const video = typeof page.video === 'function' ? page.video() : null
+
+      if (!video) {
+        return
+      }
+
+      try {
+        if (keepVideo) {
+          await fs.mkdir(artifactPaths.directory, { recursive: true })
+
+          if (typeof video.saveAs === 'function') {
+            await video.saveAs(artifactPaths.video)
+            collected.video = artifactPaths.video
+            return
+          }
+
+          if (typeof video.path === 'function') {
+            collected.video = await video.path()
+          }
+
+          return
+        }
+
+        if (typeof video.delete === 'function') {
+          await video.delete()
+          return
+        }
+
+        if (typeof video.path === 'function') {
+          const videoPath = await video.path()
+          await fs.rm(videoPath, { force: true }).catch(() => {})
+        }
+      } catch (error) {
+        pushCaptureError(collected.errors, 'video', error)
+      }
+    }
+
+    /**
+     * @param {{ failed: boolean, collected: SoundingBrowserArtifacts }} args
+     */
+    async function closeContext({ failed, collected }) {
+      if (contextClosed) {
+        return
+      }
+
+      await finalizeTrace(
+        collected,
+        failed ? capturesFailureArtifact(artifacts.trace) : capturesSuccessArtifact(artifacts.trace)
+      )
+      await context.close?.()
+      contextClosed = true
+      await finalizeVideo(
+        collected,
+        failed ? capturesFailureArtifact(artifacts.video) : capturesSuccessArtifact(artifacts.video)
+      )
+    }
+
+    /**
+     * @returns {SoundingBrowserArtifacts}
+     */
+    function createArtifactsMetadata() {
+      return {
+        outputDir: artifactPaths.outputRoot,
+        directory: artifactPaths.directory,
+        project: projectName,
+        trialName: options.trialName,
+        errors: [],
+      }
+    }
+
+    async function captureFailureArtifacts() {
+      const collected = createArtifactsMetadata()
+
+      if (artifacts.currentUrl && typeof page.url === 'function') {
+        try {
+          const currentUrl = page.url()
+          if (currentUrl) {
+            await fs.mkdir(artifactPaths.directory, { recursive: true })
+            await fs.writeFile(artifactPaths.currentUrl, `${currentUrl}\n`)
+            collected.currentUrl = currentUrl
+            collected.currentUrlPath = artifactPaths.currentUrl
+          }
+        } catch (error) {
+          pushCaptureError(collected.errors, 'currentUrl', error)
+        }
+      }
+
+      if (capturesFailureArtifact(artifacts.screenshot) && typeof page.screenshot === 'function') {
+        try {
+          await fs.mkdir(artifactPaths.directory, { recursive: true })
+          await page.screenshot({
+            path: artifactPaths.screenshot,
+            fullPage: true,
+          })
+          collected.screenshot = artifactPaths.screenshot
+        } catch (error) {
+          pushCaptureError(collected.errors, 'screenshot', error)
+        }
+      }
+
+      await finalizeTrace(collected, capturesFailureArtifact(artifacts.trace))
+
+      if (recordsArtifact(artifacts.video)) {
+        try {
+          await closeContext({ failed: true, collected })
+        } catch (error) {
+          pushCaptureError(collected.errors, 'video', error)
+        }
+      }
+
+      latestArtifacts = collected
+      return collected
+    }
+
+    async function closeSessionContext() {
+      const collected = latestArtifacts || createArtifactsMetadata()
+      await closeContext({ failed: false, collected })
+      latestArtifacts = collected
+      return collected
+    }
 
     session = {
       playwright,
@@ -153,6 +513,12 @@ function createBrowserManager({
       page,
       expect: playwrightTest?.expect,
       project: projectName,
+      artifacts,
+      captureFailureArtifacts,
+      closeSessionContext,
+      get latestArtifacts() {
+        return latestArtifacts
+      },
     }
 
     return session
@@ -163,7 +529,7 @@ function createBrowserManager({
       return
     }
 
-    await session.context?.close?.()
+    await session.closeSessionContext?.()
     await session.browser?.close?.()
     session = null
   }
@@ -191,4 +557,6 @@ module.exports = {
   defaultLoadPlaywright,
   defaultLoadPlaywrightTest,
   resolveProjectOptions,
+  resolveArtifactsConfig,
+  slugifyArtifactSegment,
 }

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -5,6 +5,8 @@ const { normalizeTestArgs, splitTestOptions } = require('./validate-test-args')
 
 /** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
 /** @typedef {import('./types').SoundingExpect} SoundingExpect */
+/** @typedef {import('./types').SoundingBrowserArtifacts} SoundingBrowserArtifacts */
+/** @typedef {import('./types').SoundingBrowserSession} SoundingBrowserSession */
 /** @typedef {import('./types').SoundingTest} SoundingTest */
 /** @typedef {import('./types').SoundingTestOptions} SoundingTestOptions */
 /** @typedef {import('./types').SoundingTrialContext} SoundingTrialContext */
@@ -98,11 +100,103 @@ function normalizeWorldOption(worldOption) {
 
 /**
  * @param {unknown} error
- * @param {{ world?: { name: string, context: Record<string, any> } }} metadata
+ * @returns {string}
+ */
+function formatUnknownError(error) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+/**
+ * @param {SoundingBrowserArtifacts | null | undefined} artifacts
+ * @returns {boolean}
+ */
+function hasBrowserArtifacts(artifacts) {
+  return Boolean(
+    artifacts &&
+      (artifacts.currentUrl ||
+        artifacts.currentUrlPath ||
+        artifacts.screenshot ||
+        artifacts.trace ||
+        artifacts.video ||
+        artifacts.errors?.length)
+  )
+}
+
+/**
+ * @param {SoundingBrowserArtifacts} artifacts
+ * @returns {string}
+ */
+function formatBrowserArtifacts(artifacts) {
+  const lines = ['Sounding browser artifacts:']
+
+  if (artifacts.currentUrl) {
+    lines.push(`- URL: ${artifacts.currentUrl}`)
+  }
+
+  if (artifacts.currentUrlPath) {
+    lines.push(`- current URL file: ${artifacts.currentUrlPath}`)
+  }
+
+  if (artifacts.screenshot) {
+    lines.push(`- screenshot: ${artifacts.screenshot}`)
+  }
+
+  if (artifacts.trace) {
+    lines.push(`- trace: ${artifacts.trace}`)
+  }
+
+  if (artifacts.video) {
+    lines.push(`- video: ${artifacts.video}`)
+  }
+
+  for (const captureError of artifacts.errors || []) {
+    lines.push(`- ${captureError.artifact} capture failed: ${captureError.message}`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * @param {SoundingBrowserSession | null} browserSession
+ * @returns {Promise<SoundingBrowserArtifacts | null>}
+ */
+async function captureBrowserFailureArtifacts(browserSession) {
+  if (typeof browserSession?.captureFailureArtifacts !== 'function') {
+    return null
+  }
+
+  try {
+    return await browserSession.captureFailureArtifacts()
+  } catch (captureError) {
+    return {
+      outputDir: '',
+      directory: '',
+      project: browserSession.project,
+      errors: [
+        {
+          artifact: 'browser',
+          message: formatUnknownError(captureError),
+        },
+      ],
+    }
+  }
+}
+
+/**
+ * @param {unknown} error
+ * @param {{ world?: { name: string, context: Record<string, any> }, browserArtifacts?: SoundingBrowserArtifacts | null }} metadata
  * @returns {unknown}
  */
 function decorateTrialError(error, metadata) {
-  if (!metadata.world || !error || typeof error !== 'object') {
+  const browserArtifacts = hasBrowserArtifacts(metadata.browserArtifacts)
+    ? metadata.browserArtifacts
+    : null
+
+  if ((!metadata.world && !browserArtifacts) || !error || typeof error !== 'object') {
     return error
   }
 
@@ -114,15 +208,25 @@ function decorateTrialError(error, metadata) {
 
   target.sounding = {
     ...existingSounding,
-    world: metadata.world,
+    ...(metadata.world ? { world: metadata.world } : {}),
+    ...(browserArtifacts ? { browserArtifacts } : {}),
   }
 
   if (existingDetails) {
     target.details = {
       ...existingDetails,
-      world: metadata.world.name,
-      worldContext: metadata.world.context,
+      ...(metadata.world
+        ? {
+            world: metadata.world.name,
+            worldContext: metadata.world.context,
+          }
+        : {}),
+      ...(browserArtifacts ? { browserArtifacts } : {}),
     }
+  }
+
+  if (browserArtifacts && typeof target.message === 'string') {
+    target.message = `${target.message}\n\n${formatBrowserArtifacts(browserArtifacts)}`
   }
 
   return error
@@ -154,13 +258,14 @@ async function runInTrialQueue(handler) {
  * @param {{
  *   runtime?: SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>),
  *   mode: string,
+ *   title?: string,
  *   nodeContext: Record<string, any>,
  *   handler: SoundingTrialHandler,
  *   options?: SoundingTestOptions,
  * }} args
  * @returns {Promise<any>}
  */
-async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
+async function runTrial({ runtime, mode, title, nodeContext, handler, options = {} }) {
   const activeRuntime = typeof runtime === 'function' ? await runtime() : runtime
   const resolved = activeRuntime
     ? {
@@ -179,6 +284,7 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
   const trialMetadata = {
     ...(worldOption ? { world: worldOption } : {}),
   }
+  let browserSession = null
 
   try {
     if (worldOption) {
@@ -219,9 +325,12 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
           }
         : sounding.sockets
 
-    let browserSession = null
     if (options.browser) {
-      browserSession = await sounding.browser.open(options.browser === true ? {} : options.browser)
+      const browserOptions = options.browser === true ? {} : options.browser
+      browserSession = await sounding.browser.open({
+        ...browserOptions,
+        trialName: title,
+      })
     }
 
     /** @type {SoundingExpect} */
@@ -255,7 +364,12 @@ async function runTrial({ runtime, mode, nodeContext, handler, options = {} }) {
 
     return await handler(context)
   } catch (error) {
-    throw decorateTrialError(error, trialMetadata)
+    const browserArtifacts = await captureBrowserFailureArtifacts(browserSession)
+
+    throw decorateTrialError(error, {
+      ...trialMetadata,
+      browserArtifacts,
+    })
   } finally {
     await resolved.teardown()
   }
@@ -282,6 +396,7 @@ function createTrialMethod(baseTest, runtime, mode, apiName = 'test') {
         return runTrial({
           runtime,
           mode,
+          title,
           nodeContext,
           handler,
           options: trialOptions,
@@ -309,6 +424,7 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
         return runTrial({
           runtime,
           mode: 'trial',
+          title,
           nodeContext,
           handler,
           options: trialOptions,

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -30,6 +30,13 @@ const DEFAULT_CONFIG = Object.freeze({
     launchOptions: {
       headless: true,
     },
+    artifacts: {
+      outputDir: '.tmp/sounding/artifacts',
+      screenshot: true,
+      trace: false,
+      video: false,
+      currentUrl: true,
+    },
   },
   mail: {
     capture: true,

--- a/lib/types.js
+++ b/lib/types.js
@@ -179,11 +179,54 @@
  *   [key: string]: any,
  * }} SoundingPage
  *
+ * @typedef {'off' | 'on' | 'on-failure'} SoundingBrowserArtifactMode
+ *
+ * @typedef {boolean | SoundingBrowserArtifactMode} SoundingBrowserArtifactSetting
+ *
+ * @typedef {{
+ *   outputDir: string,
+ *   screenshot: SoundingBrowserArtifactSetting,
+ *   trace: SoundingBrowserArtifactSetting,
+ *   video: SoundingBrowserArtifactSetting,
+ *   currentUrl: boolean,
+ * }} SoundingBrowserArtifactsConfig
+ *
+ * @typedef {{
+ *   outputDir: string,
+ *   screenshot: SoundingBrowserArtifactMode,
+ *   trace: SoundingBrowserArtifactMode,
+ *   video: SoundingBrowserArtifactMode,
+ *   currentUrl: boolean,
+ * }} SoundingBrowserResolvedArtifactsConfig
+ *
+ * @typedef {{
+ *   outputDir: string,
+ *   directory: string,
+ *   project: string,
+ *   trialName?: string,
+ *   currentUrl?: string,
+ *   currentUrlPath?: string,
+ *   screenshot?: string,
+ *   trace?: string,
+ *   video?: string,
+ *   errors: Array<{ artifact: string, message: string }>,
+ * }} SoundingBrowserArtifacts
+ *
+ * @typedef {boolean | {
+ *   outputDir?: string,
+ *   screenshot?: SoundingBrowserArtifactSetting,
+ *   trace?: SoundingBrowserArtifactSetting,
+ *   video?: SoundingBrowserArtifactSetting,
+ *   currentUrl?: boolean,
+ * }} SoundingBrowserArtifactsOption
+ *
  * @typedef {{
  *   type?: string,
  *   project?: string,
  *   launchOptions?: AnyRecord,
  *   contextOptions?: AnyRecord,
+ *   artifacts?: SoundingBrowserArtifactsOption,
+ *   trialName?: string,
  * }} SoundingBrowserOpenOptions
  *
  * @typedef {{
@@ -193,6 +236,10 @@
  *   page: SoundingPage,
  *   expect?: (actual: any) => any,
  *   project: string,
+ *   artifacts: SoundingBrowserResolvedArtifactsConfig,
+ *   readonly latestArtifacts?: SoundingBrowserArtifacts | null,
+ *   captureFailureArtifacts(error?: unknown): Promise<SoundingBrowserArtifacts>,
+ *   closeSessionContext?(): Promise<SoundingBrowserArtifacts>,
  * }} SoundingBrowserSession
  *
  * @typedef {{
@@ -412,6 +459,7 @@
  *     defaultProject: string,
  *     baseUrl?: string,
  *     launchOptions: AnyRecord,
+ *     artifacts: SoundingBrowserArtifactsConfig,
  *   },
  *   mail: {
  *     capture: boolean,

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -19,7 +19,7 @@ const SECTION_KEYS = {
   app: ['path', 'environment', 'quiet', 'loadOptions', 'liftOptions'],
   world: ['factories', 'scenarios'],
   datastore: ['mode', 'identity', 'adapter', 'root', 'isolation'],
-  browser: ['enabled', 'type', 'projects', 'defaultProject', 'baseUrl', 'launchOptions'],
+  browser: ['enabled', 'type', 'projects', 'defaultProject', 'baseUrl', 'launchOptions', 'artifacts'],
   mail: ['capture', 'layout', 'deliver', 'mode'],
   request: ['transport', 'baseUrl'],
   sockets: [
@@ -42,6 +42,8 @@ const DATASTORE_MODES = ['managed', 'inherit', 'external']
 const DATASTORE_ISOLATION = ['worker', 'run']
 const REQUEST_TRANSPORTS = ['virtual', 'http']
 const BROWSER_TYPES = ['chromium', 'firefox', 'webkit']
+const BROWSER_ARTIFACT_KEYS = ['outputDir', 'screenshot', 'trace', 'video', 'currentUrl']
+const BROWSER_ARTIFACT_MODES = ['off', 'on', 'on-failure']
 const MAIL_MODES = ['capture', 'passthrough']
 
 /**
@@ -310,6 +312,18 @@ function assertPlainObject(value, path) {
  * @param {any} value
  * @param {string} path
  */
+function assertBrowserArtifactSetting(value, path) {
+  if (typeof value === 'boolean') {
+    return
+  }
+
+  assertOneOf(value, path, BROWSER_ARTIFACT_MODES)
+}
+
+/**
+ * @param {any} value
+ * @param {string} path
+ */
 function assertStringArray(value, path) {
   if (!Array.isArray(value)) {
     throwConfigError(path, `must be an array of strings, received ${describeValue(value)}.`, {
@@ -384,6 +398,44 @@ function validateConfig(config) {
   }
 
   assertPlainObject(config.browser.launchOptions, 'sounding.browser.launchOptions')
+
+  if (config.browser.artifacts !== undefined && typeof config.browser.artifacts !== 'boolean') {
+    assertPlainObject(config.browser.artifacts, 'sounding.browser.artifacts')
+    assertKnownKeys(
+      config.browser.artifacts,
+      'sounding.browser.artifacts',
+      BROWSER_ARTIFACT_KEYS
+    )
+
+    if (config.browser.artifacts.outputDir !== undefined) {
+      assertString(config.browser.artifacts.outputDir, 'sounding.browser.artifacts.outputDir')
+    }
+
+    if (config.browser.artifacts.screenshot !== undefined) {
+      assertBrowserArtifactSetting(
+        config.browser.artifacts.screenshot,
+        'sounding.browser.artifacts.screenshot'
+      )
+    }
+
+    if (config.browser.artifacts.trace !== undefined) {
+      assertBrowserArtifactSetting(
+        config.browser.artifacts.trace,
+        'sounding.browser.artifacts.trace'
+      )
+    }
+
+    if (config.browser.artifacts.video !== undefined) {
+      assertBrowserArtifactSetting(
+        config.browser.artifacts.video,
+        'sounding.browser.artifacts.video'
+      )
+    }
+
+    if (config.browser.artifacts.currentUrl !== undefined) {
+      assertBoolean(config.browser.artifacts.currentUrl, 'sounding.browser.artifacts.currentUrl')
+    }
+  }
 
   assertSection(config.mail, 'sounding.mail')
   assertKnownKeys(config.mail, 'sounding.mail', SECTION_KEYS.mail)

--- a/lib/validate-test-args.js
+++ b/lib/validate-test-args.js
@@ -4,6 +4,8 @@ const { createSoundingError } = require('./create-error')
 /** @typedef {import('./types').SoundingTrialHandler} SoundingTrialHandler */
 
 const ALLOWED_TRANSPORTS = ['virtual', 'http']
+const ALLOWED_BROWSER_ARTIFACT_KEYS = ['outputDir', 'screenshot', 'trace', 'video', 'currentUrl']
+const ALLOWED_BROWSER_ARTIFACT_MODES = ['off', 'on', 'on-failure']
 
 /**
  * @param {any} value
@@ -163,6 +165,87 @@ function assertBrowserOptions(options, apiName) {
       apiName,
       value: options.browser.contextOptions,
       path: 'options.browser.contextOptions',
+    })
+  }
+
+  if (
+    options.browser.artifacts !== undefined &&
+    typeof options.browser.artifacts !== 'boolean' &&
+    !isPlainObject(options.browser.artifacts)
+  ) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.artifacts\` must be a boolean or artifacts options object.`,
+      apiName,
+      value: options.browser.artifacts,
+      path: 'options.browser.artifacts',
+      suggestion: 'Use `browser: { artifacts: { trace: true } }` for richer failure artifacts.',
+    })
+  }
+
+  if (!isPlainObject(options.browser.artifacts)) {
+    return
+  }
+
+  for (const key of Object.keys(options.browser.artifacts)) {
+    if (ALLOWED_BROWSER_ARTIFACT_KEYS.includes(key)) {
+      continue
+    }
+
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.artifacts.${key}\` is unknown.`,
+      apiName,
+      value: options.browser.artifacts[key],
+      path: `options.browser.artifacts.${key}`,
+      allowed: ALLOWED_BROWSER_ARTIFACT_KEYS,
+      suggestion:
+        'Use `outputDir`, `screenshot`, `trace`, `video`, or `currentUrl` inside `browser.artifacts`.',
+    })
+  }
+
+  if (
+    options.browser.artifacts.outputDir !== undefined &&
+    typeof options.browser.artifacts.outputDir !== 'string'
+  ) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.artifacts.outputDir\` must be a string.`,
+      apiName,
+      value: options.browser.artifacts.outputDir,
+      path: 'options.browser.artifacts.outputDir',
+    })
+  }
+
+  for (const key of ['screenshot', 'trace', 'video']) {
+    const value = options.browser.artifacts[key]
+
+    if (
+      value !== undefined &&
+      typeof value !== 'boolean' &&
+      !ALLOWED_BROWSER_ARTIFACT_MODES.includes(value)
+    ) {
+      throw createTestArgumentError({
+        code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+        message: `Sounding ${apiName} option \`browser.artifacts.${key}\` must be a boolean or one of \`off\`, \`on\`, \`on-failure\`.`,
+        apiName,
+        value,
+        path: `options.browser.artifacts.${key}`,
+        allowed: ALLOWED_BROWSER_ARTIFACT_MODES,
+      })
+    }
+  }
+
+  if (
+    options.browser.artifacts.currentUrl !== undefined &&
+    typeof options.browser.artifacts.currentUrl !== 'boolean'
+  ) {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser.artifacts.currentUrl\` must be a boolean.`,
+      apiName,
+      value: options.browser.artifacts.currentUrl,
+      path: 'options.browser.artifacts.currentUrl',
     })
   }
 }

--- a/test/browser-auth.test.js
+++ b/test/browser-auth.test.js
@@ -1,5 +1,8 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
 
 const { createBrowserManager } = require('../lib/create-browser-manager')
 const { createAuthHelpers } = require('../lib/create-auth-helpers')
@@ -71,6 +74,110 @@ test('createBrowserManager opens a browser session with the configured base URL'
     ['context:close'],
     ['browser:close'],
   ])
+})
+
+test('createBrowserManager captures failure artifacts with stable browser paths', async () => {
+  const artifactRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sounding-artifacts-'))
+  const calls = []
+  const currentUrl = 'http://127.0.0.1:3333/dashboard'
+  const expectedDir = path.join(artifactRoot, 'dashboard-shows-owner-stats', 'desktop')
+  const fakeVideo = {
+    async saveAs(target) {
+      calls.push(['video:saveAs', target])
+    },
+  }
+  const fakePage = {
+    url: () => currentUrl,
+    async screenshot(options) {
+      calls.push(['screenshot', options])
+    },
+    video: () => fakeVideo,
+  }
+
+  try {
+    const manager = createBrowserManager({
+      sails: {
+        config: {
+          appPath: '/tmp/app',
+          port: 3333,
+        },
+      },
+      getConfig: () => ({
+        browser: {
+          enabled: true,
+          projects: ['desktop'],
+          defaultProject: 'desktop',
+          artifacts: {
+            outputDir: artifactRoot,
+            screenshot: true,
+            trace: true,
+            video: true,
+            currentUrl: true,
+          },
+        },
+      }),
+      loadPlaywright: async () => ({
+        chromium: {
+          launch: async () => ({
+            newContext: async (contextOptions) => ({
+              contextOptions,
+              tracing: {
+                async start(options) {
+                  calls.push(['trace:start', options])
+                },
+                async stop(options) {
+                  calls.push(['trace:stop', options])
+                },
+              },
+              newPage: async () => fakePage,
+              close: async () => {
+                calls.push(['context:close'])
+              },
+            }),
+            close: async () => {
+              calls.push(['browser:close'])
+            },
+          }),
+        },
+        devices: {},
+      }),
+      loadPlaywrightTest: async () => null,
+    })
+
+    const session = await manager.open({ trialName: 'Dashboard shows owner stats' })
+    assert.equal(session.context.contextOptions.recordVideo.dir, expectedDir)
+
+    const artifacts = await session.captureFailureArtifacts()
+    await manager.close()
+
+    assert.equal(artifacts.outputDir, artifactRoot)
+    assert.equal(artifacts.directory, expectedDir)
+    assert.equal(artifacts.project, 'desktop')
+    assert.equal(artifacts.trialName, 'Dashboard shows owner stats')
+    assert.equal(artifacts.currentUrl, currentUrl)
+    assert.equal(artifacts.currentUrlPath, path.join(expectedDir, 'current-url.txt'))
+    assert.equal(artifacts.screenshot, path.join(expectedDir, 'screenshot.png'))
+    assert.equal(artifacts.trace, path.join(expectedDir, 'trace.zip'))
+    assert.equal(artifacts.video, path.join(expectedDir, 'video.webm'))
+    assert.deepEqual(artifacts.errors, [])
+    assert.equal(await fs.readFile(path.join(expectedDir, 'current-url.txt'), 'utf8'), `${currentUrl}\n`)
+    assert.deepEqual(calls, [
+      ['trace:start', { screenshots: true, snapshots: true, sources: true }],
+      [
+        'screenshot',
+        {
+          path: path.join(expectedDir, 'screenshot.png'),
+          fullPage: true,
+        },
+      ],
+      ['trace:stop', { path: path.join(expectedDir, 'trace.zip') }],
+      ['context:close'],
+      ['video:saveAs', path.join(expectedDir, 'video.webm')],
+      ['browser:close'],
+    ])
+  } finally {
+    await fs.rm(artifactRoot, { recursive: true, force: true })
+  }
 })
 
 test('createBrowserManager reports browser setup errors with stable codes', async () => {

--- a/test/config-validation.test.js
+++ b/test/config-validation.test.js
@@ -79,6 +79,53 @@ test('resolveConfig names invalid browser fields precisely', () => {
   )
 })
 
+test('resolveConfig validates browser artifact options precisely', () => {
+  const config = resolveConfig({
+    config: {
+      sounding: {
+        browser: {
+          artifacts: {
+            outputDir: '.tmp/custom-artifacts',
+            screenshot: true,
+            trace: 'on-failure',
+            video: 'off',
+            currentUrl: false,
+          },
+        },
+      },
+    },
+  })
+
+  assert.equal(config.browser.artifacts.outputDir, '.tmp/custom-artifacts')
+  assert.equal(config.browser.artifacts.screenshot, true)
+  assert.equal(config.browser.artifacts.trace, 'on-failure')
+  assert.equal(config.browser.artifacts.video, 'off')
+  assert.equal(config.browser.artifacts.currentUrl, false)
+
+  assert.throws(
+    () => {
+      resolveConfig({
+        config: {
+          sounding: {
+            browser: {
+              artifacts: {
+                video: 'sometimes',
+              },
+            },
+          },
+        },
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_CONFIG_INVALID')
+      assert.equal(error.path, 'sounding.browser.artifacts.video')
+      assert.equal(error.value, 'sometimes')
+      assert.deepEqual(error.allowed, ['off', 'on', 'on-failure'])
+      return true
+    }
+  )
+})
+
 test('resolveConfig validates websocket helper options precisely', () => {
   assert.throws(
     () => {

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -496,7 +496,100 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
     ['world:use', 'focused-dashboard', {}],
     ['using', 'http'],
     ['visit:using', 'http'],
-    ['browser:open', { project: 'desktop' }],
+    ['browser:open', { project: 'desktop', trialName: 'focused http browser trial' }],
+    ['lower'],
+  ])
+})
+
+test('test() appends browser artifact diagnostics to failed browser trials', async () => {
+  const calls = []
+  const registrations = []
+  const artifacts = {
+    outputDir: '/tmp/sounding-artifacts',
+    directory: '/tmp/sounding-artifacts/dashboard/desktop',
+    project: 'desktop',
+    trialName: 'dashboard failure keeps browser evidence',
+    currentUrl: 'http://127.0.0.1:3333/dashboard',
+    currentUrlPath: '/tmp/sounding-artifacts/dashboard/desktop/current-url.txt',
+    screenshot: '/tmp/sounding-artifacts/dashboard/desktop/screenshot.png',
+    trace: '/tmp/sounding-artifacts/dashboard/desktop/trace.zip',
+    video: '/tmp/sounding-artifacts/dashboard/desktop/video.webm',
+    errors: [],
+  }
+  const runtime = {
+    helpers: {},
+    world: {
+      reset() {},
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: {
+      transport: 'virtual',
+    },
+    sockets: {},
+    browser: {
+      async open(options) {
+        calls.push(['browser:open', options])
+
+        return {
+          browser: { name: 'browser' },
+          context: { name: 'context' },
+          page: { name: 'page' },
+          project: 'desktop',
+          async captureFailureArtifacts() {
+            calls.push(['browser:captureFailureArtifacts'])
+            return artifacts
+          },
+        }
+      },
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('dashboard failure keeps browser evidence', { browser: true }, async () => {
+    throw new Error('dashboard title was missing')
+  })
+
+  await assert.rejects(
+    async () => {
+      await registrations[0].handler({})
+    },
+    (error) => {
+      assert.match(error.message, /dashboard title was missing/)
+      assert.match(error.message, /Sounding browser artifacts:/)
+      assert.match(error.message, /http:\/\/127\.0\.0\.1:3333\/dashboard/)
+      assert.match(error.message, /screenshot\.png/)
+      assert.equal(error.sounding.browserArtifacts, artifacts)
+      return true
+    }
+  )
+
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['browser:open', { trialName: 'dashboard failure keeps browser evidence' }],
+    ['browser:captureFailureArtifacts'],
     ['lower'],
   ])
 })
@@ -576,6 +669,23 @@ test('test() reports malformed trial arguments with stable codes', () => {
       assert.equal(error.path, 'options.browser')
       assert.equal(error.value, 'mobile')
       assert.match(error.suggestion, /browser: true/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest(
+        'bad browser artifacts',
+        { browser: { artifacts: { videos: true } } },
+        async () => {}
+      )
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.browser.artifacts.videos')
+      assert.deepEqual(error.allowed, ['outputDir', 'screenshot', 'trace', 'video', 'currentUrl'])
+      assert.match(error.suggestion, /outputDir/)
       return true
     }
   )


### PR DESCRIPTION
Closes #39

## Summary
- capture current URL and full-page screenshots for failed browser trials by default
- add opt-in trace and video capture through global and per-trial browser artifact config
- append artifact paths to the original trial failure and document the browser artifact workflow

## Verification
- npm test
- npm run typecheck
- git diff --check