### PR TITLE
Add sounding test CLI runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,34 @@ Auth convention: User
 Next: run npm install, then npm test.
 ```
 
+## CLI test runner
+
+Run a Sounding suite with the framework-level runner:
+
+```sh
+npx sounding test
+```
+
+The command discovers `.test.js` files under `tests/` and `test/`, then runs Node's native test runner with Sounding-friendly filters:
+
+```sh
+npx sounding test --grep "dashboard"
+npx sounding test --file tests/sounding/examples.test.js
+npx sounding test --lane browser
+npx sounding test --watch
+```
+
+Common Node test flags pass through, and CI reporters are available without memorizing the longer Node flag names:
+
+```sh
+npx sounding test --reporter spec
+npx sounding test --junit reports/sounding-junit.xml
+npx sounding test --json
+npx sounding test --coverage
+```
+
+Use `--dry-run` to inspect the exact `node --test` command before running it.
+
 ## Typing and editor support
 
 Sounding is JSDoc-first today. The public API types live beside the CommonJS source, with shared typedefs in `lib/types.js`, so JavaScript Sails apps get autocomplete and inline docs without a separate hand-maintained declaration surface.

--- a/bin/sounding.js
+++ b/bin/sounding.js
@@ -1,20 +1,47 @@
 #!/usr/bin/env node
 
 const { initProject } = require('../lib/init-project')
+const { formatTestCommand, runTests } = require('../lib/test-runner')
 
 function printHelp() {
   process.stdout.write(`Sounding
 
 Usage:
   sounding init [--app <path>] [--config]
+  sounding test [options] [files or folders]
 
 Commands:
   init      Scaffold Sounding tests, worlds, and package scripts in a Sails app.
+  test      Run Sounding trials through the Node.js test runner.
 
 Options:
   --app     Target app directory. Defaults to the current working directory.
   --config  Also create config/sounding.js when it does not already exist.
   --help    Show this help.
