### PR TITLE
perf: cache config and world loading

### DIFF
--- a/lib/create-runtime.js
+++ b/lib/create-runtime.js
@@ -3,7 +3,7 @@ const path = require('node:path')
 const { createMailbox } = require('./create-mailbox')
 const { createMailCapture } = require('./create-mail-capture')
 const { createWorldEngine } = require('./create-world-engine')
-const { loadWorldFiles } = require('./create-world-loader')
+const { createWorldLoaderCache, loadWorldFiles } = require('./create-world-loader')
 const { createHelperRunner } = require('./create-helper-runner')
 const { createRequestClient } = require('./create-request-client')
 const { createVisitClient } = require('./create-visit-client')
@@ -27,11 +27,74 @@ const { validateConfig } = require('./validate-config')
  * @returns {SoundingConfig}
  */
 function resolveConfig(sails) {
+  return resolveConfigValue(sails.config?.sounding || {})
+}
+
+/**
+ * @param {any} value
+ * @returns {string}
+ */
+function getConfigSignature(value) {
+  try {
+    return JSON.stringify(value || {})
+  } catch (_error) {
+    return String(Date.now())
+  }
+}
+
+/**
+ * @param {any} userConfig
+ * @returns {SoundingConfig}
+ */
+function resolveConfigValue(userConfig) {
   return validateConfig(
     /** @type {SoundingConfig} */ (
-      mergeConfig(getDefaultConfig(), normalizeUserConfig(sails.config?.sounding || {}))
+      mergeConfig(getDefaultConfig(), normalizeUserConfig(userConfig || {}))
     )
   )
+}
+
+/**
+ * @param {SoundingSailsApp} sails
+ * @returns {(() => SoundingConfig) & { stats: { resolutions: number }, invalidate(): void }}
+ */
+function createConfigResolver(sails) {
+  /** @type {any} */
+  let cachedInput = null
+  /** @type {string | null} */
+  let cachedSignature = null
+  /** @type {SoundingConfig | null} */
+  let cachedConfig = null
+  const stats = {
+    resolutions: 0,
+  }
+
+  const resolver = /** @type {(() => SoundingConfig) & { stats: { resolutions: number }, invalidate(): void }} */ (
+    function resolveCachedConfig() {
+      const input = sails.config?.sounding || {}
+      const signature = getConfigSignature(input)
+
+      if (cachedConfig && cachedInput === input && cachedSignature === signature) {
+        return cachedConfig
+      }
+
+      cachedInput = input
+      cachedSignature = signature
+      cachedConfig = resolveConfigValue(input)
+      stats.resolutions += 1
+      return cachedConfig
+    }
+  )
+
+  resolver.stats = stats
+  resolver.invalidate = function invalidateConfigCache() {
+    cachedInput = null
+    cachedSignature = null
+    cachedConfig = null
+    stats.resolutions = 0
+  }
+
+  return resolver
 }
 
 /**
@@ -114,21 +177,23 @@ function createRuntime(sails) {
   const mailbox = createMailbox()
   const world = createWorldEngine({ sails })
   const helpers = createHelperRunner({ sails })
+  const getConfig = createConfigResolver(sails)
+  const worldLoaderCache = createWorldLoaderCache()
   const request = createRequestClient({
     sails,
-    getConfig: () => resolveConfig(sails),
+    getConfig,
     world,
   })
   const visit = createVisitClient({ request })
   const sockets = createSocketManager({
     sails,
-    getConfig: () => resolveConfig(sails),
+    getConfig,
     world,
   })
   const browser = createBrowserManager({
     sails,
-    getConfig: () => resolveConfig(sails),
-    appPathResolver: () => resolveAppPath(sails, resolveConfig(sails)),
+    getConfig,
+    appPathResolver: () => resolveAppPath(sails, getConfig()),
   })
   const auth = createAuthHelpers({
     sails,
@@ -139,14 +204,14 @@ function createRuntime(sails) {
   const mailCapture = createMailCapture({
     sails,
     mailbox,
-    getConfig: () => resolveConfig(sails),
+    getConfig,
   })
   let bootState = null
   let datastoreState = null
 
   return {
     get config() {
-      return resolveConfig(sails)
+      return getConfig()
     },
 
     get appPath() {
@@ -193,7 +258,7 @@ function createRuntime(sails) {
     configure() {
       datastoreState = resolveDatastore({
         sails,
-        soundingConfig: this.config,
+        soundingConfig: getConfig(),
       })
 
       return datastoreState
@@ -212,22 +277,25 @@ function createRuntime(sails) {
         datastoreState = this.configure()
       }
 
+      const config = getConfig()
+      const appPath = resolveAppPath(sails, config)
       world.reset({ preserveSequences: true })
       const loadedWorldFiles = await loadWorldFiles({
         world,
-        appPath: this.appPath,
-        config: this.config,
+        appPath,
+        config,
         sails,
+        cache: worldLoaderCache,
       })
       const captureInstalled = mailCapture.install()
 
       bootState = {
         bootedAt: new Date().toISOString(),
         mode: options.mode || 'unit',
-        config: this.config,
+        config,
         datastore: datastoreState,
         mail: {
-          captureEnabled: this.config.mail?.capture !== false,
+          captureEnabled: config.mail?.capture !== false,
           captureInstalled,
         },
         world: {
@@ -285,11 +353,24 @@ function createRuntime(sails) {
     get state() {
       return bootState
     },
+
+    get cacheStats() {
+      return {
+        config: { ...getConfig.stats },
+        worldLoader: { ...worldLoaderCache.stats },
+      }
+    },
+
+    invalidateCaches() {
+      getConfig.invalidate()
+      worldLoaderCache.clear()
+    },
   }
 }
 
 module.exports = {
   createRuntime,
+  createConfigResolver,
   resolveConfig,
   resolveAppPath,
 }

--- a/lib/create-world-loader.js
+++ b/lib/create-world-loader.js
@@ -19,16 +19,18 @@ const WORLD_EXTENSIONS = new Set(['.js', '.cjs', '.mjs'])
 
 /**
  * @param {string} directory
+ * @param {{ directories?: string[] }} [options]
  * @returns {string[]}
  */
