### PR TITLE
feat: expose app lifecycle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,37 @@ npx sounding test --coverage
 
 Use `--dry-run` to inspect the exact `node --test` command before running it.
 
+## App lifecycle
+
+Sounding keeps a warm Sails app by default. Virtual request trials load the app without opening an HTTP listener, while HTTP, socket, and browser-capable trials lift the app so the network stack exists.
+
+The app manager makes those lanes explicit:
+
+```js
+const { createAppManager } = require('sounding')
+
+const manager = createAppManager()
+
+const virtualRuntime = await manager.runtime({ app: 'load' })
+const httpRuntime = await manager.runtime({ app: 'lift' })
+const alsoHttpRuntime = await manager.runtime({ transport: 'http' })
+```
+
+Use the warm default for most suites. When a trial mutates process-global app state and needs a fresh Sails instance, force a reload:
+
+```js
+const freshRuntime = await manager.runtime({ app: 'load', reload: true })
+```
+
+Lifecycle timings are available for diagnostics:
+
+```js
+console.log(manager.lifecycle.load.durationMs)
+console.log(manager.lifecycle.lift.status)
+```
+
+Set `SOUNDING_LIFECYCLE=verbose` or `SOUNDING_DIAGNOSTICS=verbose` to print app load/lift timing messages while the suite runs.
+
 ## Concurrent trials
 
 Sounding runs trials serially by default. That keeps shared Sails app state boring while request sessions, worlds, mailboxes, sockets, and browser sessions continue to reset between trials.

--- a/lib/create-app-manager.js
+++ b/lib/create-app-manager.js
@@ -5,6 +5,7 @@ const { getDefaultConfig } = require('./default-config')
 const { mergeConfig } = require('./merge-config')
 const { normalizeUserConfig } = require('./normalize-config')
 const { buildManagedSqlitePath, resolveManagedRoot } = require('./resolve-datastore')
+const { createSoundingError } = require('./create-error')
 const { loadDependencyFromApp, resolveDependencyFromApp } = require('./resolve-dependency')
 const { validateConfig } = require('./validate-config')
 
