### PR TITLE
feat: add concurrent trial isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The canonical Sails-native surface is:
 - Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
 - mail assertions can check captured emails with `expect(mailbox).toHaveSentMail({ to, subject })` and `expect(mailbox.latest()).toHaveCtaUrl(/magic-link/)`
 - a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`
+- independent trials can opt into concurrent execution with `test('...', { concurrent: true }, ...)` or `test.concurrent(...)`
 - any trial can also scope a request client with `sails.sounding.request.using('http')`
 
 Sounding also owns its own built-in world engine, so the same package can:
@@ -155,6 +156,30 @@ npx sounding test --coverage
 ```
 
 Use `--dry-run` to inspect the exact `node --test` command before running it.
+
+## Concurrent trials
+
+Sounding runs trials serially by default. That keeps shared Sails app state boring while request sessions, worlds, mailboxes, sockets, and browser sessions continue to reset between trials.
+
+Independent trials can opt into Node test concurrency:
+
+```js
+test.concurrent('health check is isolated', async ({ get, expect }) => {
+  const response = await get('/health')
+
+  expect(response).toHaveStatus(200)
+})
+
+test('dashboard contract is isolated too', { concurrent: true }, async ({ visit, expect }) => {
+  const page = await visit('/dashboard')
+
+  expect(page).toBeInertiaPage('dashboard/index')
+})
+```
+
+Concurrent Sounding trials bypass the global serial queue and receive isolated runtime state. Their request session, mailbox, world, sockets, and browser manager are separate from other concurrent trials. Managed SQLite datastore paths remain isolated by worker using `.tmp/db/<identity>/worker-<token>.db`, where the worker token comes from `SOUNDING_WORKER_INDEX`, `PLAYWRIGHT_WORKER_INDEX`, `TEST_WORKER_INDEX`, or the process id.
+
+Use concurrent mode for trials that do not mutate process-global app state. If you build a custom `createTestApi({ runtime })`, pass a runtime factory such as `() => createRuntime(sails)` for concurrent trials; a single shared runtime object stays serial-only.
 
 ## Typing and editor support
 

--- a/lib/create-mail-capture.js
+++ b/lib/create-mail-capture.js
@@ -1,8 +1,10 @@
 const path = require('node:path')
 const url = require('node:url')
 const { createSoundingError } = require('./create-error')
+const { getTrialContext } = require('./trial-context')
 
 const DEFAULT_MAIL_LAYOUT = 'mail'
+const mailCaptureRegistry = new WeakMap()
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingMailCapture} SoundingMailCapture */
@@ -247,18 +249,27 @@ function createMailCapture({ sails, mailbox, getConfig }) {
     return soundingConfig.mail || {}
   }
 
+  function resolveCaptureTarget() {
+    const context = getTrialContext()
+
+    return {
+      mailbox: context?.mailbox || mailbox,
+      mailSettings: context?.getConfig?.().mail || resolveMailSettings(),
+    }
+  }
+
   function isEnabled() {
     return resolveMailSettings().capture !== false
   }
 
   function shouldPassthrough() {
-    const settings = resolveMailSettings()
+    const settings = resolveCaptureTarget().mailSettings
     return settings.deliver === true || settings.mode === 'passthrough'
   }
 
   function resolveMessageLayout(inputs = {}) {
     return resolvePreviewLayout(sails, inputs, {
-      mailSettings: resolveMailSettings(),
+      mailSettings: resolveCaptureTarget().mailSettings,
     })
   }
 
