### PR TITLE
Add npx sounding init scaffolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,38 @@ module.exports.sounding = {
 
 If you intentionally want Sounding during another boot path, widen the list explicitly, for example `['test', 'console']` or `['test', 'production']`.
 
+## Project init
+
+Use the initializer from a Sails app to add the first Sounding test lane:
+
+```sh
+npx sounding init
+```
+
+It updates `package.json`, creates `tests/factories`, `tests/scenarios`, and `tests/sounding`, and writes starter examples without overwriting existing files. The default setup relies on Sounding's built-in conventions, so it skips `config/sounding.js` unless you ask for an editable config scaffold:
+
+```sh
+npx sounding init --config
+```
+
+Typical output looks like:
+
+```txt
+Sounding initialized /path/to/my-sails-app
+Auth convention: User
+~ Updated package.json (added `npm test`, added `sounding` devDependency, added `sails-sqlite` devDependency)
++ Created tests
++ Created tests/factories
++ Created tests/scenarios
++ Created tests/sounding
++ Created tests/factories/user.js
++ Created tests/scenarios/signed-in-user.js
++ Created tests/sounding/examples.test.js
+- Skipped config/sounding.js because Sounding defaults are enough
+
+Next: run npm install, then npm test.
+```
+
 ## Typing and editor support
 
 Sounding is JSDoc-first today. The public API types live beside the CommonJS source, with shared typedefs in `lib/types.js`, so JavaScript Sails apps get autocomplete and inline docs without a separate hand-maintained declaration surface.

--- a/bin/sounding.js
+++ b/bin/sounding.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+const { initProject } = require('../lib/init-project')
+
+function printHelp() {
+  process.stdout.write(`Sounding
+
+Usage:
+  sounding init [--app <path>] [--config]
+
+Commands:
+  init      Scaffold Sounding tests, worlds, and package scripts in a Sails app.
+
+Options:
+  --app     Target app directory. Defaults to the current working directory.
+  --config  Also create config/sounding.js when it does not already exist.
+  --help    Show this help.
+`)
+}
+
+function parseArgs(argv) {
+  const args = [...argv]
+  const options = {}
+  const command = args.shift()
+
+  if (command === '--help' || command === '-h') {
+    return {
+      command: null,
+      options: {
+        help: true,
+      },
+    }
+  }
+
+  while (args.length > 0) {
+    const arg = args.shift()
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true
+      continue
+    }
+
+    if (arg === '--config') {
+      options.config = true
+      continue
+    }
+
+    if (arg === '--app') {
+      options.appPath = args.shift()
+      if (!options.appPath) {
+        throw new Error('Sounding option `--app` requires a path.')
+      }
+      continue
+    }
+
+    throw new Error(`Unknown Sounding option: ${arg}`)
+  }
+
+  return {
+    command,
+    options,
+  }
+}
+
+function printInitResult(result) {
+  process.stdout.write(`Sounding initialized ${result.appPath}\n`)
+  process.stdout.write(
+    `Auth convention: ${result.auth.modelName}${result.auth.detected ? '' : ' (default)'}\n`
+  )
+
+  for (const action of result.actions) {
+    const marker = action.type === 'created' ? '+' : action.type === 'updated' ? '~' : '-'
+    process.stdout.write(`${marker} ${action.message}\n`)
+  }
+
+  process.stdout.write('\nNext: run npm install, then npm test.\n')
+}
+
+async function main() {
+  const { command, options } = parseArgs(process.argv.slice(2))
+
+  if (!command || options.help) {
+    printHelp()
+    return
+  }
+
+  if (command !== 'init') {
+    throw new Error(`Unknown Sounding command: ${command}`)
+  }
+
+  const result = initProject(options)
+  printInitResult(result)
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`)
+  process.exitCode = 1
+})

--- a/lib/init-project.js
+++ b/lib/init-project.js
@@ -1,0 +1,403 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const packageJson = require('../package.json')
+
+const TEST_COMMAND = 'node --test tests/**/*.test.js'
+const SOUNDING_VERSION = `^${packageJson.version}`
+const SQLITE_VERSION = packageJson.devDependencies?.['sails-sqlite'] || '^0.2.6'
+
+/**
+ * @typedef {{
+ *   type: 'created' | 'updated' | 'skipped',
+ *   path?: string,
+ *   message: string,
+ * }} InitProjectAction
+ */
+
+/**
+ * @typedef {{
+ *   appPath?: string,
+ *   config?: boolean,
+ * }} InitProjectOptions
+ */
+
+/**
+ * @typedef {{
+ *   appPath: string,
+ *   auth: {
+ *     identity: string,
+ *     modelName: string,
+ *     collection: string,
+ *     scenario: string,
+ *     detected: boolean,
+ *   },
+ *   actions: InitProjectAction[],
+ * }} InitProjectResult
+ */
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function titleCase(value) {
+  return `${value[0].toUpperCase()}${value.slice(1)}`
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function pluralize(value) {
+  if (value.endsWith('s')) {
+    return value
+  }
+
+  return `${value}s`
+}
+
+/**
+ * @param {string} appPath
+ * @returns {InitProjectResult['auth']}
+ */
+function detectAuthConvention(appPath) {
+  const candidates = ['user', 'creator']
+
+  for (const identity of candidates) {
+    const modelName = titleCase(identity)
+    const modelPaths = [
+      path.join(appPath, 'api', 'models', `${modelName}.js`),
+      path.join(appPath, 'api', 'models', `${identity}.js`),
+    ]
+
+    if (modelPaths.some((modelPath) => fs.existsSync(modelPath))) {
+      return {
+        identity,
+        modelName,
+        collection: pluralize(identity),
+        scenario: `signed-in-${identity}`,
+        detected: true,
+      }
+    }
+  }
+
+  return {
+    identity: 'user',
+    modelName: 'User',
+    collection: 'users',
+    scenario: 'signed-in-user',
+    detected: false,
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @returns {any}
+ */
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+/**
+ * @param {string} filePath
+ * @param {any} value
+ * @returns {void}
+ */
+function writeJsonFile(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+/**
+ * @param {string} appPath
+ * @param {string} targetPath
+ * @returns {string}
+ */
+function formatPath(appPath, targetPath) {
+  return path.relative(appPath, targetPath) || path.basename(targetPath)
+}
+
+/**
+ * @param {InitProjectAction[]} actions
+ * @param {string} appPath
+ * @param {string} directory
+ * @returns {void}
+ */
+function ensureDirectory(actions, appPath, directory) {
+  if (fs.existsSync(directory)) {
+    actions.push({
+      type: 'skipped',
+      path: directory,
+      message: `Kept existing ${formatPath(appPath, directory)}`,
+    })
+    return
+  }
+
+  fs.mkdirSync(directory, { recursive: true })
+  actions.push({
+    type: 'created',
+    path: directory,
+    message: `Created ${formatPath(appPath, directory)}`,
+  })
+}
+
+/**
+ * @param {InitProjectAction[]} actions
+ * @param {string} appPath
+ * @param {string} filePath
+ * @param {string} contents
+ * @returns {void}
+ */
+function writeFileIfMissing(actions, appPath, filePath, contents) {
+  if (fs.existsSync(filePath)) {
+    actions.push({
+      type: 'skipped',
+      path: filePath,
+      message: `Kept existing ${formatPath(appPath, filePath)}`,
+    })
+    return
+  }
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, contents)
+  actions.push({
+    type: 'created',
+    path: filePath,
+    message: `Created ${formatPath(appPath, filePath)}`,
+  })
+}
+
+/**
+ * @param {any} pkg
+ * @param {string} name
+ * @returns {boolean}
+ */
+function hasDependency(pkg, name) {
+  return Boolean(pkg.dependencies?.[name] || pkg.devDependencies?.[name])
+}
+
+/**
+ * @param {any} pkg
+ * @param {string} name
+ * @param {string} version
+ * @returns {boolean}
+ */
+function ensureDevDependency(pkg, name, version) {
+  if (hasDependency(pkg, name)) {
+    return false
+  }
+
+  pkg.devDependencies ||= {}
+  pkg.devDependencies[name] = version
+  return true
+}
+
+/**
+ * @param {InitProjectAction[]} actions
+ * @param {string} appPath
+ * @returns {void}
+ */
+function updatePackageJson(actions, appPath) {
+  const packagePath = path.join(appPath, 'package.json')
+  const packageExisted = fs.existsSync(packagePath)
+  const pkg = packageExisted ? readJsonFile(packagePath) : {}
+  let changed = false
+  const details = []
+
+  pkg.scripts ||= {}
+
+  if (!pkg.scripts.test) {
+    pkg.scripts.test = TEST_COMMAND
+    changed = true
+    details.push('added `npm test`')
+  } else if (pkg.scripts.test !== TEST_COMMAND && !pkg.scripts['test:sounding']) {
+    pkg.scripts['test:sounding'] = TEST_COMMAND
+    changed = true
+    details.push('added `npm run test:sounding`')
+  }
+
+  if (ensureDevDependency(pkg, 'sounding', SOUNDING_VERSION)) {
+    changed = true
+    details.push('added `sounding` devDependency')
+  }
+
+  if (ensureDevDependency(pkg, 'sails-sqlite', SQLITE_VERSION)) {
+    changed = true
+    details.push('added `sails-sqlite` devDependency')
+  }
+
+  if (!changed) {
+    actions.push({
+      type: 'skipped',
+      path: packagePath,
+      message: 'Kept existing package.json Sounding setup',
+    })
+    return
+  }
+
+  writeJsonFile(packagePath, pkg)
+  actions.push({
+    type: packageExisted ? 'updated' : 'created',
+    path: packagePath,
+    message: `${packageExisted ? 'Updated' : 'Created'} package.json (${details.join(', ')})`,
+  })
+}
+
+/**
+ * @param {InitProjectResult['auth']} auth
+ * @returns {string}
+ */
+function buildFactoryTemplate(auth) {
+  return `module.exports = ({ defineFactory }) =>
+  defineFactory('${auth.identity}', ({ sequence }) => ({
+    email: sequence('${auth.identity}-email', (next) => \`${auth.identity}-\${next}@example.com\`),
+    fullName: 'Test ${auth.modelName}'
+  }))
+`
+}
+
+/**
+ * @param {InitProjectResult['auth']} auth
+ * @returns {string}
+ */
+function buildScenarioTemplate(auth) {
+  return `module.exports = ({ defineScenario }) =>
+  defineScenario('${auth.scenario}', async ({ create }) => {
+    const member = await create('${auth.identity}')
+
+    return {
+      ${auth.collection}: {
+        member
+      }
+    }
+  })
+`
+}
+
+/**
+ * @param {InitProjectResult['auth']} auth
+ * @returns {string}
+ */
+function buildExamplesTemplate(auth) {
+  return `const { test } = require('sounding')
+
+test('Sounding boots this Sails app', async ({ sails, expect }) => {
+  expect(sails.config.environment).toBe('test')
+})
+
+test('virtual request example reaches Sails', async ({ get, expect }) => {
+  const response = await get('/')
+
+  expect(response.status).toBeDefined()
+})
+
+test('helper trial example has access to Sails helpers', async ({ sails, expect }) => {
+  expect(sails.helpers).toBeDefined()
+})
+
+test.skip('authenticated request example', { world: '${auth.scenario}' }, async ({ request, world, expect }) => {
+  const response = await request.as('member').get('/account')
+
+  expect(response).toHaveStatus(200)
+  expect(response).toHaveSession('${auth.identity}Id', world.current.${auth.collection}.member.id)
+})
+
+test.skip('Inertia page contract example', async ({ visit, expect }) => {
+  const page = await visit('/dashboard')
+
+  expect(page).toBeInertiaPage('dashboard/index')
+  expect(page).toHaveNoInertiaErrors()
+})
+
+test.skip('captured mail example', async ({ sails, mailbox, expect }) => {
+  await sails.helpers.mail.send.with({
+    to: 'reader@example.com',
+    subject: 'Welcome',
+    template: 'welcome'
+  })
+
+  expect(mailbox).toHaveSentMail({ to: 'reader@example.com' })
+})
+
+test.skip('browser journey example', { browser: true }, async ({ page, expect }) => {
+  await page.goto('/')
+
+  await expect(page).toBeDefined()
+})
+`
+}
+
+/**
+ * @returns {string}
+ */
+function buildConfigTemplate() {
+  return `module.exports.sounding = {
+  // Defaults are enough for most apps. Keep app-specific overrides here.
+  environments: ['test']
+}
+`
+}
+
+/**
+ * @param {InitProjectOptions} [options]
+ * @returns {InitProjectResult}
+ */
+function initProject(options = {}) {
+  const appPath = path.resolve(options.appPath || process.cwd())
+  /** @type {InitProjectAction[]} */
+  const actions = []
+  const auth = detectAuthConvention(appPath)
+
+  updatePackageJson(actions, appPath)
+
+  const testsPath = path.join(appPath, 'tests')
+  const factoriesPath = path.join(testsPath, 'factories')
+  const scenariosPath = path.join(testsPath, 'scenarios')
+  const examplesPath = path.join(testsPath, 'sounding')
+
+  ensureDirectory(actions, appPath, testsPath)
+  ensureDirectory(actions, appPath, factoriesPath)
+  ensureDirectory(actions, appPath, scenariosPath)
+  ensureDirectory(actions, appPath, examplesPath)
+
+  writeFileIfMissing(
+    actions,
+    appPath,
+    path.join(factoriesPath, `${auth.identity}.js`),
+    buildFactoryTemplate(auth)
+  )
+  writeFileIfMissing(
+    actions,
+    appPath,
+    path.join(scenariosPath, `${auth.scenario}.js`),
+    buildScenarioTemplate(auth)
+  )
+  writeFileIfMissing(
+    actions,
+    appPath,
+    path.join(examplesPath, 'examples.test.js'),
+    buildExamplesTemplate(auth)
+  )
+
+  const configPath = path.join(appPath, 'config', 'sounding.js')
+  if (options.config) {
+    writeFileIfMissing(actions, appPath, configPath, buildConfigTemplate())
+  } else {
+    actions.push({
+      type: 'skipped',
+      path: configPath,
+      message: 'Skipped config/sounding.js because Sounding defaults are enough',
+    })
+  }
+
+  return {
+    appPath,
+    auth,
+    actions,
+  }
+}
+
+module.exports = {
+  TEST_COMMAND,
+  detectAuthConvention,
+  initProject,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "sounding",
       "version": "0.0.4",
       "license": "MIT",
+      "bin": {
+        "sounding": "bin/sounding.js"
+      },
       "devDependencies": {
         "@types/node": "^25.9.1",
         "sails": "^1.5.18",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.4",
   "description": "Testing framework for Sails applications and The Boring JavaScript Stack.",
   "main": "index.js",
+  "bin": {
+    "sounding": "bin/sounding.js"
+  },
   "license": "MIT",
   "keywords": [
     "sails",
@@ -12,6 +15,7 @@
     "tbjs"
   ],
   "files": [
+    "bin",
     "index.js",
     "lib",
     "README.md",

--- a/test/init-project.test.js
+++ b/test/init-project.test.js
@@ -1,0 +1,153 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const { TEST_COMMAND, initProject } = require('../lib/init-project')
+
+function createTempApp(prefix = 'sounding-init-') {
+  const appPath = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  fs.mkdirSync(path.join(appPath, 'api', 'models'), { recursive: true })
+  fs.mkdirSync(path.join(appPath, 'config'), { recursive: true })
+  return appPath
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+test('initProject scaffolds package scripts, dependencies, worlds, and examples', () => {
+  const appPath = createTempApp()
+  fs.writeFileSync(path.join(appPath, 'api', 'models', 'User.js'), 'module.exports = {}\n')
+  fs.writeFileSync(
+    path.join(appPath, 'package.json'),
+    JSON.stringify({ name: 'example-sails-app', private: true }, null, 2)
+  )
+
+  const result = initProject({ appPath })
+  const pkg = readJson(path.join(appPath, 'package.json'))
+  const exampleFile = path.join(appPath, 'tests', 'sounding', 'examples.test.js')
+
+  assert.equal(result.auth.identity, 'user')
+  assert.equal(result.auth.detected, true)
+  assert.equal(pkg.scripts.test, TEST_COMMAND)
+  assert.match(pkg.devDependencies.sounding, /^\^0\.0\./)
+  assert.equal(pkg.devDependencies['sails-sqlite'], '^0.2.6')
+  assert.equal(fs.existsSync(path.join(appPath, 'tests', 'factories')), true)
+  assert.equal(fs.existsSync(path.join(appPath, 'tests', 'scenarios')), true)
+  assert.equal(fs.existsSync(path.join(appPath, 'config', 'sounding.js')), false)
+  assert.match(
+    fs.readFileSync(path.join(appPath, 'tests', 'factories', 'user.js'), 'utf8'),
+    /defineFactory\('user'/
+  )
+  assert.match(
+    fs.readFileSync(path.join(appPath, 'tests', 'scenarios', 'signed-in-user.js'), 'utf8'),
+    /users:/
+  )
+  assert.match(fs.readFileSync(exampleFile, 'utf8'), /virtual request example/)
+  assert.match(fs.readFileSync(exampleFile, 'utf8'), /browser journey example/)
+})
+
+test('initProject preserves existing scripts and files on repeated runs', () => {
+  const appPath = createTempApp()
+  const packagePath = path.join(appPath, 'package.json')
+  const factoryPath = path.join(appPath, 'tests', 'factories', 'user.js')
+
+  fs.mkdirSync(path.dirname(factoryPath), { recursive: true })
+  fs.writeFileSync(path.join(appPath, 'api', 'models', 'User.js'), 'module.exports = {}\n')
+  fs.writeFileSync(factoryPath, 'module.exports = customFactory\n')
+  fs.writeFileSync(
+    packagePath,
+    JSON.stringify(
+      {
+        name: 'custom-sails-app',
+        scripts: {
+          test: 'node ./custom-test-runner.js',
+        },
+        devDependencies: {
+          sounding: 'workspace:*',
+        },
+      },
+      null,
+      2
+    )
+  )
+
+  initProject({ appPath })
+  const firstPackage = fs.readFileSync(packagePath, 'utf8')
+
+  initProject({ appPath })
+  const secondPackage = fs.readFileSync(packagePath, 'utf8')
+  const pkg = readJson(packagePath)
+
+  assert.equal(pkg.scripts.test, 'node ./custom-test-runner.js')
+  assert.equal(pkg.scripts['test:sounding'], TEST_COMMAND)
+  assert.equal(pkg.devDependencies.sounding, 'workspace:*')
+  assert.equal(fs.readFileSync(factoryPath, 'utf8'), 'module.exports = customFactory\n')
+  assert.equal(secondPackage, firstPackage)
+})
+
+test('initProject can scaffold optional config and detect Creator conventions', () => {
+  const appPath = createTempApp()
+  fs.writeFileSync(path.join(appPath, 'api', 'models', 'Creator.js'), 'module.exports = {}\n')
+  fs.writeFileSync(
+    path.join(appPath, 'package.json'),
+    JSON.stringify({ name: 'creator-app', private: true }, null, 2)
+  )
+
+  const result = initProject({ appPath, config: true })
+  const configPath = path.join(appPath, 'config', 'sounding.js')
+
+  assert.equal(result.auth.identity, 'creator')
+  assert.equal(result.auth.collection, 'creators')
+  assert.match(fs.readFileSync(configPath, 'utf8'), /module\.exports\.sounding/)
+  assert.match(
+    fs.readFileSync(path.join(appPath, 'tests', 'factories', 'creator.js'), 'utf8'),
+    /defineFactory\('creator'/
+  )
+  assert.match(
+    fs.readFileSync(path.join(appPath, 'tests', 'scenarios', 'signed-in-creator.js'), 'utf8'),
+    /creators:/
+  )
+})
+
+test('bin/sounding.js runs init from the command line', () => {
+  const appPath = createTempApp()
+  fs.writeFileSync(path.join(appPath, 'api', 'models', 'User.js'), 'module.exports = {}\n')
+  fs.writeFileSync(
+    path.join(appPath, 'package.json'),
+    JSON.stringify({ name: 'cli-app', private: true }, null, 2)
+  )
+
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'init',
+    '--app',
+    appPath,
+  ])
+
+  assert.equal(result.status, 0, result.stderr.toString())
+  assert.match(result.stdout.toString(), /Sounding initialized/)
+  assert.equal(fs.existsSync(path.join(appPath, 'tests', 'sounding', 'examples.test.js')), true)
+})
+
+test('bin/sounding.js shows help and reports missing option values', () => {
+  const help = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    '--help',
+  ])
+
+  assert.equal(help.status, 0)
+  assert.match(help.stdout.toString(), /Usage:/)
+
+  const missingApp = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'init',
+    '--app',
+  ])
+
+  assert.equal(missingApp.status, 1)
+  assert.match(missingApp.stderr.toString(), /requires a path/)
+})


### PR DESCRIPTION
## Summary

- Add a `sounding init` CLI entrypoint for `npx sounding init`.
- Scaffold package scripts, dev dependencies, test folders, factories, scenarios, and starter trial examples without overwriting existing files.
- Detect User vs Creator model conventions and optionally create `config/sounding.js` with `--config`.
- Document the initializer flow and expected output.

## Validation

- npm run typecheck
- npm test
- npm pack --dry-run

Closes #37