@@ -190,6 +191,46 @@ function createOutputFilter(config = {}) {
 }
 
 /**
+ * @param {'load' | 'lift'} mode
+ * @returns {import('./types').SoundingAppLifecycleState}
+ */
+function createLifecycleState(mode) {
+  return {
+    mode,
+    status: 'idle',
+    runs: 0,
+    reuses: 0,
+    reloads: 0,
+    durationMs: null,
+    startedAt: null,
+    readyAt: null,
+    error: null,
+  }
+}
+
+/**
+ * @returns {boolean}
+ */
+function shouldReportLifecycle() {
+  return (
+    process.env.SOUNDING_LIFECYCLE === 'verbose' ||
+    process.env.SOUNDING_DIAGNOSTICS === 'verbose'
+  )
+}
+
+/**
+ * @param {string} message
+ * @returns {void}
+ */
+function reportLifecycle(message) {
+  if (!shouldReportLifecycle()) {
+    return
+  }
+
+  process.stderr.write(`[sounding] ${message}\n`)
+}
+
+/**
  * @param {SoundingConfig} config
  * @param {string} appPath
  * @returns {string | null}
@@ -228,6 +269,10 @@ function createAppManager({
   let liftPromise = null
   const managedArtifacts = new Set()
   let outputFilter = null
+  const lifecycle = {
+    load: createLifecycleState('load'),
+    lift: createLifecycleState('lift'),
+  }
 
   function resolveAppPath() {
     return path.resolve(appPath)
@@ -299,33 +344,198 @@ function createAppManager({
     }
   }
 
-  async function load() {
+  /**
+   * @param {SoundingSailsApp} app
+   * @returns {void}
+   */
+  function activateGlobalApp(app) {
+    globalThis.sails = app
+    globalThis.sounding = app.sounding || app.hooks?.sounding
+  }
+
+  /**
+   * @returns {void}
+   */
+  function syncGlobalApp() {
+    const activeApp = liftedApp || loadedApp
+
+    if (activeApp) {
+      activateGlobalApp(activeApp)
+      return
+    }
+
+    delete globalThis.sails
+    delete globalThis.sounding
+    outputFilter?.uninstall()
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @returns {void}
+   */
+  function recordLifecycleStart(mode) {
+    const entry = lifecycle[mode]
+    entry.status = 'loading'
+    entry.runs += 1
+    entry.error = null
+    entry.startedAt = new Date().toISOString()
+    entry.readyAt = null
+    entry.durationMs = null
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @param {number} startedAt
+   * @returns {void}
+   */
+  function recordLifecycleReady(mode, startedAt) {
+    const entry = lifecycle[mode]
+    entry.status = 'ready'
+    entry.durationMs = Date.now() - startedAt
+    entry.readyAt = new Date().toISOString()
+    reportLifecycle(`app ${mode} ready in ${entry.durationMs}ms`)
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @param {unknown} error
+   * @returns {void}
+   */
+  function recordLifecycleError(mode, error) {
+    const entry = lifecycle[mode]
+    entry.status = 'error'
+    entry.error = error instanceof Error ? error.message : String(error)
+    reportLifecycle(`app ${mode} failed: ${entry.error}`)
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @returns {void}
+   */
+  function recordLifecycleReuse(mode) {
+    const entry = lifecycle[mode]
+    entry.reuses += 1
+    reportLifecycle(`app ${mode} reused warm instance`)
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @returns {void}
+   */
+  function recordLifecycleReload(mode) {
+    lifecycle[mode].reloads += 1
+    reportLifecycle(`app ${mode} reload requested`)
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @returns {void}
+   */
+  function recordLifecycleIdle(mode) {
+    lifecycle[mode].status = 'idle'
+  }
+
+  /**
+   * @param {SoundingSailsApp} app
+   * @returns {Promise<void>}
+   */
+  async function lowerApp(app) {
+    await new Promise((resolve) => {
+      app.lower(() => resolve())
+    })
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @returns {Promise<void>}
+   */
+  async function lowerMode(mode) {
+    const app = mode === 'load' ? loadedApp : liftedApp
+
+    if (mode === 'load') {
+      loadedApp = null
+      loadPromise = null
+    } else {
+      liftedApp = null
+      liftPromise = null
+    }
+
+    if (app) {
+      await lowerApp(app)
+    }
+
+    recordLifecycleIdle(mode)
+    syncGlobalApp()
+  }
+
+  /**
+   * @param {'load' | 'lift'} mode
+   * @param {{ reload?: boolean }} [options]
+   * @returns {Promise<void>}
+   */
+  async function prepareReload(mode, options = {}) {
+    if (!options.reload) {
+      return
+    }
+
+    recordLifecycleReload(mode)
+
+    if (mode === 'load' && loadPromise) {
+      await loadPromise.catch(() => {})
+    }
+
+    if (mode === 'lift' && liftPromise) {
+      await liftPromise.catch(() => {})
+    }
+
+    await lowerMode(mode)
+  }
+
+  /**
+   * @returns {SoundingAppManager['lifecycle']}
+   */
+  function getLifecycleSnapshot() {
+    return {
+      load: { ...lifecycle.load },
+      lift: { ...lifecycle.lift },
+    }
+  }
+
+  async function load(options = {}) {
+    await prepareReload('load', options)
+
     if (loadedApp) {
+      activateGlobalApp(loadedApp)
+      recordLifecycleReuse('load')
       return loadedApp
     }
 
     if (loadPromise) {
+      recordLifecycleReuse('load')
       return loadPromise
     }
 
     const Sails = resolveSailsConstructor()
     const sailsApp = new Sails()
     const nextLoadOptions = buildOptions('load')
+    const startedAt = Date.now()
+    recordLifecycleStart('load')
     outputFilter?.install()
 
     loadPromise = new Promise((resolve, reject) => {
       sailsApp.load(nextLoadOptions, (error, loadedSails) => {
         if (error) {
           loadPromise = null
+          recordLifecycleError('load', error)
           cleanupManagedArtifacts().catch(() => {})
-          outputFilter?.uninstall()
+          syncGlobalApp()
           reject(error)
           return
         }
 
         loadedApp = loadedSails
-        globalThis.sails = loadedSails
-        globalThis.sounding = loadedSails.sounding
+        activateGlobalApp(loadedSails)
+        recordLifecycleReady('load', startedAt)
         resolve(loadedSails)
       })
     })
@@ -333,33 +543,41 @@ function createAppManager({
     return loadPromise
   }
 
-  async function lift() {
+  async function lift(options = {}) {
+    await prepareReload('lift', options)
+
     if (liftedApp) {
+      activateGlobalApp(liftedApp)
+      recordLifecycleReuse('lift')
       return liftedApp
     }
 
     if (liftPromise) {
+      recordLifecycleReuse('lift')
       return liftPromise
     }
 
     const Sails = resolveSailsConstructor()
     const sailsApp = new Sails()
     const nextLiftOptions = buildOptions('lift')
+    const startedAt = Date.now()
+    recordLifecycleStart('lift')
     outputFilter?.install()
 
     liftPromise = new Promise((resolve, reject) => {
       sailsApp.lift(nextLiftOptions, (error, liftedSails) => {
         if (error) {
           liftPromise = null
+          recordLifecycleError('lift', error)
           cleanupManagedArtifacts().catch(() => {})
-          outputFilter?.uninstall()
+          syncGlobalApp()
           reject(error)
           return
         }
 
         liftedApp = liftedSails
-        globalThis.sails = liftedSails
-        globalThis.sounding = liftedSails.sounding
+        activateGlobalApp(liftedSails)
+        recordLifecycleReady('lift', startedAt)
         resolve(liftedSails)
       })
     })
@@ -367,8 +585,33 @@ function createAppManager({
     return liftPromise
   }
 
+  function resolveRuntimeMode(options = {}) {
+    if (options.app !== undefined) {
+      if (options.app === 'load' || options.app === 'lift') {
+        return options.app
+      }
+
+      throw createSoundingError({
+        code: 'E_SOUNDING_APP_MODE_UNKNOWN',
+        name: 'SoundingAppLifecycleError',
+        message: `Sounding app lifecycle mode must be \`load\` or \`lift\`. Received \`${options.app}\`.`,
+        details: {
+          app: options.app,
+          allowed: ['load', 'lift'],
+        },
+      })
+    }
+
+    if (options.transport === 'http' || options.http) {
+      return 'lift'
+    }
+
+    return 'load'
+  }
+
   async function runtime(options = {}) {
-    const app = options.http ? await lift() : await load()
+    const mode = resolveRuntimeMode(options)
+    const app = mode === 'lift' ? await lift(options) : await load(options)
     return app.sounding || app.hooks?.sounding
   }
 
@@ -380,18 +623,13 @@ function createAppManager({
     loadPromise = null
     liftPromise = null
 
-    await Promise.all(
-      apps.map(
-        (app) =>
-          new Promise((resolve) => {
-            app.lower(() => resolve())
-          })
-      )
-    )
+    await Promise.all(apps.map((app) => lowerApp(app)))
 
     delete globalThis.sails
     delete globalThis.sounding
     outputFilter?.uninstall()
+    recordLifecycleIdle('load')
+    recordLifecycleIdle('lift')
     await cleanupManagedArtifacts()
   }
 
@@ -401,6 +639,9 @@ function createAppManager({
     runtime,
     lower,
     resolveConfig,
+    get lifecycle() {
+      return getLifecycleSnapshot()
+    },
   }
 }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -592,11 +592,27 @@
  * }} SoundingAppManagerOptions
  *
  * @typedef {{
- *   load(): Promise<SoundingSailsApp>,
- *   lift(): Promise<SoundingSailsApp>,
- *   runtime(options?: { http?: boolean }): Promise<SoundingRuntime>,
+ *   mode: 'load' | 'lift',
+ *   status: 'idle' | 'loading' | 'ready' | 'error',
+ *   runs: number,
+ *   reuses: number,
+ *   reloads: number,
+ *   durationMs: number | null,
+ *   startedAt: string | null,
+ *   readyAt: string | null,
+ *   error: string | null,
+ * }} SoundingAppLifecycleState
+ *
+ * @typedef {{
+ *   load(options?: { reload?: boolean }): Promise<SoundingSailsApp>,
+ *   lift(options?: { reload?: boolean }): Promise<SoundingSailsApp>,
+ *   runtime(options?: { http?: boolean, transport?: SoundingTransport, app?: 'load' | 'lift', reload?: boolean }): Promise<SoundingRuntime>,
  *   lower(): Promise<void>,
  *   resolveConfig(): SoundingConfig,
+ *   readonly lifecycle: {
+ *     load: SoundingAppLifecycleState,
+ *     lift: SoundingAppLifecycleState,
+ *   },
  * }} SoundingAppManager
  *
  * @typedef {string | {

--- a/test/app-manager.test.js
+++ b/test/app-manager.test.js
@@ -130,6 +130,113 @@ test('createAppManager loads consumer apps by default and disables shipwright fo
   await manager.lower()
 })
 
+test('createAppManager exposes explicit load, lift, reload, and lifecycle timing controls', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-app-manager-'))
+  fs.mkdirSync(path.join(tempRoot, 'config'), { recursive: true })
+  fs.writeFileSync(
+    path.join(tempRoot, 'config', 'sounding.js'),
+    "module.exports.sounding = { datastore: 'inherit', app: { environment: 'test' } }\n"
+  )
+
+  const loadCalls = []
+  const liftCalls = []
+  const lowerCalls = []
+
+  class FakeSails {
+    load(options, done) {
+      loadCalls.push(options)
+      this.config = { appPath: tempRoot }
+      this.sounding = {
+        id: `load-${loadCalls.length}`,
+        boot: async () => ({ sails: this }),
+        lower: async () => {},
+      }
+      this.hooks = { sounding: this.sounding }
+      done(undefined, this)
+    }
+
+    lift(options, done) {
+      liftCalls.push(options)
+      this.config = { appPath: tempRoot }
+      this.sounding = {
+        id: `lift-${liftCalls.length}`,
+        boot: async () => ({ sails: this }),
+        lower: async () => {},
+      }
+      this.hooks = { sounding: this.sounding }
+      done(undefined, this)
+    }
+
+    lower(done) {
+      lowerCalls.push(this.sounding.id)
+      done()
+    }
+  }
+
+  const manager = createAppManager({
+    appPath: tempRoot,
+    SailsConstructor: FakeSails,
+  })
+
+  const loadedRuntime = await manager.runtime({ app: 'load' })
+  const warmLoadedRuntime = await manager.runtime({ app: 'load' })
+
+  assert.equal(warmLoadedRuntime, loadedRuntime)
+  assert.equal(loadedRuntime.id, 'load-1')
+  assert.equal(loadCalls.length, 1)
+  assert.equal(manager.lifecycle.load.status, 'ready')
+  assert.equal(manager.lifecycle.load.runs, 1)
+  assert.equal(manager.lifecycle.load.reuses, 1)
+  assert.equal(typeof manager.lifecycle.load.durationMs, 'number')
+  assert.ok(manager.lifecycle.load.readyAt)
+  assert.equal(globalThis.sails.sounding.id, 'load-1')
+
+  const reloadedRuntime = await manager.runtime({ app: 'load', reload: true })
+
+  assert.equal(reloadedRuntime.id, 'load-2')
+  assert.notEqual(reloadedRuntime, loadedRuntime)
+  assert.equal(loadCalls.length, 2)
+  assert.deepEqual(lowerCalls, ['load-1'])
+  assert.equal(manager.lifecycle.load.reloads, 1)
+  assert.equal(globalThis.sails.sounding.id, 'load-2')
+
+  const liftedRuntime = await manager.runtime({ app: 'lift' })
+  const transportLiftedRuntime = await manager.runtime({ transport: 'http' })
+
+  assert.equal(liftedRuntime.id, 'lift-1')
+  assert.equal(transportLiftedRuntime, liftedRuntime)
+  assert.equal(liftCalls.length, 1)
+  assert.equal(manager.lifecycle.lift.status, 'ready')
+  assert.equal(manager.lifecycle.lift.runs, 1)
+  assert.equal(manager.lifecycle.lift.reuses, 1)
+  assert.equal(globalThis.sails.sounding.id, 'lift-1')
+
+  await manager.lower()
+
+  assert.deepEqual(lowerCalls.sort(), ['lift-1', 'load-1', 'load-2'].sort())
+  assert.equal(manager.lifecycle.load.status, 'idle')
+  assert.equal(manager.lifecycle.lift.status, 'idle')
+  assert.equal(globalThis.sails, undefined)
+  assert.equal(globalThis.sounding, undefined)
+})
+
+test('createAppManager reports unknown app lifecycle modes with a stable code', async () => {
+  const manager = createAppManager({
+    SailsConstructor: class FakeSails {},
+  })
+
+  await assert.rejects(
+    async () => {
+      await manager.runtime({ app: 'reload' })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_APP_MODE_UNKNOWN')
+      assert.deepEqual(error.allowed, ['load', 'lift'])
+      return true
+    }
+  )
+})
+
 test('createAppManager suppresses noisy app boot logs when quiet mode is enabled', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-app-quiet-'))
   fs.mkdirSync(path.join(tempRoot, 'config'), { recursive: true })

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -204,6 +204,14 @@ appManager.resolveConfig().request.transport = 'virtual'
 appManager.runtime({ http: true }).then((activeRuntime) => {
   activeRuntime.request.using('http')
 })
+appManager.runtime({ app: 'load', reload: true }).then((activeRuntime) => {
+  activeRuntime.request.using('virtual')
+})
+appManager.runtime({ transport: 'http' }).then((activeRuntime) => {
+  activeRuntime.request.using('http')
+})
+appManager.lifecycle.load.status.toUpperCase()
+appManager.lifecycle.lift.durationMs?.toFixed()
 
 const worldEngine = createWorldEngine({ sails: fakeSails })
 const userFactory = defineFactory('member', ({ sequence }) => ({


### PR DESCRIPTION
## Summary

- expose explicit `load`/`lift` app lifecycle modes plus `reload` support on the app manager
- track load/lift lifecycle state, reuse/reload counts, timings, and verbose lifecycle diagnostics
- document load vs lift behavior and cover the public API/type smoke paths

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`

Closes #44