-function listDefinitionFiles(directory) {
+function listDefinitionFiles(directory, options = {}) {
   const output = []
+  options.directories?.push(directory)
 
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
     const nextPath = path.join(directory, entry.name)
 
     if (entry.isDirectory()) {
-      output.push(...listDefinitionFiles(nextPath))
+      output.push(...listDefinitionFiles(nextPath, options))
       continue
     }
 
@@ -38,6 +40,87 @@ function listDefinitionFiles(directory) {
   }
 
   return output.sort()
+}
+
+/**
+ * @param {string} entryPath
+ * @returns {{ path: string, mtimeMs: number, size: number }}
+ */
+function getFileSignature(entryPath) {
+  const stat = fs.statSync(entryPath)
+
+  return {
+    path: entryPath,
+    mtimeMs: stat.mtimeMs,
+    size: stat.size,
+  }
+}
+
+/**
+ * @returns {{
+ *   directories: Map<string, { signatures: Array<{ path: string, mtimeMs: number, size: number }>, files: string[] }>,
+ *   modules: Map<string, { signature: { path: string, mtimeMs: number, size: number }, value: any }>,
+ *   stats: { directoryScans: number, moduleLoads: number },
+ *   clear(): void,
+ * }}
+ */
+function createWorldLoaderCache() {
+  const stats = {
+    directoryScans: 0,
+    moduleLoads: 0,
+  }
+
+  return {
+    directories: new Map(),
+    modules: new Map(),
+    stats,
+    clear() {
+      this.directories.clear()
+      this.modules.clear()
+      stats.directoryScans = 0
+      stats.moduleLoads = 0
+    },
+  }
+}
+
+/**
+ * @param {{ path: string, mtimeMs: number, size: number }} expected
+ * @returns {boolean}
+ */
+function signatureMatches(expected) {
+  if (!fs.existsSync(expected.path)) {
+    return false
+  }
+
+  const actual = getFileSignature(expected.path)
+  return actual.mtimeMs === expected.mtimeMs && actual.size === expected.size
+}
+
+/**
+ * @param {string} directory
+ * @param {ReturnType<typeof createWorldLoaderCache> | undefined} cache
+ * @returns {string[]}
+ */
+function getDefinitionFiles(directory, cache) {
+  if (!cache) {
+    return listDefinitionFiles(directory)
+  }
+
+  const cached = cache.directories.get(directory)
+
+  if (cached && cached.signatures.every(signatureMatches)) {
+    return cached.files
+  }
+
+  const directories = []
+  const files = listDefinitionFiles(directory, { directories })
+  cache.stats.directoryScans += 1
+  cache.directories.set(directory, {
+    signatures: directories.map(getFileSignature),
+    files,
+  })
+
+  return files
 }
 
 /**
@@ -55,6 +138,36 @@ async function loadModule(filePath) {
 
     return import(`${pathToFileURL(filePath).href}?t=${Date.now()}`)
   }
+}
+
+/**
+ * @param {string} filePath
+ * @param {ReturnType<typeof createWorldLoaderCache> | undefined} cache
+ * @returns {Promise<any>}
+ */
+async function loadCachedModule(filePath, cache) {
+  if (!cache) {
+    return loadModule(filePath)
+  }
+
+  const signature = getFileSignature(filePath)
+  const cached = cache.modules.get(filePath)
+
+  if (
+    cached &&
+    cached.signature.mtimeMs === signature.mtimeMs &&
+    cached.signature.size === signature.size
+  ) {
+    return cached.value
+  }
+
+  const value = await loadModule(filePath)
+  cache.stats.moduleLoads += 1
+  cache.modules.set(filePath, {
+    signature,
+    value,
+  })
+  return value
 }
 
 /**
@@ -114,10 +227,10 @@ async function registerExport(value, api, source) {
 }
 
 /**
- * @param {{ world: SoundingWorldEngine, appPath: string, config: SoundingConfig, sails?: SoundingSailsApp }} input
+ * @param {{ world: SoundingWorldEngine, appPath: string, config: SoundingConfig, sails?: SoundingSailsApp, cache?: ReturnType<typeof createWorldLoaderCache> }} input
  * @returns {Promise<string[]>}
  */
-async function loadWorldFiles({ world, appPath, config, sails }) {
+async function loadWorldFiles({ world, appPath, config, sails, cache }) {
   const directories = [config.world?.factories, config.world?.scenarios]
     .filter(Boolean)
     .map((relativePath) => path.resolve(appPath, relativePath))
@@ -139,8 +252,8 @@ async function loadWorldFiles({ world, appPath, config, sails }) {
       continue
     }
 
-    for (const filePath of listDefinitionFiles(directory)) {
-      const loaded = await loadModule(filePath)
+    for (const filePath of getDefinitionFiles(directory, cache)) {
+      const loaded = await loadCachedModule(filePath, cache)
       await registerExport(loaded, api, filePath)
       loadedFiles.push(filePath)
     }
@@ -150,6 +263,7 @@ async function loadWorldFiles({ world, appPath, config, sails }) {
 }
 
 module.exports = {
+  createWorldLoaderCache,
   loadWorldFiles,
   listDefinitionFiles,
   loadModule,

--- a/lib/types.js
+++ b/lib/types.js
@@ -575,6 +575,11 @@
  *   readonly datastore: SoundingDatastoreState | null,
  *   boot(options?: { mode?: string }): Promise<SoundingBootResult>,
  *   lower(): Promise<void>,
+ *   readonly cacheStats: {
+ *     config: { resolutions: number },
+ *     worldLoader: { directoryScans: number, moduleLoads: number },
+ *   },
+ *   invalidateCaches(): void,
  *   readonly state: SoundingRuntimeState | null,
  * }} SoundingRuntime
  *

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -1,5 +1,8 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
 const soundingHook = require('../index')
 const { createRuntime, resolveConfig } = require('../lib/create-runtime')
@@ -59,6 +62,129 @@ test('Sounding normalizes shorthand datastore config', () => {
   assert.equal(shorthand.datastore.mode, 'inherit')
   assert.equal(shorthand.datastore.root, '.tmp/db')
   assert.equal(shorthand.datastore.adapter, 'sails-sqlite')
+})
+
+test('createRuntime caches resolved config until Sails config changes or caches are invalidated', () => {
+  const sails = {
+    config: {
+      sounding: {
+        request: {
+          transport: 'virtual',
+        },
+      },
+    },
+    models: {},
+    helpers: {},
+  }
+  const runtime = createRuntime(sails)
+
+  assert.equal(runtime.cacheStats.config.resolutions, 0)
+
+  const first = runtime.config
+  const repeated = runtime.config
+
+  assert.equal(repeated, first)
+  assert.equal(runtime.cacheStats.config.resolutions, 1)
+
+  sails.config.sounding.request.transport = 'http'
+  const changed = runtime.config
+
+  assert.notEqual(changed, first)
+  assert.equal(changed.request.transport, 'http')
+  assert.equal(runtime.cacheStats.config.resolutions, 2)
+
+  runtime.invalidateCaches()
+  assert.equal(runtime.cacheStats.config.resolutions, 0)
+
+  const afterInvalidation = runtime.config
+
+  assert.notEqual(afterInvalidation, changed)
+  assert.equal(afterInvalidation.request.transport, 'http')
+  assert.equal(runtime.cacheStats.config.resolutions, 1)
+})
+
+test('createRuntime reuses cached world loading between repeated boots', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-runtime-worlds-'))
+  const factoriesDir = path.join(tempRoot, 'tests', 'factories')
+  const scenariosDir = path.join(tempRoot, 'tests', 'scenarios')
+
+  fs.mkdirSync(factoriesDir, { recursive: true })
+  fs.mkdirSync(scenariosDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(factoriesDir, 'user.js'),
+    "module.exports = ({ factory }) => factory('user', { email: 'reader@example.com' })\n"
+  )
+  fs.writeFileSync(
+    path.join(scenariosDir, 'signed-in-user.js'),
+    "module.exports = ({ scenario }) => scenario('signed-in-user', ({ build }) => ({ user: build('user') }))\n"
+  )
+
+  const runtime = createRuntime({
+    config: {
+      appPath: tempRoot,
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+      sounding: {
+        datastore: 'inherit',
+        world: {
+          factories: 'tests/factories',
+          scenarios: 'tests/scenarios',
+        },
+      },
+    },
+    models: {},
+    helpers: {},
+  })
+
+  await runtime.boot()
+  assert.deepEqual(runtime.cacheStats, {
+    config: {
+      resolutions: 1,
+    },
+    worldLoader: {
+      directoryScans: 2,
+      moduleLoads: 2,
+    },
+  })
+  assert.deepEqual(runtime.world.factories, ['user'])
+  assert.deepEqual(runtime.world.scenarios, ['signed-in-user'])
+
+  await runtime.lower()
+  await runtime.boot()
+
+  assert.deepEqual(runtime.cacheStats, {
+    config: {
+      resolutions: 1,
+    },
+    worldLoader: {
+      directoryScans: 2,
+      moduleLoads: 2,
+    },
+  })
+  assert.deepEqual(runtime.world.factories, ['user'])
+  assert.deepEqual(runtime.world.scenarios, ['signed-in-user'])
+
+  await runtime.lower()
+  runtime.invalidateCaches()
+  await runtime.boot()
+
+  assert.deepEqual(runtime.cacheStats, {
+    config: {
+      resolutions: 1,
+    },
+    worldLoader: {
+      directoryScans: 2,
+      moduleLoads: 2,
+    },
+  })
+  assert.deepEqual(runtime.world.factories, ['user'])
+  assert.deepEqual(runtime.world.scenarios, ['signed-in-user'])
+
+  await runtime.lower()
 })
 
 test('resolveDatastore reports configuration errors with stable codes', () => {

--- a/test/world-loader.test.js
+++ b/test/world-loader.test.js
@@ -5,7 +5,41 @@ const os = require('node:os')
 const path = require('node:path')
 
 const { createWorldEngine } = require('../lib/create-world-engine')
-const { loadWorldFiles } = require('../lib/create-world-loader')
+const { createWorldLoaderCache, loadWorldFiles } = require('../lib/create-world-loader')
+
+let moduleTimestamp = Date.now()
+
+function writeModule(filePath, source, options = {}) {
+  fs.writeFileSync(filePath, source)
+
+  moduleTimestamp += 2000
+  const timestamp = new Date(moduleTimestamp)
+  fs.utimesSync(filePath, timestamp, timestamp)
+
+  if (options.touchDirectory) {
+    fs.utimesSync(path.dirname(filePath), timestamp, timestamp)
+  }
+}
+
+function createWorldLoadInput(tempRoot, cache) {
+  const world = createWorldEngine({ sails: {} })
+
+  return {
+    world,
+    input: {
+      world,
+      appPath: tempRoot,
+      config: {
+        world: {
+          factories: 'tests/factories',
+          scenarios: 'tests/scenarios',
+        },
+      },
+      sails: {},
+      cache,
+    },
+  }
+}
 
 test('loadWorldFiles discovers factory and scenario definitions from tests/', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-worlds-'))
@@ -45,6 +79,112 @@ test('loadWorldFiles discovers factory and scenario definitions from tests/', as
   const current = await world.use('issue-access')
   assert.equal(current.users.subscriber.role, 'subscriber')
   assert.match(current.users.subscriber.email, /^user\d+@example.com$/)
+})
+
+test('loadWorldFiles reuses cached directory scans and module loads for unchanged worlds', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-worlds-'))
+  const factoriesDir = path.join(tempRoot, 'tests', 'factories')
+  const scenariosDir = path.join(tempRoot, 'tests', 'scenarios')
+
+  fs.mkdirSync(factoriesDir, { recursive: true })
+  fs.mkdirSync(scenariosDir, { recursive: true })
+
+  for (let index = 0; index < 12; index += 1) {
+    writeModule(
+      path.join(factoriesDir, `entity-${index}.js`),
+      `module.exports = ({ factory }) => factory('entity${index}', { index: ${index} })\n`
+    )
+  }
+
+  for (let index = 0; index < 8; index += 1) {
+    writeModule(
+      path.join(scenariosDir, `scenario-${index}.js`),
+      `module.exports = ({ scenario }) => scenario('scenario${index}', () => ({ index: ${index} }))\n`
+    )
+  }
+
+  const cache = createWorldLoaderCache()
+  const first = createWorldLoadInput(tempRoot, cache)
+  const firstLoaded = await loadWorldFiles(first.input)
+
+  assert.equal(firstLoaded.length, 20)
+  assert.equal(cache.stats.directoryScans, 2)
+  assert.equal(cache.stats.moduleLoads, 20)
+  assert.equal(first.world.factories.length, 12)
+  assert.equal(first.world.scenarios.length, 8)
+
+  const second = createWorldLoadInput(tempRoot, cache)
+  const secondLoaded = await loadWorldFiles(second.input)
+
+  assert.equal(secondLoaded.length, 20)
+  assert.equal(cache.stats.directoryScans, 2)
+  assert.equal(cache.stats.moduleLoads, 20)
+  assert.deepEqual(second.world.build('entity4'), { index: 4 })
+})
+
+test('loadWorldFiles invalidates changed modules, changed directories, and explicit cache clears', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-worlds-'))
+  const factoriesDir = path.join(tempRoot, 'tests', 'factories')
+  const scenariosDir = path.join(tempRoot, 'tests', 'scenarios')
+  const userFactory = path.join(factoriesDir, 'user.js')
+
+  fs.mkdirSync(factoriesDir, { recursive: true })
+  fs.mkdirSync(scenariosDir, { recursive: true })
+
+  writeModule(
+    userFactory,
+    "module.exports = ({ factory }) => factory('user', { role: 'reader' })\n"
+  )
+  writeModule(
+    path.join(scenariosDir, 'member-access.js'),
+    "module.exports = ({ scenario }) => scenario('member-access', ({ build }) => ({ user: build('user') }))\n"
+  )
+
+  const cache = createWorldLoaderCache()
+  const first = createWorldLoadInput(tempRoot, cache)
+  await loadWorldFiles(first.input)
+
+  assert.equal(cache.stats.directoryScans, 2)
+  assert.equal(cache.stats.moduleLoads, 2)
+  assert.deepEqual(first.world.build('user'), { role: 'reader' })
+
+  const unchanged = createWorldLoadInput(tempRoot, cache)
+  await loadWorldFiles(unchanged.input)
+
+  assert.equal(cache.stats.directoryScans, 2)
+  assert.equal(cache.stats.moduleLoads, 2)
+
+  writeModule(
+    userFactory,
+    "module.exports = ({ factory }) => factory('user', { role: 'writer' })\n"
+  )
+
+  const changedModule = createWorldLoadInput(tempRoot, cache)
+  await loadWorldFiles(changedModule.input)
+
+  assert.equal(cache.stats.directoryScans, 2)
+  assert.equal(cache.stats.moduleLoads, 3)
+  assert.deepEqual(changedModule.world.build('user'), { role: 'writer' })
+
+  writeModule(
+    path.join(scenariosDir, 'admin-access.js'),
+    "module.exports = ({ scenario }) => scenario('admin-access', () => ({ role: 'admin' }))\n",
+    { touchDirectory: true }
+  )
+
+  const changedDirectory = createWorldLoadInput(tempRoot, cache)
+  await loadWorldFiles(changedDirectory.input)
+
+  assert.equal(cache.stats.directoryScans, 3)
+  assert.equal(cache.stats.moduleLoads, 4)
+  assert.deepEqual(changedDirectory.world.scenarios.sort(), ['admin-access', 'member-access'])
+
+  cache.clear()
+  const afterClear = createWorldLoadInput(tempRoot, cache)
+  await loadWorldFiles(afterClear.input)
+
+  assert.equal(cache.stats.directoryScans, 2)
+  assert.equal(cache.stats.moduleLoads, 3)
 })
 
 test('createWorldEngine builders merge overrides and keep withOnly available', async () => {

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -182,6 +182,9 @@ visit('/dashboard', {
 
 const runtime = createRuntime(fakeSails)
 runtime.configure()
+runtime.cacheStats.config.resolutions.toFixed()
+runtime.cacheStats.worldLoader.moduleLoads.toFixed()
+runtime.invalidateCaches()
 runtime.request.using('virtual').get('/runtime-health')
 runtime.boot({ mode: 'trial' }).then((booted) => {
   booted.request.using('http')


### PR DESCRIPTION
## Summary
- cache normalized runtime config until the Sounding config changes or caches are invalidated
- cache world directory scans and module loads across repeated runtime boots
- expose runtime cache stats and explicit cache invalidation

## Validation
- npm test
- npm run typecheck

Closes #41