### PR TITLE
feat: improve browser project ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The canonical Sails-native surface is:
 - `await auth.request.withPassword('creator@example.com', { password: 'secret123' })` inside request trials
 - `test('...', { world: 'signed-in-user' }, async ({ request }) => {})` can auto-load named worlds before the handler runs
 - `request.as('owner')` and `visit.as('owner')` can resolve actor aliases from the current world
+- `test('...', { browser: 'mobile' }, async ({ page }) => {})` can select a named browser project without extra ceremony
 - failed browser trials capture the current URL and a full-page screenshot under `.tmp/sounding/artifacts`
 - request helpers default to Sails virtual requests powered by `sails.request()`
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
@@ -79,6 +80,7 @@ The default configuration story is intentionally calm:
 - managed SQLite artifacts live under `.tmp/db`
 - the default datastore identity is `default`
 - browser projects start with `desktop`
+- browser projects can be strings or named project objects with `type`, `device`, `viewport`, `contextOptions`, and `launchOptions`
 - browser failure artifacts store screenshots and current URLs by default, while traces and videos are opt-in
 - mail capture previews use the `mail` layout by default, matching the current `sails-hook-mail` convention
 - apps with a different mail layout can set `sounding.mail.layout`, for example `layout-email`
@@ -93,6 +95,48 @@ module.exports.sounding = {
 ```
 
 If you intentionally want Sounding during another boot path, widen the list explicitly, for example `['test', 'console']` or `['test', 'production']`.
+
+## Browser projects
+
+Browser trials start on the `desktop` project:
+
+```js
+test('subscriber can read a gated issue', { browser: true }, async ({ page }) => {
+  await page.goto('/issues/the-nerve-to-build')
+})
+```
+
+Use a string when a trial needs a named project:
+
+```js
+test('mobile navigation opens the account menu', { browser: 'mobile' }, async ({ page }) => {
+  await page.goto('/dashboard')
+})
+```
+
+Configure named projects in `config/sounding.js` when an app needs mobile devices, WebKit, or custom context options:
+
+```js
+module.exports.sounding = {
+  browser: {
+    projects: {
+      desktop: {},
+      mobile: {
+        device: 'iPhone 13'
+      },
+      safari: {
+        type: 'webkit',
+        viewport: {
+          width: 1280,
+          height: 720
+        }
+      }
+    }
+  }
+}
+```
+
+The object form stays Sails-simple while still passing through to Playwright where it matters.
 
 ## Browser failure artifacts
 

--- a/lib/create-browser-manager.js
+++ b/lib/create-browser-manager.js
@@ -15,6 +15,14 @@ const { loadDependencyFromApp } = require('./resolve-dependency')
 /** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
 
 const ARTIFACT_MODES = ['off', 'on', 'on-failure']
+const MOBILE_FALLBACK_OPTIONS = {
+  viewport: {
+    width: 390,
+    height: 844,
+  },
+  isMobile: true,
+  hasTouch: true,
+}
 
 /**
  * @param {string} appPath
@@ -54,19 +62,125 @@ function defaultLoadPlaywrightTest(appPath, options = {}) {
  */
 function resolveProjectOptions(projectName, devices = {}) {
   if (projectName === 'mobile') {
-    return (
-      devices['iPhone 13'] || {
-        viewport: {
-          width: 390,
-          height: 844,
-        },
-        isMobile: true,
-        hasTouch: true,
-      }
-    )
+    return devices['iPhone 13'] || MOBILE_FALLBACK_OPTIONS
   }
 
   return {}
+}
+
+/**
+ * @param {any} projects
+ * @returns {AnyRecord[]}
+ */
+function normalizeBrowserProjects(projects) {
+  if (Array.isArray(projects)) {
+    const entries = projects
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          return {
+            name: entry,
+          }
+        }
+
+        if (isPlainObject(entry) && typeof entry.name === 'string') {
+          return {
+            ...entry,
+            name: entry.name,
+          }
+        }
+
+        return null
+      })
+      .filter(Boolean)
+
+    return entries.length ? entries : [{ name: 'desktop' }]
+  }
+
+  if (isPlainObject(projects)) {
+    const entries = Object.entries(projects).map(([name, value]) => ({
+      ...(isPlainObject(value) ? value : {}),
+      name,
+    }))
+
+    return entries.length ? entries : [{ name: 'desktop' }]
+  }
+
+  return [{ name: 'desktop' }]
+}
+
+/**
+ * @param {any} projects
+ * @returns {string[]}
+ */
+function getBrowserProjectNames(projects) {
+  return normalizeBrowserProjects(projects).map((project) => project.name)
+}
+
+/**
+ * @param {AnyRecord} project
+ * @param {AnyRecord} devices
+ * @returns {AnyRecord}
+ */
+function resolveProjectDeviceOptions(project, devices = {}) {
+  if (project.device) {
+    const deviceOptions = devices[project.device]
+
+    if (!deviceOptions) {
+      throw createSoundingError({
+        code: 'E_SOUNDING_BROWSER_DEVICE_UNAVAILABLE',
+        message: `Sounding could not find a Playwright device named \`${project.device}\` for browser project \`${project.name}\`.`,
+        details: {
+          project: project.name,
+          device: project.device,
+          availableDevices: Object.keys(devices).sort(),
+        },
+      })
+    }
+
+    return deviceOptions
+  }
+
+  return resolveProjectOptions(project.name, devices)
+}
+
+/**
+ * @param {{
+ *   config: AnyRecord,
+ *   options?: SoundingBrowserOpenOptions,
+ *   devices?: AnyRecord,
+ * }} input
+ * @returns {{ name: string, type?: string, launchOptions: AnyRecord, contextOptions: AnyRecord }}
+ */
+function resolveBrowserProject({ config, options = {}, devices = {} }) {
+  const projects = normalizeBrowserProjects(config.browser?.projects)
+  const projectName =
+    options.project ||
+    config.browser?.defaultProject ||
+    projects[0]?.name ||
+    'desktop'
+  const project = projects.find((candidate) => candidate.name === projectName)
+
+  if (!project) {
+    throw createSoundingError({
+      code: 'E_SOUNDING_BROWSER_PROJECT_UNAVAILABLE',
+      message: `Sounding could not find a browser project named \`${projectName}\`.`,
+      details: {
+        project: projectName,
+        availableProjects: projects.map((candidate) => candidate.name),
+      },
+    })
+  }
+
+  return {
+    name: project.name,
+    type: project.type,
+    launchOptions: project.launchOptions || {},
+    contextOptions: {
+      ...resolveProjectDeviceOptions(project, devices),
+      ...(project.viewport ? { viewport: project.viewport } : {}),
+      ...(project.contextOptions || {}),
+    },
+  }
 }
 
 /**
@@ -294,7 +408,12 @@ function createBrowserManager({
         throw error
       })
 
-    const browserTypeName = options.type || config.browser?.type || 'chromium'
+    const project = resolveBrowserProject({
+      config,
+      options,
+      devices: playwright.devices || {},
+    })
+    const browserTypeName = options.type || project.type || config.browser?.type || 'chromium'
     const browserType = playwright?.[browserTypeName]
 
     if (!browserType?.launch) {
@@ -307,18 +426,13 @@ function createBrowserManager({
       })
     }
 
-    const projectName =
-      options.project ||
-      config.browser?.defaultProject ||
-      config.browser?.projects?.[0] ||
-      'desktop'
-
     const artifacts = resolveArtifactsConfig(config, options)
     const artifactPaths = resolveArtifactPaths(appPath, artifacts, {
       trialName: options.trialName,
-      projectName,
+      projectName: project.name,
     })
     const contextOptions = {
+      ...project.contextOptions,
       ...(options.contextOptions || {}),
     }
 
@@ -331,12 +445,12 @@ function createBrowserManager({
     const browser = await browserType.launch({
       headless: true,
       ...(config.browser?.launchOptions || {}),
+      ...project.launchOptions,
       ...(options.launchOptions || {}),
     })
 
     const context = await browser.newContext({
       baseURL: resolveBaseUrl({ sails, getConfig }),
-      ...resolveProjectOptions(projectName, playwright.devices || {}),
       ...contextOptions,
     })
 
@@ -449,7 +563,7 @@ function createBrowserManager({
       return {
         outputDir: artifactPaths.outputRoot,
         directory: artifactPaths.directory,
-        project: projectName,
+        project: project.name,
         trialName: options.trialName,
         errors: [],
       }
@@ -512,7 +626,7 @@ function createBrowserManager({
       context,
       page,
       expect: playwrightTest?.expect,
-      project: projectName,
+      project: project.name,
       artifacts,
       captureFailureArtifacts,
       closeSessionContext,
@@ -557,6 +671,9 @@ module.exports = {
   defaultLoadPlaywright,
   defaultLoadPlaywrightTest,
   resolveProjectOptions,
+  resolveBrowserProject,
+  normalizeBrowserProjects,
+  getBrowserProjectNames,
   resolveArtifactsConfig,
   slugifyArtifactSegment,
 }

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -99,6 +99,31 @@ function normalizeWorldOption(worldOption) {
 }
 
 /**
+ * @param {SoundingTestOptions['browser']} browserOption
+ * @param {string | undefined} title
+ * @returns {import('./types').SoundingBrowserOpenOptions}
+ */
+function normalizeBrowserOpenOptions(browserOption, title) {
+  if (browserOption === true) {
+    return {
+      trialName: title,
+    }
+  }
+
+  if (typeof browserOption === 'string') {
+    return {
+      project: browserOption.trim(),
+      trialName: title,
+    }
+  }
+
+  return {
+    ...(browserOption || {}),
+    trialName: title,
+  }
+}
+
+/**
  * @param {unknown} error
  * @returns {string}
  */
