### PR TITLE
docs: document HTTP upload trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The canonical Sails-native surface is:
 - Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
 - mail assertions can check captured emails with `expect(mailbox).toHaveSentMail({ to, subject })` and `expect(mailbox.latest()).toHaveCtaUrl(/magic-link/)`
 - a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`
+- upload trials use `FormData` over the HTTP transport so Sails can exercise real Skipper streams
 - independent trials can opt into concurrent execution with `test('...', { concurrent: true }, ...)` or `test.concurrent(...)`
 - any trial can also scope a request client with `sails.sounding.request.using('http')`
 
@@ -96,6 +97,44 @@ module.exports.sounding = {
 ```
 
 If you intentionally want Sounding during another boot path, widen the list explicitly, for example `['test', 'console']` or `['test', 'production']`.
+
+## Upload trials
+
+Use HTTP request trials for Sails file uploads. Uploads in Sails are streaming
+Skipper requests, so they need the HTTP stack that Sails uses for real multipart
+forms.
+
+```js
+const { test } = require('sounding')
+
+test(
+  'creator can upload a receipt',
+  { transport: 'http' },
+  async ({ request, expect }) => {
+    const form = new FormData()
+
+    form.append('description', 'Home office monitor')
+    form.append('amount', '1200')
+    form.append(
+      'receipt',
+      new Blob(['receipt bytes'], { type: 'application/pdf' }),
+      'receipt.pdf'
+    )
+
+    const response = await request.post('/expenses', form)
+
+    expect(response).toRedirectTo('/expenses/new')
+  }
+)
+```
+
+When a multipart form mixes text fields and files, append the text fields before
+the files. That matches Sails and Skipper's streaming model, where actions can
+start while file streams are still arriving.
+
+Do not use the virtual transport for upload behavior. Virtual requests are still
+right for normal endpoints, JSON APIs, session assertions, redirects, and
+Inertia contracts, but real `req.file()` uploads are HTTP-only in Sails.
 
 ## Project init
 

--- a/test/fixture-app.integration.test.js
+++ b/test/fixture-app.integration.test.js
@@ -1,5 +1,6 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
 const net = require('node:net')
 const path = require('node:path')
 
@@ -112,6 +113,7 @@ test('createAppManager exercises a real Sails fixture app through the Sounding r
 
 test('createAppManager can lift the real fixture app for HTTP request trials', async (t) => {
   const port = await getFreePort()
+  const uploadDir = path.join(fixtureAppPath, '.tmp', 'sounding-fixture-uploads')
   const manager = createAppManager({
     appPath: fixtureAppPath,
     liftOptions: {
@@ -121,6 +123,7 @@ test('createAppManager can lift the real fixture app for HTTP request trials', a
 
   t.after(async () => {
     await manager.lower()
+    fs.rmSync(uploadDir, { recursive: true, force: true })
   })
 
   const runtime = await manager.runtime({ app: 'lift' })
@@ -130,6 +133,28 @@ test('createAppManager can lift the real fixture app for HTTP request trials', a
   assert.equal(health.status, 200)
   assert.equal(health.data.ok, true)
   assert.equal(health.session, undefined)
+
+  const form = new FormData()
+  form.append('displayName', 'Ada Lovelace')
+  form.append(
+    'avatar',
+    new Blob(['hello upload'], { type: 'text/plain' }),
+    'avatar.txt'
+  )
+
+  const upload = await booted.request
+    .using('http')
+    .post('/api/uploads/avatar', form)
+  assert.equal(upload.status, 200)
+  assert.deepEqual(upload.data.body, {
+    displayName: 'Ada Lovelace',
+  })
+  assert.equal(upload.data.files.length, 1)
+  assert.equal(upload.data.files[0].field, 'avatar')
+  assert.equal(upload.data.files[0].filename, 'avatar.txt')
+  assert.equal(upload.data.files[0].size, 12)
+  assert.equal(upload.data.files[0].type, 'text/plain')
+  assert.equal(fs.readFileSync(upload.data.files[0].fd, 'utf8'), 'hello upload')
 
   await runtime.lower()
 })

--- a/test/fixtures/sails-app/config/routes.js
+++ b/test/fixtures/sails-app/config/routes.js
@@ -1,3 +1,5 @@
+const path = require('node:path')
+
 async function resolveSessionUser(req) {
   if (req.session.userId) {
     const user = await req._sails.models.user.findOne({ id: req.session.userId })
@@ -70,6 +72,34 @@ module.exports.routes = {
       email: user.email,
       fullName: user.fullName,
     })
+  },
+
+  'POST /api/uploads/avatar': function uploadAvatar(req, res) {
+    req.file('avatar').upload(
+      {
+        dirname: path.join(
+          req._sails.config.appPath,
+          '.tmp',
+          'sounding-fixture-uploads'
+        ),
+      },
+      (error, files) => {
+        if (error) {
+          return res.serverError(error)
+        }
+
+        return res.json({
+          body: req.body,
+          files: files.map((file) => ({
+            fd: file.fd,
+            field: file.field,
+            filename: file.filename,
+            size: file.size,
+            type: file.type,
+          })),
+        })
+      }
+    )
   },
 
   'GET /api/socket-health': function socketHealth(req, res) {


### PR DESCRIPTION
## What changed

- Documented Sails upload testing as an HTTP-only Sounding lane using `FormData`.
- Added a fixture route that exercises real Skipper `req.file('avatar').upload(...)` behavior.
- Added integration coverage proving `request.using('http').post(..., formData)` sends text fields and file streams through the real Sails HTTP stack.

## Why

Issue #47 was broader than the current reality. Sockets already have first-class Sounding helpers, and jobs/webhooks/payments are better owned by their domain hooks or docs for now. Uploads are the one lane worth grounding because Sails file uploads require Skipper's HTTP streaming path.

This keeps Sounding honest: no virtual upload magic, no new helper API until real app tests prove the current `FormData` shape is too noisy.

## Validation

- `node --test test/fixture-app.integration.test.js`
- `npm test`
- `npm run typecheck`

Closes #47