@@ -361,16 +372,18 @@ function createMailCapture({ sails, mailbox, getConfig }) {
   }
 
   async function captureSuccessfulSend(inputs = {}) {
+    const target = resolveCaptureTarget()
+
     try {
       const message = await buildCapturedMail(sails, inputs, {
-        mailSettings: resolveMailSettings(),
+        mailSettings: target.mailSettings,
       })
-      mailbox.capture({
+      target.mailbox.capture({
         ...message,
         status: 'sent',
       })
     } catch (error) {
-      mailbox.capture({
+      target.mailbox.capture({
         mailer: resolveMailerName(sails, inputs),
         transport: resolveTransportName(sails, resolveMailerName(sails, inputs)),
         to: normalizeList(inputs.to),
@@ -384,11 +397,12 @@ function createMailCapture({ sails, mailbox, getConfig }) {
   }
 
   async function captureFailedSend(inputs = {}, error) {
+    const target = resolveCaptureTarget()
     let message
 
     try {
       message = await buildCapturedMail(sails, inputs, {
-        mailSettings: resolveMailSettings(),
+        mailSettings: target.mailSettings,
       })
     } catch (captureError) {
       message = {
@@ -402,7 +416,7 @@ function createMailCapture({ sails, mailbox, getConfig }) {
       }
     }
 
-    mailbox.capture({
+    target.mailbox.capture({
       ...message,
       status: 'failed',
       error: toErrorShape(error),
@@ -448,27 +462,60 @@ function createMailCapture({ sails, mailbox, getConfig }) {
       return false
     }
 
-    const sendHelper = sails?.helpers?.mail?.send
+    const mailHelpers = sails?.helpers?.mail
+    const sendHelper = mailHelpers?.send
     if (!sendHelper) {
       return false
     }
 
-    if (sendHelper.__soundingWrapped) {
-      originalSend = sendHelper.__soundingOriginal || originalSend
+    const registered = mailCaptureRegistry.get(mailHelpers) || sendHelper.__soundingRegistry
+    if (registered && sendHelper === registered.wrappedSend) {
+      registered.installs += 1
+      originalSend = registered.originalSend
+      mailCaptureRegistry.set(mailHelpers, registered)
       return true
     }
 
     originalSend = sendHelper
-    sails.helpers.mail.send = wrapSendHelper(sendHelper)
+    const wrappedSend = wrapSendHelper(sendHelper)
+    const registry = {
+      originalSend,
+      wrappedSend,
+      installs: 1,
+    }
+
+    Object.defineProperty(wrappedSend, '__soundingRegistry', {
+      value: registry,
+      configurable: true,
+    })
+
+    mailCaptureRegistry.set(mailHelpers, registry)
+    mailHelpers.send = wrappedSend
     return true
   }
 
   function uninstall() {
-    if (!originalSend || !sails?.helpers?.mail) {
+    const mailHelpers = sails?.helpers?.mail
+
+    if (!originalSend || !mailHelpers) {
       return false
     }
 
-    sails.helpers.mail.send = originalSend
+    const registered = mailCaptureRegistry.get(mailHelpers)
+
+    if (registered && registered.originalSend === originalSend) {
+      registered.installs -= 1
+
+      if (registered.installs <= 0) {
+        mailHelpers.send = originalSend
+        mailCaptureRegistry.delete(mailHelpers)
+      }
+
+      originalSend = null
+      return true
+    }
+
+    mailHelpers.send = originalSend
     originalSend = null
     return true
   }

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -1,6 +1,9 @@
 const nodeTest = require('node:test')
 const { createAppManager } = require('./create-app-manager')
 const { createExpect } = require('./create-expect')
+const { createRuntime } = require('./create-runtime')
+const { createSoundingError } = require('./create-error')
+const { runWithTrialContext } = require('./trial-context')
 const { normalizeTestArgs, splitTestOptions } = require('./validate-test-args')
 
 /** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
@@ -65,6 +68,140 @@ async function resolveRuntimeFromGlobals(options = {}) {
     sounding,
     teardown: async () => sounding.lower(),
   }
+}
+
+/**
+ * @param {{ http?: boolean, browser?: boolean, socket?: boolean }} [options]
+ * @returns {Promise<{ sounding: SoundingRuntime, teardown(): Promise<void> }>}
+ */
+async function resolveIsolatedRuntimeFromGlobals(options = {}) {
+  const requiresHttp = Boolean(options.http || options.browser || options.socket)
+  const httpServer = globalThis.sails?.hooks?.http?.server
+  const hasHttpServer = Boolean(
+    httpServer &&
+      (httpServer.listening ||
+        (typeof httpServer.address === 'function' && httpServer.address()))
+  )
+  let sails = null
+
+  if (globalThis.sails && (!requiresHttp || hasHttpServer)) {
+    sails = globalThis.sails
+  } else {
+    const appManager = getDefaultAppManager()
+    ensureDefaultAppManagerCleanup()
+    sails = requiresHttp ? await appManager.lift() : await appManager.load()
+  }
+
+  const sounding = createRuntime(sails)
+
+  return {
+    sounding,
+    teardown: async () => sounding.lower(),
+  }
+}
+
+/**
+ * @param {SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>) | undefined} runtime
+ * @param {SoundingTestOptions} options
+ * @returns {Promise<{ sounding: SoundingRuntime, teardown(): Promise<void>, isolated: boolean }>}
+ */
+async function resolveTrialRuntime(runtime, options = {}) {
+  const requires = {
+    http: options.transport === 'http',
+    browser: Boolean(options.browser),
+    socket: Boolean(options.socket),
+  }
+
+  if (typeof runtime === 'function') {
+    const sounding = await runtime()
+    return {
+      sounding,
+      teardown: async () => sounding.lower(),
+      isolated: Boolean(options.concurrent),
+    }
+  }
+
+  if (runtime) {
+    if (options.concurrent) {
+      throw createSoundingError({
+        code: 'E_SOUNDING_CONCURRENT_RUNTIME_SHARED',
+        name: 'SoundingConcurrencyError',
+        message:
+          'Sounding concurrent trials need isolated runtime state. Pass a runtime factory to createTestApi({ runtime: () => createRuntime(sails) }) or use the default app manager.',
+        details: {
+          suggestion:
+            'Use `concurrent: true` only when each trial receives its own Sounding runtime.',
+        },
+      })
+    }
+
+    return {
+      sounding: runtime,
+      teardown: async () => runtime.lower(),
+      isolated: false,
+    }
+  }
+
+  const resolved = options.concurrent
+    ? await resolveIsolatedRuntimeFromGlobals(requires)
+    : await resolveRuntimeFromGlobals(requires)
+
+  return {
+    ...resolved,
+    isolated: Boolean(options.concurrent),
+  }
+}
+
+/**
+ * @param {Record<string, any>} sails
+ * @param {SoundingRuntime} sounding
+ * @param {{ isolated?: boolean }} [options]
+ * @returns {Record<string, any>}
+ */
+function createTrialSails(sails, sounding, options = {}) {
+  if (!options.isolated) {
+    sails.sounding ||= sounding
+    sails.hooks ||= {}
+    sails.hooks.sounding ||= sounding
+    sails.helpers ||= sounding.helpers
+    return sails
+  }
+
+  const hooks = {
+    ...(sails.hooks || {}),
+    sounding,
+  }
+
+  return new Proxy(sails, {
+    get(target, property, receiver) {
+      if (property === 'sounding') {
+        return sounding
+      }
+
+      if (property === 'hooks') {
+        return hooks
+      }
+
+      if (property === 'helpers') {
+        return target.helpers || sounding.helpers
+      }
+
+      return Reflect.get(target, property, receiver)
+    },
+    set(target, property, value, receiver) {
+      if (property === 'sounding') {
+        return true
+      }
+
+      if (property === 'hooks') {
+        Object.assign(hooks, value || {})
+        hooks.sounding = sounding
+        return true
+      }
+
+      return Reflect.set(target, property, value, receiver)
+    },
+  })
 }
 
 /**
@@ -291,120 +428,118 @@ async function runInTrialQueue(handler) {
  * @returns {Promise<any>}
  */
 async function runTrial({ runtime, mode, title, nodeContext, handler, options = {} }) {
-  const activeRuntime = typeof runtime === 'function' ? await runtime() : runtime
-  const resolved = activeRuntime
-    ? {
-        sounding: activeRuntime,
-        teardown: async () => activeRuntime.lower(),
-      }
-    : await resolveRuntimeFromGlobals({
-        http: options.transport === 'http',
-        browser: Boolean(options.browser),
-        socket: Boolean(options.socket),
-      })
+  const resolved = await resolveTrialRuntime(runtime, options)
   const sounding = resolved.sounding
-  const booted = await sounding.boot({ mode })
-  const sails = booted.sails || {}
-  const worldOption = normalizeWorldOption(options.world)
-  const trialMetadata = {
-    ...(worldOption ? { world: worldOption } : {}),
-  }
-  let browserSession = null
 
-  try {
-    if (worldOption) {
-      await sounding.world.use(worldOption.name, worldOption.context)
-    }
+  return runWithTrialContext(
+    {
+      runtime: sounding,
+      mailbox: sounding.mailbox,
+      getConfig: () => sounding.config,
+    },
+    async () => {
+      const booted = await sounding.boot({ mode })
+      const sails = createTrialSails(booted.sails || {}, sounding, {
+        isolated: resolved.isolated,
+      })
+      const worldOption = normalizeWorldOption(options.world)
+      const trialMetadata = {
+        ...(worldOption ? { world: worldOption } : {}),
+      }
+      let browserSession = null
 
-    sails.sounding ||= sounding
-    sails.hooks ||= {}
-    sails.hooks.sounding ||= sounding
-    sails.helpers ||= sounding.helpers
+      try {
+        if (worldOption) {
+          await sounding.world.use(worldOption.name, worldOption.context)
+        }
 
-    const request = options.transport ? sounding.request.using(options.transport) : sounding.request
-    const visit = options.transport ? sounding.visit.using(options.transport) : sounding.visit
-    const socketOptions =
-      options.socket && typeof options.socket === 'object' ? options.socket : {}
-    const sockets =
-      options.socket && typeof options.socket === 'object'
-        ? {
-            connect(connectOptions = {}) {
-              return sounding.sockets.connect({
-                ...socketOptions,
-                ...connectOptions,
-              })
-            },
-            as(actor) {
-              return {
+        const request = options.transport ? sounding.request.using(options.transport) : sounding.request
+        const visit = options.transport ? sounding.visit.using(options.transport) : sounding.visit
+        const socketOptions =
+          options.socket && typeof options.socket === 'object' ? options.socket : {}
+        const sockets =
+          options.socket && typeof options.socket === 'object'
+            ? {
                 connect(connectOptions = {}) {
-                  return sounding.sockets.as(actor).connect({
+                  return sounding.sockets.connect({
                     ...socketOptions,
                     ...connectOptions,
                   })
                 },
+                as(actor) {
+                  return {
+                    connect(connectOptions = {}) {
+                      return sounding.sockets.as(actor).connect({
+                        ...socketOptions,
+                        ...connectOptions,
+                      })
+                    },
+                  }
+                },
+                closeAll() {
+                  return sounding.sockets.closeAll()
+                },
               }
-            },
-            closeAll() {
-              return sounding.sockets.closeAll()
-            },
-          }
-        : sounding.sockets
+            : sounding.sockets
 
-    if (options.browser) {
-      browserSession = await sounding.browser.open(
-        normalizeBrowserOpenOptions(options.browser, title)
-      )
+        if (options.browser) {
+          browserSession = await sounding.browser.open(
+            normalizeBrowserOpenOptions(options.browser, title)
+          )
+        }
+
+        /** @type {SoundingExpect} */
+        const expect = browserSession?.expect
+          ? createExpect.withFallback(browserSession.expect)
+          : /** @type {SoundingExpect} */ (createExpect)
+
+        /** @type {SoundingTrialContext} */
+        const context = {
+          ...nodeContext,
+          t: nodeContext,
+          expect,
+          sails,
+          request,
+          visit,
+          sockets,
+          auth: sounding.auth,
+          login: sounding.auth?.login,
+          world: sounding.world,
+          mailbox: sounding.mailbox,
+          browser: browserSession?.browser,
+          browserContext: browserSession?.context,
+          page: browserSession?.page,
+          get: /** @type {any} */ (bindRequestMethod(request, 'get')),
+          head: /** @type {any} */ (bindRequestMethod(request, 'head')),
+          post: /** @type {any} */ (bindRequestMethod(request, 'post')),
+          put: /** @type {any} */ (bindRequestMethod(request, 'put')),
+          patch: /** @type {any} */ (bindRequestMethod(request, 'patch')),
+          del: /** @type {any} */ (bindRequestMethod(request, 'delete')),
+        }
+
+        return await handler(context)
+      } catch (error) {
+        const browserArtifacts = await captureBrowserFailureArtifacts(browserSession)
+
+        throw decorateTrialError(error, {
+          ...trialMetadata,
+          browserArtifacts,
+        })
+      } finally {
+        await resolved.teardown()
+      }
     }
-
-    /** @type {SoundingExpect} */
-    const expect = browserSession?.expect
-      ? createExpect.withFallback(browserSession.expect)
-      : /** @type {SoundingExpect} */ (createExpect)
-
-    /** @type {SoundingTrialContext} */
-    const context = {
-      ...nodeContext,
-      t: nodeContext,
-      expect,
-      sails,
-      request,
-      visit,
-      sockets,
-      auth: sounding.auth,
-      login: sounding.auth?.login,
-      world: sounding.world,
-      mailbox: sounding.mailbox,
-      browser: browserSession?.browser,
-      browserContext: browserSession?.context,
-      page: browserSession?.page,
-      get: /** @type {any} */ (bindRequestMethod(request, 'get')),
-      head: /** @type {any} */ (bindRequestMethod(request, 'head')),
-      post: /** @type {any} */ (bindRequestMethod(request, 'post')),
-      put: /** @type {any} */ (bindRequestMethod(request, 'put')),
-      patch: /** @type {any} */ (bindRequestMethod(request, 'patch')),
-      del: /** @type {any} */ (bindRequestMethod(request, 'delete')),
-    }
-
-    return await handler(context)
-  } catch (error) {
-    const browserArtifacts = await captureBrowserFailureArtifacts(browserSession)
-
-    throw decorateTrialError(error, {
-      ...trialMetadata,
-      browserArtifacts,
-    })
-  } finally {
-    await resolved.teardown()
-  }
+  )
 }
 
 /**
  * @param {NodeTestLike} baseTest
  * @param {SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>) | undefined} runtime
  * @param {string} mode
+ * @param {boolean} [forceConcurrent]
  * @returns {SoundingTrialRegistrar}
  */
-function createTrialMethod(baseTest, runtime, mode, apiName = 'test') {
+function createTrialMethod(baseTest, runtime, mode, apiName = 'test', forceConcurrent = false) {
   const registerTrial = function registerTrial(title, optionsOrHandler, maybeHandler) {
     const { options, handler } = normalizeTestArgs(
       title,
@@ -412,10 +547,13 @@ function createTrialMethod(baseTest, runtime, mode, apiName = 'test') {
       maybeHandler,
       apiName
     )
-    const { nodeOptions, trialOptions } = splitTestOptions(options, apiName)
+    const nextOptions = forceConcurrent ? { ...options, concurrent: true } : options
+    const { nodeOptions, trialOptions } = splitTestOptions(nextOptions, apiName)
 
     return baseTest(title, nodeOptions, async (nodeContext) => {
-      return runInTrialQueue(async () => {
+      const run = trialOptions.concurrent ? (action) => action() : runInTrialQueue
+
+      return run(async () => {
         return runTrial({
           runtime,
           mode,
@@ -443,7 +581,9 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
     const { nodeOptions, trialOptions } = splitTestOptions(options, 'test')
 
     return baseTest(title, nodeOptions, async (nodeContext) => {
-      return runInTrialQueue(async () => {
+      const run = trialOptions.concurrent ? (action) => action() : runInTrialQueue
+
+      return run(async () => {
         return runTrial({
           runtime,
           mode: 'trial',
@@ -461,6 +601,7 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
   if (typeof baseTest.only === 'function') {
     soundingTest.only = createTrialMethod(baseTest.only.bind(baseTest), runtime, 'trial', 'test.only')
   }
+  soundingTest.concurrent = createTrialMethod(baseTest, runtime, 'trial', 'test.concurrent', true)
 
   // Temporary compatibility aliases while the public docs move fully to `test()`.
   soundingTest.helper = createTrialMethod(baseTest, runtime, 'helper', 'test.helper')

--- a/lib/trial-context.js
+++ b/lib/trial-context.js
@@ -1,0 +1,29 @@
+const { AsyncLocalStorage } = require('node:async_hooks')
+
+/** @typedef {import('./types').SoundingMailbox} SoundingMailbox */
+/** @typedef {import('./types').SoundingRuntime} SoundingRuntime */
+
+/** @type {AsyncLocalStorage<{ runtime?: SoundingRuntime, mailbox?: SoundingMailbox, getConfig?: () => any }>} */
+const trialContextStorage = new AsyncLocalStorage()
+
+/**
+ * @template T
+ * @param {{ runtime?: SoundingRuntime, mailbox?: SoundingMailbox, getConfig?: () => any }} context
+ * @param {() => T | Promise<T>} handler
+ * @returns {T | Promise<T>}
+ */
+function runWithTrialContext(context, handler) {
+  return trialContextStorage.run(context, handler)
+}
+
+/**
+ * @returns {{ runtime?: SoundingRuntime, mailbox?: SoundingMailbox, getConfig?: () => any } | null}
+ */
+function getTrialContext() {
+  return trialContextStorage.getStore() || null
+}
+
+module.exports = {
+  getTrialContext,
+  runWithTrialContext,
+}

--- a/lib/types.js
+++ b/lib/types.js
@@ -609,6 +609,8 @@
  *   browser?: boolean | string | SoundingBrowserOpenOptions,
  *   socket?: boolean | SoundingSocketConnectOptions,
  *   world?: SoundingTrialWorldOption,
+ *   concurrent?: boolean,
+ *   concurrency?: boolean | number,
  * }} SoundingTestOptions
  *
  * @typedef {AnyRecord & {
@@ -644,6 +646,7 @@
  *   skip(...args: any[]): unknown,
  *   todo(...args: any[]): unknown,
  *   only?: SoundingTrialRegistrar,
+ *   concurrent: SoundingTrialRegistrar,
  *   helper: SoundingTrialRegistrar,
  *   endpoint: SoundingTrialRegistrar,
  * }} SoundingTest

--- a/lib/validate-test-args.js
+++ b/lib/validate-test-args.js
@@ -384,6 +384,18 @@ function assertTrialOptions(options, apiName) {
     })
   }
 
+  if (options.concurrent !== undefined && typeof options.concurrent !== 'boolean') {
+    throw createTestArgumentError({
+      code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
+      message: `Sounding ${apiName} option \`concurrent\` must be a boolean.`,
+      apiName,
+      value: options.concurrent,
+      path: 'options.concurrent',
+      suggestion:
+        'Use `concurrent: true` only for trials that can run with isolated runtime state.',
+    })
+  }
+
   if (options.transport !== undefined && !ALLOWED_TRANSPORTS.includes(options.transport)) {
     throw createTestArgumentError({
       code: 'E_SOUNDING_TEST_OPTIONS_INVALID',
@@ -440,18 +452,24 @@ function normalizeTestArgs(title, optionsOrHandler, maybeHandler, apiName = 'tes
 function splitTestOptions(options = {}, apiName = 'test') {
   assertTrialOptions(options, apiName)
 
-  const { transport, browser, socket, world, ...nodeOptions } = options
+  const { transport, browser, socket, world, concurrent, ...nodeOptions } = options
+  const nodeConcurrency = nodeOptions.concurrency
+  const concurrentEnabled =
+    concurrent === true ||
+    nodeConcurrency === true ||
+    (typeof nodeConcurrency === 'number' && nodeConcurrency > 1)
 
   return {
     nodeOptions: {
-      concurrency: false,
       ...nodeOptions,
+      concurrency: concurrentEnabled ? nodeConcurrency ?? true : false,
     },
     trialOptions: {
       transport,
       browser,
       socket,
       world,
+      concurrent: concurrentEnabled,
     },
   }
 }

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -547,6 +547,19 @@ test('buildManagedSqlitePath uses the worker token by default', () => {
   assert.equal(filePath, '/tmp/default/worker-4.db')
 })
 
+test('buildManagedSqlitePath lets Sounding worker tokens isolate concurrent lanes', () => {
+  const filePath = buildManagedSqlitePath({
+    root: '/tmp',
+    identity: 'default',
+    env: {
+      SOUNDING_WORKER_INDEX: 'ci-2',
+      PLAYWRIGHT_WORKER_INDEX: '4',
+    },
+  })
+
+  assert.equal(filePath, '/tmp/default/worker-ci-2.db')
+})
+
 test('the hook exposes sails.sounding and sails.hooks.sounding', async () => {
   const sails = {
     config: {

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -1,7 +1,9 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const { setTimeout: delay } = require('node:timers/promises')
 
 const { createTestApi } = require('../lib/create-test-api')
+const { createRuntime } = require('../lib/create-runtime')
 
 test('test() boots the runtime and passes a Sails-native helper context', async () => {
   const calls = []
@@ -306,6 +308,226 @@ test('test() can auto-load a world before the trial handler', async () => {
     ['request:get', '/issues/first'],
     ['lower'],
   ])
+})
+
+test('test() can opt into concurrent isolated runtime factories', async () => {
+  const registrations = []
+  const seenRuntimeIds = []
+  let nextRuntimeId = 0
+  let activeBoots = 0
+  let maxActiveBoots = 0
+
+  function createIsolatedRuntime() {
+    nextRuntimeId += 1
+    const id = nextRuntimeId
+    const messages = []
+
+    return {
+      __id: id,
+      helpers: {},
+      world: {
+        use: async () => ({}),
+      },
+      mailbox: {
+        capture(message) {
+          messages.push(message)
+          return message
+        },
+        all() {
+          return [...messages]
+        },
+        latest() {
+          return messages.at(-1)
+        },
+        clear() {
+          messages.length = 0
+        },
+      },
+      request: {
+        transport: 'virtual',
+      },
+      visit: {
+        transport: 'virtual',
+      },
+      sockets: {},
+      auth: {
+        login: {},
+      },
+      async boot() {
+        activeBoots += 1
+        maxActiveBoots = Math.max(maxActiveBoots, activeBoots)
+        await delay(20)
+        return {
+          sails: {
+            config: {},
+          },
+        }
+      },
+      async lower() {
+        activeBoots -= 1
+      },
+    }
+  }
+
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({
+    baseTest,
+    runtime: createIsolatedRuntime,
+  })
+
+  soundingTest('concurrent explicit option', { concurrent: true }, async ({ sails, mailbox }) => {
+    seenRuntimeIds.push(sails.sounding.__id)
+    mailbox.capture({ subject: `trial-${sails.sounding.__id}` })
+    assert.equal(mailbox.all().length, 1)
+  })
+
+  soundingTest.concurrent('concurrent helper alias', async ({ sails, mailbox }) => {
+    seenRuntimeIds.push(sails.sounding.__id)
+    mailbox.capture({ subject: `trial-${sails.sounding.__id}` })
+    assert.equal(mailbox.all().length, 1)
+  })
+
+  assert.deepEqual(
+    registrations.map((registration) => registration.options),
+    [
+      {
+        concurrency: true,
+      },
+      {
+        concurrency: true,
+      },
+    ]
+  )
+
+  await Promise.all(registrations.map((registration) => registration.handler({})))
+
+  assert.equal(maxActiveBoots, 2)
+  assert.deepEqual(seenRuntimeIds.sort(), [1, 2])
+})
+
+test('test() rejects concurrent trials backed by one shared runtime object', async () => {
+  const registrations = []
+  const runtime = {
+    helpers: {},
+    world: {
+      use: async () => ({}),
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: {
+      transport: 'virtual',
+    },
+    async boot() {
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {},
+  }
+
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('shared runtime cannot run concurrently', { concurrent: true }, async () => {})
+
+  await assert.rejects(
+    () => registrations[0].handler({}),
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_CONCURRENT_RUNTIME_SHARED')
+      assert.match(error.message, /isolated runtime state/)
+      return true
+    }
+  )
+})
+
+test('test() routes captured mail to the active concurrent runtime mailbox', async () => {
+  const registrations = []
+  const sends = []
+  const send = {
+    with(inputs) {
+      sends.push(inputs.subject)
+      return Promise.resolve({})
+    },
+  }
+  const sails = {
+    config: {
+      appPath: process.cwd(),
+      datastores: {
+        default: {
+          adapter: 'sails-sqlite',
+          url: '.tmp/test.db',
+        },
+      },
+      sounding: {
+        datastore: 'inherit',
+        mail: {
+          capture: true,
+        },
+      },
+    },
+    models: {},
+    helpers: {
+      mail: {
+        send,
+      },
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({
+    baseTest,
+    runtime: () => createRuntime(sails),
+  })
+
+  soundingTest('captures first concurrent message', { concurrent: true }, async ({ sails, mailbox }) => {
+    await delay(10)
+    await sails.helpers.mail.send.with({
+      to: 'first@example.com',
+      subject: 'First concurrent message',
+    })
+
+    assert.equal(mailbox.latest().subject, 'First concurrent message')
+    assert.equal(mailbox.all().length, 1)
+  })
+
+  soundingTest('captures second concurrent message', { concurrent: true }, async ({ sails, mailbox }) => {
+    await sails.helpers.mail.send.with({
+      to: 'second@example.com',
+      subject: 'Second concurrent message',
+    })
+
+    assert.equal(mailbox.latest().subject, 'Second concurrent message')
+    assert.equal(mailbox.all().length, 1)
+  })
+
+  await Promise.all(registrations.map((registration) => registration.handler({})))
+
+  assert.deepEqual(sends, [])
+  assert.equal(sails.helpers.mail.send, send)
 })
 
 test('test() exposes socket helpers for socket-capable trials', async () => {
@@ -656,6 +878,19 @@ test('test() reports malformed trial arguments with stable codes', () => {
       assert.equal(error.value, 'socket')
       assert.deepEqual(error.allowed, ['virtual', 'http'])
       assert.match(error.suggestion, /Use `virtual`/)
+      return true
+    }
+  )
+
+  assert.throws(
+    () => {
+      soundingTest('bad concurrency option', { concurrent: 'yes' }, async () => {})
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_TEST_OPTIONS_INVALID')
+      assert.equal(error.path, 'options.concurrent')
+      assert.equal(error.value, 'yes')
+      assert.match(error.suggestion, /concurrent: true/)
       return true
     }
   )

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -309,6 +309,8 @@ test(
 
 test('world string options are typed from JSDoc', { world: 'signed-in-user' }, async () => {})
 
+test.concurrent('concurrent trial options are typed from JSDoc', { concurrent: true }, async () => {})
+
 // @ts-expect-error Trial options only support virtual and http transports.
 test('invalid transport options are caught by public JSDoc', { transport: 'ftp' }, async () => {})
 


### PR DESCRIPTION
## Summary
- add opt-in concurrent Sounding trials through `concurrent: true` and `test.concurrent`
- bypass the global serial queue only when trials use isolated runtime state
- route mail capture through per-trial async context so overlapping runtimes keep separate mailboxes
- document the serial default, worker datastore isolation, and custom runtime tradeoffs

## Validation
- npm test
- npm run typecheck

Closes #42