@@ -326,11 +351,9 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
         : sounding.sockets
 
     if (options.browser) {
-      const browserOptions = options.browser === true ? {} : options.browser
-      browserSession = await sounding.browser.open({
-        ...browserOptions,
-        trialName: title,
-      })
+      browserSession = await sounding.browser.open(
+        normalizeBrowserOpenOptions(options.browser, title)
+      )
     }
 
     /** @type {SoundingExpect} */
@@ -448,6 +471,7 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
 
 module.exports = {
   createTestApi,
+  normalizeBrowserOpenOptions,
   normalizeTestArgs,
   resolveRuntimeFromGlobals,
   runInTrialQueue,

--- a/lib/types.js
+++ b/lib/types.js
@@ -221,6 +221,20 @@
  * }} SoundingBrowserArtifactsOption
  *
  * @typedef {{
+ *   width: number,
+ *   height: number,
+ * }} SoundingBrowserViewport
+ *
+ * @typedef {{
+ *   name?: string,
+ *   type?: 'chromium' | 'firefox' | 'webkit' | string,
+ *   device?: string,
+ *   viewport?: SoundingBrowserViewport,
+ *   contextOptions?: AnyRecord,
+ *   launchOptions?: AnyRecord,
+ * }} SoundingBrowserProjectConfig
+ *
+ * @typedef {{
  *   type?: string,
  *   project?: string,
  *   launchOptions?: AnyRecord,
@@ -455,7 +469,7 @@
  *   browser: {
  *     enabled: boolean,
  *     type: string,
- *     projects: string[],
+ *     projects: string[] | Array<string | (SoundingBrowserProjectConfig & { name: string })> | Record<string, SoundingBrowserProjectConfig>,
  *     defaultProject: string,
  *     baseUrl?: string,
  *     launchOptions: AnyRecord,
@@ -587,7 +601,7 @@
  *
  * @typedef {SoundingRequestOptions & {
  *   transport?: SoundingTransport,
- *   browser?: boolean | SoundingBrowserOpenOptions,
+ *   browser?: boolean | string | SoundingBrowserOpenOptions,
  *   socket?: boolean | SoundingSocketConnectOptions,
  *   world?: SoundingTrialWorldOption,
  * }} SoundingTestOptions

--- a/lib/validate-config.js
+++ b/lib/validate-config.js
@@ -42,6 +42,8 @@ const DATASTORE_MODES = ['managed', 'inherit', 'external']
 const DATASTORE_ISOLATION = ['worker', 'run']
 const REQUEST_TRANSPORTS = ['virtual', 'http']
 const BROWSER_TYPES = ['chromium', 'firefox', 'webkit']
+const BROWSER_PROJECT_KEYS = ['name', 'type', 'device', 'viewport', 'contextOptions', 'launchOptions']
+const BROWSER_PROJECT_VIEWPORT_KEYS = ['width', 'height']
 const BROWSER_ARTIFACT_KEYS = ['outputDir', 'screenshot', 'trace', 'video', 'currentUrl']
 const BROWSER_ARTIFACT_MODES = ['off', 'on', 'on-failure']
 const MAIL_MODES = ['capture', 'passthrough']
@@ -337,6 +339,107 @@ function assertStringArray(value, path) {
 }
 
 /**
+ * @param {any} viewport
+ * @param {string} path
+ */
+function assertBrowserProjectViewport(viewport, path) {
+  assertPlainObject(viewport, path)
+  assertKnownKeys(viewport, path, BROWSER_PROJECT_VIEWPORT_KEYS)
+  assertPositiveNumber(viewport.width, `${path}.width`)
+  assertPositiveNumber(viewport.height, `${path}.height`)
+}
+
+/**
+ * @param {AnyRecord} project
+ * @param {string} path
+ * @param {{ requireName?: boolean }} [options]
+ */
+function assertBrowserProjectObject(project, path, options = {}) {
+  assertPlainObject(project, path)
+  assertKnownKeys(project, path, BROWSER_PROJECT_KEYS)
+
+  if (options.requireName) {
+    assertString(project.name, `${path}.name`)
+
+    if (!project.name.trim()) {
+      throwConfigError(`${path}.name`, 'must be a non-empty string.', {
+        value: project.name,
+      })
+    }
+  }
+
+  if (project.type !== undefined) {
+    assertOneOf(project.type, `${path}.type`, BROWSER_TYPES)
+  }
+
+  if (project.device !== undefined) {
+    assertString(project.device, `${path}.device`)
+  }
+
+  if (project.viewport !== undefined) {
+    assertBrowserProjectViewport(project.viewport, `${path}.viewport`)
+  }
+
+  if (project.contextOptions !== undefined) {
+    assertPlainObject(project.contextOptions, `${path}.contextOptions`)
+  }
+
+  if (project.launchOptions !== undefined) {
+    assertPlainObject(project.launchOptions, `${path}.launchOptions`)
+  }
+}
+
+/**
+ * @param {any} projects
+ * @returns {string[]}
+ */
+function getBrowserProjectNames(projects) {
+  if (Array.isArray(projects)) {
+    return projects
+      .map((project) => (typeof project === 'string' ? project : project?.name))
+      .filter((name) => typeof name === 'string' && name.trim())
+  }
+
+  if (isPlainObject(projects)) {
+    return Object.keys(projects)
+  }
+
+  return []
+}
+
+/**
+ * @param {any} projects
+ * @param {string} path
+ */
+function assertBrowserProjects(projects, path) {
+  if (Array.isArray(projects)) {
+    projects.forEach((entry, index) => {
+      if (typeof entry === 'string') {
+        assertString(entry, `${path}[${index}]`)
+        return
+      }
+
+      assertBrowserProjectObject(entry, `${path}[${index}]`, {
+        requireName: true,
+      })
+    })
+    return
+  }
+
+  assertPlainObject(projects, path)
+
+  for (const [name, project] of Object.entries(projects)) {
+    if (!name.trim()) {
+      throwConfigError(`${path}.${name}`, 'project names must be non-empty strings.', {
+        value: name,
+      })
+    }
+
+    assertBrowserProjectObject(project, `${path}.${name}`)
+  }
+}
+
+/**
  * @param {any} value
  * @param {string} path
  */
@@ -390,8 +493,20 @@ function validateConfig(config) {
   assertKnownKeys(config.browser, 'sounding.browser', SECTION_KEYS.browser)
   assertBoolean(config.browser.enabled, 'sounding.browser.enabled')
   assertOneOf(config.browser.type, 'sounding.browser.type', BROWSER_TYPES)
-  assertStringArray(config.browser.projects, 'sounding.browser.projects')
+  assertBrowserProjects(config.browser.projects, 'sounding.browser.projects')
   assertString(config.browser.defaultProject, 'sounding.browser.defaultProject')
+
+  const browserProjectNames = getBrowserProjectNames(config.browser.projects)
+  if (!browserProjectNames.includes(config.browser.defaultProject)) {
+    throwConfigError(
+      'sounding.browser.defaultProject',
+      `must reference one of the configured browser projects: ${browserProjectNames.map((project) => `\`${project}\``).join(', ')}.`,
+      {
+        value: config.browser.defaultProject,
+        allowed: browserProjectNames,
+      }
+    )
+  }
 
   if (config.browser.baseUrl !== undefined) {
     assertString(config.browser.baseUrl, 'sounding.browser.baseUrl')

--- a/lib/validate-test-args.js
+++ b/lib/validate-test-args.js
@@ -112,15 +112,31 @@ function assertBrowserOptions(options, apiName) {
   if (
     options.browser !== undefined &&
     typeof options.browser !== 'boolean' &&
+    typeof options.browser !== 'string' &&
     !isPlainObject(options.browser)
   ) {
     throw createTestArgumentError({
       code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
-      message: `Sounding ${apiName} option \`browser\` must be a boolean or browser options object.`,
+      message: `Sounding ${apiName} option \`browser\` must be a boolean, project name, or browser options object.`,
       apiName,
       value: options.browser,
       path: 'options.browser',
-      suggestion: 'Use `browser: true` or `browser: { project: "desktop" }`.',
+      suggestion: 'Use `browser: true`, `browser: "mobile"`, or `browser: { project: "desktop" }`.',
+    })
+  }
+
+  if (typeof options.browser === 'string') {
+    if (options.browser.trim()) {
+      return
+    }
+
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`browser\` must name a browser project when provided as a string.`,
+      apiName,
+      value: options.browser,
+      path: 'options.browser',
+      suggestion: 'Use `browser: "mobile"` or `browser: { project: "mobile" }`.',
     })
   }
 