+`)
+}
+
+function printTestHelp() {
+  process.stdout.write(`Sounding test
+
+Usage:
+  sounding test [options] [files or folders]
+
+Options:
+  --app <path>                   Target app directory.
+  --grep <pattern>               Forward to --test-name-pattern.
+  --file <path>                  Run one file. May be repeated.
+  --lane <name>                  Run tests under tests/<name> or test/<name>.
+  --changed                      Run changed .test.js files when git metadata is available.
+  --watch                        Forward to Node watch mode.
+  --reporter <name>              Forward to --test-reporter.
+  --reporter-destination <path>  Forward to --test-reporter-destination.
+  --junit [path]                 Use the junit reporter.
+  --json                         Use the json reporter.
+  --coverage                     Enable Node test coverage.
+  --dry-run                      Print the Node command without running it.
+
+Unknown --test-* and Node flags pass through to node.
 `)
 }
 
@@ -28,6 +55,15 @@ function parseArgs(argv) {
       command: null,
       options: {
         help: true,
+      },
+    }
+  }
+
+  if (command === 'test') {
+    return {
+      command,
+      options: {
+        argv: args,
       },
     }
   }
@@ -84,12 +120,34 @@ async function main() {
     return
   }
 
-  if (command !== 'init') {
-    throw new Error(`Unknown Sounding command: ${command}`)
+  if (command === 'init') {
+    const result = initProject(options)
+    printInitResult(result)
+    return
   }
 
-  const result = initProject(options)
-  printInitResult(result)
+  if (command === 'test') {
+    if (options.argv.includes('--help') || options.argv.includes('-h')) {
+      printTestHelp()
+      return
+    }
+
+    const result = await runTests({
+      argv: options.argv,
+      stdio: 'inherit',
+    })
+
+    if (result.command.dryRun) {
+      process.stdout.write(`${formatTestCommand(result.command)}\n`)
+    }
+
+    process.exitCode = result.status
+    return
+  }
+
+  {
+    throw new Error(`Unknown Sounding command: ${command}`)
+  }
 }
 
 main().catch((error) => {

--- a/lib/init-project.js
+++ b/lib/init-project.js
@@ -3,7 +3,7 @@ const path = require('node:path')
 
 const packageJson = require('../package.json')
 
-const TEST_COMMAND = 'node --test tests/**/*.test.js'
+const TEST_COMMAND = 'sounding test'
 const SOUNDING_VERSION = `^${packageJson.version}`
 const SQLITE_VERSION = packageJson.devDependencies?.['sails-sqlite'] || '^0.2.6'
 

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -1,0 +1,427 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { execFileSync, spawn } = require('node:child_process')
+
+const DEFAULT_TEST_DIRECTORIES = ['tests', 'test']
+const DEFAULT_JUNIT_DESTINATION = 'reports/sounding-junit.xml'
+const NODE_VALUE_FLAGS = new Set([
+  '--test-name-pattern',
+  '--test-reporter',
+  '--test-reporter-destination',
+  '--test-shard',
+  '--test-timeout',
+])
+
+/**
+ * @typedef {{
+ *   appPath?: string,
+ *   argv?: string[],
+ *   nodeExecutable?: string,
+ * }} BuildTestCommandOptions
+ */
+
+/**
+ * @typedef {{
+ *   command: string,
+ *   args: string[],
+ *   cwd: string,
+ *   files: string[],
+ *   dryRun: boolean,
+ * }} SoundingTestCommand
+ */
+
+/**
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function isTestFile(filePath) {
+  return /\.test\.(js|cjs|mjs)$/.test(filePath)
+}
+
+/**
+ * @param {string} directory
+ * @returns {string[]}
+ */
+function listTestFiles(directory) {
+  if (!fs.existsSync(directory)) {
+    return []
+  }
+
+  const files = []
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const nextPath = path.join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) {
+        continue
+      }
+
+      files.push(...listTestFiles(nextPath))
+      continue
+    }
+
+    if (entry.isFile() && isTestFile(nextPath)) {
+      files.push(nextPath)
+    }
+  }
+
+  return files.sort()
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function hasGlob(value) {
+  return /[*?[\]{}]/.test(value)
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeRegExp(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&')
+}
+
+/**
+ * @param {string} pattern
+ * @returns {RegExp}
+ */
+function globToRegExp(pattern) {
+  const normalized = pattern.split(path.sep).join('/')
+  let output = '^'
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index]
+    const nextChar = normalized[index + 1]
+    const followingChar = normalized[index + 2]
+
+    if (char === '*' && nextChar === '*') {
+      if (followingChar === '/') {
+        output += '(?:.*/)?'
+        index += 2
+        continue
+      }
+
+      output += '.*'
+      index += 1
+      continue
+    }
+
+    if (char === '*') {
+      output += '[^/]*'
+      continue
+    }
+
+    if (char === '?') {
+      output += '[^/]'
+      continue
+    }
+
+    output += escapeRegExp(char)
+  }
+
+  output += '$'
+  return new RegExp(output)
+}
+
+/**
+ * @param {string} pattern
+ * @returns {string}
+ */
+function resolveGlobBase(pattern) {
+  const segments = pattern.split(/[\\/]/)
+  const baseSegments = []
+
+  for (const segment of segments) {
+    if (hasGlob(segment)) {
+      break
+    }
+
+    baseSegments.push(segment)
+  }
+
+  return baseSegments.length > 0 ? baseSegments.join(path.sep) : '.'
+}
+
+/**
+ * @param {string} appPath
+ * @param {string} target
+ * @returns {string[]}
+ */
+function resolveTargetFiles(appPath, target) {
+  const absoluteTarget = path.resolve(appPath, target)
+
+  if (hasGlob(target)) {
+    const relativeBase = resolveGlobBase(target)
+    const absoluteBase = path.resolve(appPath, relativeBase)
+    const matcher = globToRegExp(target.split(path.sep).join('/'))
+
+    return listTestFiles(absoluteBase).filter((filePath) => {
+      const relativePath = path.relative(appPath, filePath).split(path.sep).join('/')
+      return matcher.test(relativePath)
+    })
+  }
+
+  if (!fs.existsSync(absoluteTarget)) {
+    return []
+  }
+
+  const stat = fs.statSync(absoluteTarget)
+
+  if (stat.isDirectory()) {
+    return listTestFiles(absoluteTarget)
+  }
+
+  return isTestFile(absoluteTarget) ? [absoluteTarget] : []
+}
+
+/**
+ * @param {string} appPath
+ * @returns {string[]}
+ */
+function getChangedTestFiles(appPath) {
+  try {
+    const output = execFileSync('git', ['-C', appPath, 'diff', '--name-only', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+
+    return output
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .filter(isTestFile)
+  } catch (_error) {
+    return []
+  }
+}
+
+/**
+ * @param {string} appPath
+ * @param {string[]} targets
+ * @returns {string[]}
+ */
+function resolveTestFiles(appPath, targets) {
+  const nextTargets =
+    targets.length > 0
+      ? targets
+      : DEFAULT_TEST_DIRECTORIES.filter((directory) => fs.existsSync(path.join(appPath, directory)))
+
+  const files = new Set()
+
+  for (const target of nextTargets) {
+    for (const filePath of resolveTargetFiles(appPath, target)) {
+      files.add(path.relative(appPath, filePath))
+    }
+  }
+
+  return Array.from(files).sort()
+}
+
+/**
+ * @param {string[]} argv
+ * @param {string} appPath
+ * @returns {{
+ *   appPath: string,
+ *   dryRun: boolean,
+ *   targets: string[],
+ *   nodeArgs: string[],
+ * }}
+ */
+function parseTestArgs(argv = [], appPath = process.cwd()) {
+  const args = [...argv]
+  const targets = []
+  const nodeArgs = []
+  let dryRun = false
+  let useChanged = false
+  let resolvedAppPath = path.resolve(appPath)
+
+  function readValue(flag) {
+    const value = args.shift()
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Sounding test option \`${flag}\` requires a value.`)
+    }
+
+    return value
+  }
+
+  while (args.length > 0) {
+    const arg = args.shift()
+
+    if (arg === '--dry-run') {
+      dryRun = true
+      continue
+    }
+
+    if (arg === '--app') {
+      resolvedAppPath = path.resolve(readValue(arg))
+      continue
+    }
+
+    if (arg === '--grep') {
+      nodeArgs.push('--test-name-pattern', readValue(arg))
+      continue
+    }
+
+    if (arg === '--file') {
+      targets.push(readValue(arg))
+      continue
+    }
+
+    if (arg === '--lane') {
+      const lane = readValue(arg)
+      targets.push(`tests/${lane}`)
+      targets.push(`test/${lane}`)
+      continue
+    }
+
+    if (arg === '--changed') {
+      useChanged = true
+      continue
+    }
+
+    if (arg === '--reporter') {
+      nodeArgs.push('--test-reporter', readValue(arg))
+      continue
+    }
+
+    if (arg === '--reporter-destination') {
+      nodeArgs.push('--test-reporter-destination', readValue(arg))
+      continue
+    }
+
+    if (arg === '--junit') {
+      nodeArgs.push('--test-reporter', 'junit')
+
+      if (args[0] && !args[0].startsWith('-')) {
+        nodeArgs.push('--test-reporter-destination', args.shift())
+      } else {
+        nodeArgs.push('--test-reporter-destination', DEFAULT_JUNIT_DESTINATION)
+      }
+
+      continue
+    }
+
+    if (arg === '--json') {
+      nodeArgs.push('--test-reporter', 'json')
+      continue
+    }
+
+    if (arg === '--coverage') {
+      nodeArgs.push('--experimental-test-coverage')
+      continue
+    }
+
+    if (arg === '--watch') {
+      nodeArgs.push('--watch')
+      continue
+    }
+
+    if (arg === '--') {
+      nodeArgs.push(...args)
+      break
+    }
+
+    if (NODE_VALUE_FLAGS.has(arg)) {
+      nodeArgs.push(arg, readValue(arg))
+      continue
+    }
+
+    if (arg.startsWith('--')) {
+      nodeArgs.push(arg)
+      continue
+    }
+
+    targets.push(arg)
+  }
+
+  if (useChanged) {
+    targets.push(...getChangedTestFiles(resolvedAppPath))
+  }
+
+  return {
+    appPath: resolvedAppPath,
+    dryRun,
+    targets,
+    nodeArgs,
+  }
+}
+
+/**
+ * @param {BuildTestCommandOptions} [options]
+ * @returns {SoundingTestCommand}
+ */
+function buildTestCommand(options = {}) {
+  const parsed = parseTestArgs(options.argv || [], options.appPath)
+  const files = resolveTestFiles(parsed.appPath, parsed.targets)
+
+  return {
+    command: options.nodeExecutable || process.execPath,
+    args: ['--test', ...parsed.nodeArgs, ...files],
+    cwd: parsed.appPath,
+    files,
+    dryRun: parsed.dryRun,
+  }
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function quoteShell(value) {
+  if (/^[A-Za-z0-9_./:=@-]+$/.test(value)) {
+    return value
+  }
+
+  return JSON.stringify(value)
+}
+
+/**
+ * @param {SoundingTestCommand} command
+ * @returns {string}
+ */
+function formatTestCommand(command) {
+  return [command.command, ...command.args].map(quoteShell).join(' ')
+}
+
+/**
+ * @param {BuildTestCommandOptions & { stdio?: 'inherit' | 'pipe' }} [options]
+ * @returns {Promise<{ status: number, command: SoundingTestCommand }>}
+ */
+function runTests(options = {}) {
+  const command = buildTestCommand(options)
+
+  if (command.dryRun) {
+    return Promise.resolve({
+      status: 0,
+      command,
+    })
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(command.command, command.args, {
+      cwd: command.cwd,
+      stdio: options.stdio || 'inherit',
+    })
+
+    child.on('exit', (code, signal) => {
+      resolve({
+        status: code ?? (signal ? 1 : 0),
+        command,
+      })
+    })
+  })
+}
+
+module.exports = {
+  DEFAULT_JUNIT_DESTINATION,
+  DEFAULT_TEST_DIRECTORIES,
+  buildTestCommand,
+  formatTestCommand,
+  parseTestArgs,
+  resolveTestFiles,
+  runTests,
+}

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -1,0 +1,151 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const {
+  DEFAULT_JUNIT_DESTINATION,
+  buildTestCommand,
+  formatTestCommand,
+  resolveTestFiles,
+} = require('../lib/test-runner')
+
+function createTempApp() {
+  const appPath = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-test-runner-'))
+  fs.mkdirSync(path.join(appPath, 'tests', 'browser'), { recursive: true })
+  fs.mkdirSync(path.join(appPath, 'test'), { recursive: true })
+  fs.writeFileSync(path.join(appPath, 'tests', 'account.test.js'), "require('node:test')('account', () => {})\n")
+  fs.writeFileSync(path.join(appPath, 'tests', 'browser', 'login.test.js'), "require('node:test')('login', () => {})\n")
+  fs.writeFileSync(path.join(appPath, 'test', 'legacy.test.js'), "require('node:test')('legacy', () => {})\n")
+  fs.writeFileSync(path.join(appPath, 'tests', 'readme.md'), '# ignored\n')
+  return appPath
+}
+
+test('resolveTestFiles discovers tests and test directories by default', () => {
+  const appPath = createTempApp()
+
+  assert.deepEqual(resolveTestFiles(appPath, []), [
+    'test/legacy.test.js',
+    'tests/account.test.js',
+    'tests/browser/login.test.js',
+  ])
+})
+
+test('buildTestCommand maps Sounding flags to node --test flags', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: [
+      '--grep',
+      'login',
+      '--file',
+      'tests/account.test.js',
+      '--reporter',
+      'spec',
+      '--watch',
+      '--coverage',
+      '--dry-run',
+    ],
+  })
+
+  assert.equal(command.command, 'node')
+  assert.equal(command.cwd, appPath)
+  assert.equal(command.dryRun, true)
+  assert.deepEqual(command.files, ['tests/account.test.js'])
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-name-pattern',
+    'login',
+    '--test-reporter',
+    'spec',
+    '--watch',
+    '--experimental-test-coverage',
+    'tests/account.test.js',
+  ])
+})
+
+test('buildTestCommand supports lane filters and CI reporters', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: ['--lane', 'browser', '--junit'],
+  })
+
+  assert.deepEqual(command.files, ['tests/browser/login.test.js'])
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-reporter',
+    'junit',
+    '--test-reporter-destination',
+    DEFAULT_JUNIT_DESTINATION,
+    'tests/browser/login.test.js',
+  ])
+})
+
+test('buildTestCommand preserves Node test runner pass-through flags', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: ['--test-concurrency=1', '--test-reporter', 'tap', 'tests/**/*.test.js'],
+  })
+
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-concurrency=1',
+    '--test-reporter',
+    'tap',
+    'tests/account.test.js',
+    'tests/browser/login.test.js',
+  ])
+})
+
+test('formatTestCommand produces a copyable dry-run command', () => {
+  const command = {
+    command: 'node',
+    args: ['--test', '--test-name-pattern', 'sign in', 'tests/account.test.js'],
+    cwd: process.cwd(),
+    files: ['tests/account.test.js'],
+    dryRun: true,
+  }
+
+  assert.equal(
+    formatTestCommand(command),
+    'node --test --test-name-pattern "sign in" tests/account.test.js'
+  )
+})
+
+test('bin/sounding.js can dry-run the test command', () => {
+  const appPath = createTempApp()
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'test',
+    '--app',
+    appPath,
+    '--grep',
+    'account',
+    '--dry-run',
+  ])
+
+  assert.equal(result.status, 0, result.stderr.toString())
+  assert.match(result.stdout.toString(), /--test-name-pattern account/)
+  assert.match(result.stdout.toString(), /tests\/account\.test\.js/)
+})
+
+test('bin/sounding.js can run a selected test file', () => {
+  const appPath = createTempApp()
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'test',
+    '--app',
+    appPath,
+    '--file',
+    'tests/account.test.js',
+  ])
+
+  assert.equal(result.status, 0, result.stderr.toString())
+})


### PR DESCRIPTION
## Summary

- Add `sounding test` on top of the Node test runner.
- Discover `.test.js` files under `tests/` and `test/`, including glob, file, lane, and changed-test targeting.
- Support Sounding-friendly aliases for grep, watch, coverage, JSON/JUnit reporters, and dry-run output while preserving Node test flag pass-through.
- Update `sounding init` to generate `npm test` as `sounding test` and document CLI runner usage.

## Validation

- npm run typecheck
- npm test
- node bin/sounding.js test --file test/init-project.test.js
- node bin/sounding.js test --grep init --dry-run
- npm pack --dry-run

Closes #38