### PR TITLE
feat!: remove compatibility aliases

### DIFF
--- a/lib/create-app-manager.js
+++ b/lib/create-app-manager.js
@@ -231,6 +231,31 @@ function reportLifecycle(message) {
 }
 
 /**
+ * @param {string} method
+ * @param {Record<string, any>} options
+ * @param {string[]} allowed
+ * @returns {void}
+ */
+function assertKnownAppManagerOptions(method, options, allowed) {
+  const unknown = Object.keys(options || {}).filter((key) => !allowed.includes(key))
+
+  if (unknown.length === 0) {
+    return
+  }
+
+  throw createSoundingError({
+    code: 'E_SOUNDING_APP_MANAGER_OPTION_UNKNOWN',
+    name: 'SoundingAppLifecycleError',
+    message: `Sounding app manager option \`${unknown[0]}\` is not supported for ${method}().`,
+    details: {
+      option: unknown[0],
+      allowed,
+      method,
+    },
+  })
+}
+
+/**
  * @param {SoundingConfig} config
  * @param {string} appPath
  * @returns {string | null}
@@ -502,6 +527,7 @@ function createAppManager({
   }
 
   async function load(options = {}) {
+    assertKnownAppManagerOptions('load', options, ['reload'])
     await prepareReload('load', options)
 
     if (loadedApp) {
@@ -544,6 +570,7 @@ function createAppManager({
   }
 
   async function lift(options = {}) {
+    assertKnownAppManagerOptions('lift', options, ['reload'])
     await prepareReload('lift', options)
 
     if (liftedApp) {
@@ -602,7 +629,7 @@ function createAppManager({
       })
     }
 
-    if (options.transport === 'http' || options.http) {
+    if (options.transport === 'http') {
       return 'lift'
     }
 
@@ -610,8 +637,10 @@ function createAppManager({
   }
 
   async function runtime(options = {}) {
+    assertKnownAppManagerOptions('runtime', options, ['app', 'transport', 'reload'])
     const mode = resolveRuntimeMode(options)
-    const app = mode === 'lift' ? await lift(options) : await load(options)
+    const lifecycleOptions = { reload: options.reload }
+    const app = mode === 'lift' ? await lift(lifecycleOptions) : await load(lifecycleOptions)
     return app.sounding || app.hooks?.sounding
   }
 

--- a/lib/create-runtime.js
+++ b/lib/create-runtime.js
@@ -230,11 +230,6 @@ function createRuntime(sails) {
       return helpers
     },
 
-    // Temporary compatibility alias while the DX settles.
-    get helper() {
-      return helpers
-    },
-
     get request() {
       return request
     },

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -41,12 +41,12 @@ function ensureDefaultAppManagerCleanup() {
 }
 
 /**
- * @param {{ http?: boolean, browser?: boolean, socket?: boolean }} [options]
+ * @param {{ requiresHttp?: boolean, browser?: boolean, socket?: boolean }} [options]
  * @returns {Promise<{ sounding: SoundingRuntime, teardown(): Promise<void> }>}
  */
 async function resolveRuntimeFromGlobals(options = {}) {
   const runtime = globalThis.sounding || globalThis.sails?.sounding || globalThis.sails?.hooks?.sounding
-  const requiresHttp = Boolean(options.http || options.browser || options.socket)
+  const requiresHttp = Boolean(options.requiresHttp || options.browser || options.socket)
   const httpServer = globalThis.sails?.hooks?.http?.server
   const hasHttpServer = Boolean(
     httpServer &&
@@ -63,7 +63,7 @@ async function resolveRuntimeFromGlobals(options = {}) {
 
   const appManager = getDefaultAppManager()
   ensureDefaultAppManagerCleanup()
-  const sounding = await appManager.runtime({ http: requiresHttp })
+  const sounding = await appManager.runtime({ app: requiresHttp ? 'lift' : 'load' })
   return {
     sounding,
     teardown: async () => sounding.lower(),
@@ -71,11 +71,11 @@ async function resolveRuntimeFromGlobals(options = {}) {
 }
 
 /**
- * @param {{ http?: boolean, browser?: boolean, socket?: boolean }} [options]
+ * @param {{ requiresHttp?: boolean, browser?: boolean, socket?: boolean }} [options]
  * @returns {Promise<{ sounding: SoundingRuntime, teardown(): Promise<void> }>}
  */
 async function resolveIsolatedRuntimeFromGlobals(options = {}) {
-  const requiresHttp = Boolean(options.http || options.browser || options.socket)
+  const requiresHttp = Boolean(options.requiresHttp || options.browser || options.socket)
   const httpServer = globalThis.sails?.hooks?.http?.server
   const hasHttpServer = Boolean(
     httpServer &&
@@ -107,7 +107,7 @@ async function resolveIsolatedRuntimeFromGlobals(options = {}) {
  */
 async function resolveTrialRuntime(runtime, options = {}) {
   const requires = {
-    http: options.transport === 'http',
+    requiresHttp: options.transport === 'http',
     browser: Boolean(options.browser),
     socket: Boolean(options.socket),
   }
@@ -602,10 +602,6 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
     soundingTest.only = createTrialMethod(baseTest.only.bind(baseTest), runtime, 'trial', 'test.only')
   }
   soundingTest.concurrent = createTrialMethod(baseTest, runtime, 'trial', 'test.concurrent', true)
-
-  // Temporary compatibility aliases while the public docs move fully to `test()`.
-  soundingTest.helper = createTrialMethod(baseTest, runtime, 'helper', 'test.helper')
-  soundingTest.endpoint = createTrialMethod(baseTest, runtime, 'endpoint', 'test.endpoint')
 
   return soundingTest
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -565,7 +565,6 @@
  *   readonly mailbox: SoundingMailbox,
  *   readonly world: SoundingWorldEngine,
  *   readonly helpers: SoundingHelperRunner,
- *   readonly helper: SoundingHelperRunner,
  *   readonly request: SoundingRequestClient,
  *   readonly visit: SoundingVisitClient,
  *   readonly sockets: SoundingSocketManager,
@@ -606,7 +605,7 @@
  * @typedef {{
  *   load(options?: { reload?: boolean }): Promise<SoundingSailsApp>,
  *   lift(options?: { reload?: boolean }): Promise<SoundingSailsApp>,
- *   runtime(options?: { http?: boolean, transport?: SoundingTransport, app?: 'load' | 'lift', reload?: boolean }): Promise<SoundingRuntime>,
+ *   runtime(options?: { transport?: SoundingTransport, app?: 'load' | 'lift', reload?: boolean }): Promise<SoundingRuntime>,
  *   lower(): Promise<void>,
  *   resolveConfig(): SoundingConfig,
  *   readonly lifecycle: {
@@ -663,8 +662,6 @@
  *   todo(...args: any[]): unknown,
  *   only?: SoundingTrialRegistrar,
  *   concurrent: SoundingTrialRegistrar,
- *   helper: SoundingTrialRegistrar,
- *   endpoint: SoundingTrialRegistrar,
  * }} SoundingTest
  *
  * @typedef {{

--- a/test/app-manager.test.js
+++ b/test/app-manager.test.js
@@ -123,7 +123,7 @@ test('createAppManager loads consumer apps by default and disables shipwright fo
   assert.equal(loadCalls[0].datastores, undefined)
   assert.equal(liftCalls.length, 0)
 
-  const liftedRuntime = await manager.runtime({ http: true })
+  const liftedRuntime = await manager.runtime({ app: 'lift' })
   assert.equal(liftedRuntime, runtime)
   assert.equal(liftCalls[0].environment, 'test')
 
@@ -220,10 +220,22 @@ test('createAppManager exposes explicit load, lift, reload, and lifecycle timing
   assert.equal(globalThis.sounding, undefined)
 })
 
-test('createAppManager reports unknown app lifecycle modes with a stable code', async () => {
+test('createAppManager reports unknown app lifecycle options and modes with stable codes', async () => {
   const manager = createAppManager({
     SailsConstructor: class FakeSails {},
   })
+
+  await assert.rejects(
+    async () => {
+      await manager.runtime({ http: true })
+    },
+    (error) => {
+      assert.equal(error.code, 'E_SOUNDING_APP_MANAGER_OPTION_UNKNOWN')
+      assert.equal(error.option, 'http')
+      assert.deepEqual(error.allowed, ['app', 'transport', 'reload'])
+      return true
+    }
+  )
 
   await assert.rejects(
     async () => {

--- a/test/fixture-app.integration.test.js
+++ b/test/fixture-app.integration.test.js
@@ -123,7 +123,7 @@ test('createAppManager can lift the real fixture app for HTTP request trials', a
     await manager.lower()
   })
 
-  const runtime = await manager.runtime({ http: true })
+  const runtime = await manager.runtime({ app: 'lift' })
   const booted = await runtime.boot({ mode: 'http' })
 
   const health = await booted.request.using('http').get('/api/health')

--- a/test/socket-manager.test.js
+++ b/test/socket-manager.test.js
@@ -43,7 +43,7 @@ test('createSocketManager exercises Sails socket requests and room broadcasts', 
     await manager.lower()
   })
 
-  const runtime = await manager.runtime({ http: true })
+  const runtime = await manager.runtime({ app: 'lift' })
   const booted = await runtime.boot({ mode: 'socket' })
 
   const member = await booted.sockets.connect()

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -201,9 +201,6 @@ const appManager = createAppManager({
   },
 })
 appManager.resolveConfig().request.transport = 'virtual'
-appManager.runtime({ http: true }).then((activeRuntime) => {
-  activeRuntime.request.using('http')
-})
 appManager.runtime({ app: 'load', reload: true }).then((activeRuntime) => {
   activeRuntime.request.using('virtual')
 })
@@ -288,7 +285,7 @@ loadWorldFiles({
 }).then((loadedFiles) => loadedFiles.map((filePath) => filePath.toUpperCase()))
 
 const localTest = createTestApi({ runtime: () => runtime })
-localTest.endpoint('typed endpoint alias', async ({ get, expect }) => {
+localTest('typed trial', async ({ get, expect }) => {
   const response = await get('/health')
   expect(response).toHaveStatus(200)
 })


### PR DESCRIPTION
## Summary

- remove the `createAppManager().runtime({ http: true })` lift shortcut and reject unknown app-manager options with a stable error
- remove temporary `runtime.helper`, `test.helper`, and `test.endpoint` compatibility aliases from the public surface
- update internal callers, public typedefs, smoke coverage, and tests to use the current explicit API

## Audit Notes

Searched for compatibility-only aliases and legacy shims across README, lib, test, and typecheck. Remaining `alias`/`legacy` hits are current domain features or rejection diagnostics, not old API shapes kept alive.

## Validation

- `npm test`
- `npm run typecheck`
- `git diff --check`

Closes #79