--- a/test/browser-auth.test.js
+++ b/test/browser-auth.test.js
@@ -76,6 +76,185 @@ test('createBrowserManager opens a browser session with the configured base URL'
   ])
 })
 
+test('createBrowserManager resolves mobile and custom browser projects', async () => {
+  const calls = []
+  const fakePage = {}
+  const devices = {
+    'Pixel 7': {
+      viewport: {
+        width: 412,
+        height: 915,
+      },
+      isMobile: true,
+      hasTouch: true,
+    },
+  }
+  const createBrowserType = (name) => ({
+    launch: async (launchOptions) => {
+      calls.push([`${name}:launch`, launchOptions])
+
+      return {
+        newContext: async (contextOptions) => {
+          calls.push([`${name}:context`, contextOptions])
+
+          return {
+            contextOptions,
+            newPage: async () => fakePage,
+            close: async () => {
+              calls.push([`${name}:context:close`])
+            },
+          }
+        },
+        close: async () => {
+          calls.push([`${name}:browser:close`])
+        },
+      }
+    },
+  })
+  const config = {
+    browser: {
+      enabled: true,
+      type: 'chromium',
+      projects: {
+        desktop: {},
+        mobile: {
+          device: 'Pixel 7',
+        },
+        safari: {
+          type: 'webkit',
+          viewport: {
+            width: 1280,
+            height: 720,
+          },
+          contextOptions: {
+            colorScheme: 'dark',
+          },
+          launchOptions: {
+            slowMo: 25,
+          },
+        },
+      },
+      defaultProject: 'desktop',
+      launchOptions: {
+        timeout: 5000,
+      },
+    },
+  }
+
+  const createManager = () =>
+    createBrowserManager({
+      sails: {
+        config: {
+          appPath: '/tmp/app',
+          port: 3333,
+        },
+      },
+      getConfig: () => config,
+      loadPlaywright: async () => ({
+        chromium: createBrowserType('chromium'),
+        webkit: createBrowserType('webkit'),
+        devices,
+      }),
+      loadPlaywrightTest: async () => null,
+    })
+
+  const mobileManager = createManager()
+  const mobileSession = await mobileManager.open({ project: 'mobile' })
+  assert.equal(mobileSession.project, 'mobile')
+  assert.equal(mobileSession.page, fakePage)
+  await mobileManager.close()
+
+  const safariManager = createManager()
+  const safariSession = await safariManager.open({
+    project: 'safari',
+    contextOptions: {
+      timezoneId: 'Africa/Lagos',
+    },
+    launchOptions: {
+      timeout: 1000,
+    },
+  })
+  assert.equal(safariSession.project, 'safari')
+  await safariManager.close()
+
+  assert.deepEqual(calls, [
+    ['chromium:launch', { headless: true, timeout: 5000 }],
+    [
+      'chromium:context',
+      {
+        baseURL: 'http://127.0.0.1:3333',
+        viewport: {
+          width: 412,
+          height: 915,
+        },
+        isMobile: true,
+        hasTouch: true,
+      },
+    ],
+    ['chromium:context:close'],
+    ['chromium:browser:close'],
+    ['webkit:launch', { headless: true, timeout: 1000, slowMo: 25 }],
+    [
+      'webkit:context',
+      {
+        baseURL: 'http://127.0.0.1:3333',
+        viewport: {
+          width: 1280,
+          height: 720,
+        },
+        colorScheme: 'dark',
+        timezoneId: 'Africa/Lagos',
+      },
+    ],
+    ['webkit:context:close'],
+    ['webkit:browser:close'],
+  ])
+})
+
+test('createBrowserManager reports unknown browser projects with available names', async () => {
+  const manager = createBrowserManager({
+    sails: {
+      config: {
+        appPath: '/tmp/app',
+        port: 3333,
+      },
+    },
+    getConfig: () => ({
+      browser: {
+        enabled: true,
+        projects: {
+          desktop: {},
+          mobile: {
+            device: 'iPhone 13',
+          },
+        },
+        defaultProject: 'desktop',
+      },
+    }),
+    loadPlaywright: async () => ({
+      chromium: {
+        launch: async () => {
+          throw new Error('browser should not launch for unknown projects')
+        },
+      },
+      devices: {},
+    }),
+    loadPlaywrightTest: async () => null,
+  })
+
+  await assert.rejects(
+    async () => {
+      await manager.open({ project: 'tablet' })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_BROWSER_PROJECT_UNAVAILABLE')
+      assert.equal(error.project, 'tablet')
+      assert.deepEqual(error.availableProjects, ['desktop', 'mobile'])
+      return true
+    }
+  )
+})
+
 test('createBrowserManager captures failure artifacts with stable browser paths', async () => {
   const artifactRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sounding-artifacts-'))
   const calls = []

--- a/test/config-validation.test.js
+++ b/test/config-validation.test.js
@@ -73,7 +73,92 @@ test('resolveConfig names invalid browser fields precisely', () => {
       assert.equal(error.code, 'E_SOUNDING_CONFIG_INVALID')
       assert.equal(error.path, 'sounding.browser.projects[1]')
       assert.equal(error.value, 42)
-      assert.match(error.message, /must be a string/)
+      assert.match(error.message, /must be an object/)
+      return true
+    }
+  )
+})
+
+test('resolveConfig validates named browser projects', () => {
+  const config = resolveConfig({
+    config: {
+      sounding: {
+        browser: {
+          projects: {
+            desktop: {},
+            mobile: {
+              device: 'iPhone 13',
+            },
+            safari: {
+              type: 'webkit',
+              viewport: {
+                width: 1280,
+                height: 720,
+              },
+              contextOptions: {
+                colorScheme: 'dark',
+              },
+              launchOptions: {
+                slowMo: 25,
+              },
+            },
+          },
+          defaultProject: 'safari',
+        },
+      },
+    },
+  })
+
+  assert.equal(config.browser.defaultProject, 'safari')
+  assert.equal(config.browser.projects.safari.type, 'webkit')
+  assert.equal(config.browser.projects.mobile.device, 'iPhone 13')
+
+  assert.throws(
+    () => {
+      resolveConfig({
+        config: {
+          sounding: {
+            browser: {
+              projects: {
+                desktop: {},
+              },
+              defaultProject: 'mobile',
+            },
+          },
+        },
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_CONFIG_INVALID')
+      assert.equal(error.path, 'sounding.browser.defaultProject')
+      assert.equal(error.value, 'mobile')
+      assert.deepEqual(error.allowed, ['desktop'])
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      resolveConfig({
+        config: {
+          sounding: {
+            browser: {
+              projects: {
+                safari: {
+                  type: 'safari',
+                },
+              },
+              defaultProject: 'safari',
+            },
+          },
+        },
+      })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_CONFIG_INVALID')
+      assert.equal(error.path, 'sounding.browser.projects.safari.type')
+      assert.equal(error.value, 'safari')
+      assert.deepEqual(error.allowed, ['chromium', 'firefox', 'webkit'])
       return true
     }
   )

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -468,7 +468,7 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
     {
       transport: 'http',
       world: 'focused-dashboard',
-      browser: { project: 'desktop' },
+      browser: 'desktop',
       timeout: 500,
     },
     async ({ sails, get, request, visit, page, expect }) => {
@@ -662,13 +662,26 @@ test('test() reports malformed trial arguments with stable codes', () => {
 
   assert.throws(
     () => {
-      soundingTest('bad browser', { browser: 'mobile' }, async () => {})
+      soundingTest('bad browser', { browser: 42 }, async () => {})
     },
     (error) => {
       assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
       assert.equal(error.path, 'options.browser')
-      assert.equal(error.value, 'mobile')
-      assert.match(error.suggestion, /browser: true/)
+      assert.equal(error.value, 42)
+      assert.match(error.suggestion, /browser: "mobile"/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest('empty browser project', { browser: '' }, async () => {})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.browser')
+      assert.equal(error.value, '')
+      assert.match(error.suggestion, /browser: "mobile"/)
       return true
     }
   )


### PR DESCRIPTION
Closes #40

## Summary
- Add named browser project resolution with device, browser type, viewport, context option, and launch option support.
- Support the `browser: "mobile"` shorthand while keeping `{ browser: { project } }` for explicit selection.
- Validate browser project config and report unknown project names with structured available project details.

## Verification
- `npm test`
- `npm run typecheck`
- `git diff --check`