### PR TITLE
feat: add pretty sounding reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,31 @@ npx sounding test --json
 npx sounding test --coverage
 ```
 
+When no reporter is specified, `sounding test` uses Sounding's readable reporter. Failed response assertions group the request, response, body, file location, and code frame so the behavior is visible without digging through a raw stack trace. Use `--verbose` when you want full stacks and expanded Sounding diagnostics:
+
+```sh
+npx sounding test --verbose
+```
+
+Use `--raw-error` or `SOUNDING_RAW=1` when the formatted view hides something important. Raw mode keeps the pretty failure first, then prints the original Node test error, its `cause`, Sounding metadata, and the primary frame payload:
+
+```sh
+npx sounding test --raw-error
+```
+
 Use `--dry-run` to inspect the exact `node --test` command before running it.
+
+The repository includes an intentionally failing reporter fixture that is useful for before/after screenshots:
+
+```sh
+node ./bin/sounding.js test --app examples/pretty-output-demo
+```
+
+There is also a small passing fixture for successful-output screenshots:
+
+```sh
+node ./bin/sounding.js test --app examples/pretty-output-success
+```
 
 ## App lifecycle
 

--- a/bin/sounding.js
+++ b/bin/sounding.js
@@ -34,8 +34,11 @@ Options:
   --lane <name>                  Run tests under tests/<name> or test/<name>.
   --changed                      Run changed .test.js files when git metadata is available.
   --watch                        Forward to Node watch mode.
-  --reporter <name>              Forward to --test-reporter.
+  --reporter <name>              Use a Node reporter, or "sounding" for Sounding output.
   --reporter-destination <path>  Forward to --test-reporter-destination.
+  --compact                      Keep Sounding reporter output failure-focused.
+  --verbose                      Show full stacks and verbose Sounding diagnostics.
+  --raw-error                    Show raw Node/Sounding error details after formatted failures.
   --junit [path]                 Use the junit reporter.
   --json                         Use the json reporter.
   --coverage                     Enable Node test coverage.

--- a/examples/pretty-output-demo/README.md
+++ b/examples/pretty-output-demo/README.md
@@ -1,0 +1,16 @@
+# Pretty Output Demo
+
+This fixture intentionally fails so Sounding's test reporter can be photographed
+and compared before/after reporter work.
+
+Run it from the repository root:
+
+```sh
+node ./bin/sounding.js test --app examples/pretty-output-demo
+```
+
+To compare against raw Node output:
+
+```sh
+node --test examples/pretty-output-demo/tests/billing.test.js
+```

--- a/examples/pretty-output-demo/tests/billing.test.js
+++ b/examples/pretty-output-demo/tests/billing.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test')
+const { createExpect: expect } = require('../../..')
+
+test('creator sees billing summary', () => {
+  const response = {
+    status: 500,
+    statusText: 'Server Error',
+    headers: {
+      'content-type': 'application/json',
+    },
+    data: {
+      message: 'boom',
+    },
+    request: {
+      method: 'GET',
+      target: '/api/billing/summary',
+      transport: 'http',
+      url: 'http://localhost:1337/api/billing/summary',
+      headers: {
+        accept: 'application/json',
+      },
+    },
+  }
+
+  expect(response).toHaveStatus(200)
+})

--- a/examples/pretty-output-success/README.md
+++ b/examples/pretty-output-success/README.md
@@ -1,0 +1,10 @@
+# Pretty Output Success Demo
+
+This fixture passes so Sounding's successful test output can be photographed
+without running the full suite.
+
+Run it from the repository root:
+
+```sh
+node ./bin/sounding.js test --app examples/pretty-output-success
+```

--- a/examples/pretty-output-success/tests/arch.test.js
+++ b/examples/pretty-output-success/tests/arch.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test')
+const { createExpect: expect } = require('../../..')
+
+test('request helpers stay response-shaped', () => {
+  expect({
+    status: 200,
+    data: {
+      ok: true,
+    },
+  }).toHaveStatus(200)
+})
+
+test('JSON paths read like product facts', () => {
+  expect({
+    data: {
+      billing: {
+        plan: 'pro',
+      },
+    },
+  }).toHaveJsonPath('billing.plan', 'pro')
+})

--- a/lib/sounding-reporter.js
+++ b/lib/sounding-reporter.js
@@ -1,0 +1,907 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const INTERNAL_FRAME_PATTERN = /(?:^|\/)(?:node:internal|internal\/|node_modules\/internal)/
+
+function supportsColor() {
+  if (process.env.NO_COLOR || process.env.FORCE_COLOR === '0') {
+    return false
+  }
+
+  return Boolean(process.env.FORCE_COLOR || process.stdout.isTTY)
+}
+
+function colorize(enabled, code, value) {
+  return enabled ? `\u001b[${code}m${value}\u001b[0m` : value
+}
+
+function createTheme() {
+  const color = supportsColor()
+
+  return {
+    color,
+    red(value) {
+      return colorize(color, '31', value)
+    },
+    green(value) {
+      return colorize(color, '32', value)
+    },
+    dim(value) {
+      return colorize(color, '2', value)
+    },
+    bold(value) {
+      return colorize(color, '1', value)
+    },
+    cyan(value) {
+      return colorize(color, '36', value)
+    },
+    passBadge(value) {
+      return color ? colorize(color, '30;42;1', ` ${value} `) : value
+    },
+    failBadge(value) {
+      return color ? colorize(color, '30;41;1', ` ${value} `) : value
+    },
+  }
+}
+
+function isVerbose() {
+  return process.env.SOUNDING_REPORTER_VERBOSE === '1' || process.env.SOUNDING_DIAGNOSTICS === 'verbose'
+}
+
+function isCompact() {
+  return process.env.SOUNDING_REPORTER_COMPACT === '1'
+}
+
+function isRaw() {
+  return process.env.SOUNDING_RAW === '1' || process.env.SOUNDING_RAW_ERROR === '1'
+}
+
+function shouldListPassedTests(summary) {
+  if (isCompact()) {
+    return false
+  }
+
+  if (isVerbose() || process.env.SOUNDING_REPORTER_LIST === '1') {
+    return true
+  }
+
+  return (summary?.counts?.tests || 0) <= 12
+}
+
+function formatDuration(durationMs) {
+  if (typeof durationMs !== 'number' || Number.isNaN(durationMs)) {
+    return ''
+  }
+
+  if (durationMs < 1000) {
+    return `${Math.round(durationMs)}ms`
+  }
+
+  return `${(durationMs / 1000).toFixed(2)}s`
+}
+
+function safeRealpath(filePath) {
+  try {
+    return fs.realpathSync(filePath)
+  } catch (_error) {
+    return filePath
+  }
+}
+
+function isInside(filePath, directory) {
+  const relative = path.relative(directory, filePath)
+  return Boolean(relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+function normalizeFileUrl(value) {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  if (!value.startsWith('file://')) {
+    return value
+  }
+
+  try {
+    return new URL(value).pathname
+  } catch (_error) {
+    return value
+  }
+}
+
+function isObject(value) {
+  return Boolean(value && typeof value === 'object')
+}
+
+function parseStackFrames(stack) {
+  if (!stack) {
+    return []
+  }
+
+  return String(stack)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .map((line) => {
+      const parenMatch = line.match(/\((.*):(\d+):(\d+)\)$/)
+      const plainMatch = parenMatch ? null : line.match(/at (.*):(\d+):(\d+)$/)
+      const match = parenMatch || plainMatch
+
+      if (!match) {
+        return null
+      }
+
+      return {
+        file: normalizeFileUrl(match[1]),
+        line: Number(match[2]),
+        column: Number(match[3]),
+      }
+    })
+    .filter(Boolean)
+}
+
+function getOriginalError(data) {
+  return data?.details?.error
+}
+
+function getFailureError(data) {
+  const error = data?.details?.error
+  return error?.cause && typeof error.cause === 'object' ? error.cause : error
+}
+
+function getErrorObjects(error) {
+  const errors = []
+  const seen = new Set()
+  let current = error
+
+  while (isObject(current) && !seen.has(current)) {
+    seen.add(current)
+    errors.push(current)
+    current = current.cause
+  }
+
+  return errors
+}
+
+function resolveFailureLocation(data) {
+  const originalError = getOriginalError(data)
+  const error = getFailureError(data)
+  const root = safeRealpath(process.cwd())
+  const frames = [
+    ...parseStackFrames(error?.stack),
+    ...(originalError && originalError !== error ? parseStackFrames(originalError.stack) : []),
+  ]
+  const userFrame = frames.find((frame) => {
+    if (!frame.file || INTERNAL_FRAME_PATTERN.test(frame.file)) {
+      return false
+    }
+
+    return isInside(safeRealpath(frame.file), root)
+  })
+
+  if (userFrame) {
+    return userFrame
+  }
+
+  return {
+    file: data.file,
+    line: data.line,
+    column: data.column,
+  }
+}
+
+function formatPath(filePath) {
+  if (!filePath) {
+    return ''
+  }
+
+  const relative = path.relative(process.cwd(), filePath)
+
+  if (relative && !relative.startsWith('..') && !path.isAbsolute(relative)) {
+    return relative.split(path.sep).join('/')
+  }
+
+  return filePath
+}
+
+function indentLines(value, prefix = '  ') {
+  return String(value)
+    .split(/\r?\n/)
+    .map((line) => `${prefix}${line}`)
+    .join('\n')
+}
+
+function stripTrailingBlankLines(value) {
+  return String(value).replace(/\s+$/g, '')
+}
+
+function splitMarkedBlock(message, marker) {
+  const index = message.indexOf(marker)
+
+  if (index === -1) {
+    return {
+      before: stripTrailingBlankLines(message),
+      lines: [],
+    }
+  }
+
+  return {
+    before: stripTrailingBlankLines(message.slice(0, index)),
+    lines: message
+      .slice(index + marker.length)
+      .split(/\r?\n/)
+      .map((line) => line.replace(/^- /, '').trim())
+      .filter(Boolean),
+  }
+}
+
+function parseSoundingDiagnostics(message) {
+  const marker = '\n\nSounding response diagnostics:\n'
+  const block = splitMarkedBlock(message, marker)
+
+  if (block.lines.length === 0) {
+    return {
+      message: stripTrailingBlankLines(message),
+      diagnostics: null,
+    }
+  }
+
+  const diagnostics = {}
+
+  for (const line of block.lines) {
+    const separatorIndex = line.indexOf(':')
+
+    if (separatorIndex === -1) {
+      continue
+    }
+
+    const key = line.slice(0, separatorIndex)
+    const value = line.slice(separatorIndex + 1).trim()
+    diagnostics[key] = value
+  }
+
+  return {
+    message: block.before,
+    diagnostics,
+  }
+}
+
+function parseBrowserArtifactDiagnostics(message) {
+  const block = splitMarkedBlock(message, '\n\nSounding browser artifacts:\n')
+
+  if (block.lines.length === 0) {
+    return {
+      message: stripTrailingBlankLines(message),
+      browserArtifacts: null,
+    }
+  }
+
+  const browserArtifacts = {
+    errors: [],
+  }
+
+  for (const line of block.lines) {
+    const separatorIndex = line.indexOf(':')
+
+    if (separatorIndex === -1) {
+      continue
+    }
+
+    const key = line.slice(0, separatorIndex).trim()
+    const value = line.slice(separatorIndex + 1).trim()
+
+    if (key === 'URL') {
+      browserArtifacts.currentUrl = value
+    } else if (key === 'current URL file') {
+      browserArtifacts.currentUrlPath = value
+    } else if (key === 'screenshot') {
+      browserArtifacts.screenshot = value
+    } else if (key === 'trace') {
+      browserArtifacts.trace = value
+    } else if (key === 'video') {
+      browserArtifacts.video = value
+    } else if (key.endsWith(' capture failed')) {
+      browserArtifacts.errors.push({
+        artifact: key.replace(/ capture failed$/, ''),
+        message: value,
+      })
+    }
+  }
+
+  return {
+    message: block.before,
+    browserArtifacts,
+  }
+}
+
+function formatMetadataValue(value) {
+  if (value === undefined || value === null || value === '') {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  try {
+    return JSON.stringify(value)
+  } catch (_error) {
+    return String(value)
+  }
+}
+
+function createMetadataRow(label, value) {
+  const formatted = formatMetadataValue(value)
+
+  if (!formatted) {
+    return null
+  }
+
+  return {
+    label,
+    value: formatted,
+  }
+}
+
+function hasRows(section) {
+  return section?.rows?.length > 0
+}
+
+function createMetadataGroups(input) {
+  const diagnostics = input?.diagnostics
+  const sounding = input?.sounding && typeof input.sounding === 'object' ? input.sounding : {}
+  const browserArtifacts = input?.browserArtifacts || sounding.browserArtifacts
+  const groups = []
+
+  if (sounding.world) {
+    const worldRows = [
+      createMetadataRow('scenario', sounding.world.name || sounding.world.scenario),
+      createMetadataRow('actor', sounding.world.actor),
+      createMetadataRow(
+        'context',
+        sounding.world.context && Object.keys(sounding.world.context).length > 0
+          ? sounding.world.context
+          : null
+      ),
+    ].filter(Boolean)
+
+    if (worldRows.length > 0) {
+      groups.push({
+        title: 'World',
+        sections: [
+          {
+            rows: worldRows,
+          },
+        ],
+      })
+    }
+  }
+
+  if (diagnostics) {
+    const requestRows = [
+      createMetadataRow(null, diagnostics.Request || diagnostics.URL),
+      createMetadataRow('headers', diagnostics['Request headers']),
+    ].filter(Boolean)
+    const responseRows = [
+      createMetadataRow(null, diagnostics.Response),
+      createMetadataRow('headers', diagnostics.Headers),
+    ].filter(Boolean)
+    const bodyRows = [createMetadataRow(null, diagnostics.Body)].filter(Boolean)
+
+    if (requestRows.length > 0) {
+      groups.push({
+        title: 'Request',
+        sections: [
+          {
+            rows: requestRows,
+          },
+        ],
+      })
+    }
+
+    if (responseRows.length > 0) {
+      groups.push({
+        title: 'Response',
+        sections: [
+          {
+            rows: responseRows,
+          },
+        ],
+      })
+    }
+
+    if (bodyRows.length > 0) {
+      groups.push({
+        title: 'Body',
+        sections: [
+          {
+            rows: bodyRows,
+          },
+        ],
+      })
+    }
+  }
+
+  if (browserArtifacts) {
+    const errorRows = (browserArtifacts.errors || [])
+      .map((error) => createMetadataRow(`${error.artifact} error`, error.message))
+      .filter(Boolean)
+    const browserRows = [
+      createMetadataRow('project', browserArtifacts.project),
+      createMetadataRow('trial', browserArtifacts.trialName),
+      createMetadataRow('url', browserArtifacts.currentUrl),
+      createMetadataRow('current URL file', browserArtifacts.currentUrlPath),
+      createMetadataRow('screenshot', browserArtifacts.screenshot),
+      createMetadataRow('trace', browserArtifacts.trace),
+      createMetadataRow('video', browserArtifacts.video),
+      ...errorRows,
+    ].filter(Boolean)
+
+    if (browserRows.length > 0) {
+      groups.push({
+        title: 'Browser',
+        sections: [
+          {
+            rows: browserRows,
+          },
+        ],
+      })
+    }
+  }
+
+  return groups
+}
+
+function formatMetadataGroups(groups, theme) {
+  const renderedGroups = []
+
+  for (const group of groups || []) {
+    const lines = [`  ${theme.bold(group.title)}`]
+
+    for (const section of group.sections || []) {
+      if (!hasRows(section)) {
+        continue
+      }
+
+      if (section.title) {
+        lines.push(`    ${theme.dim(section.title)}`)
+      }
+
+      for (const row of section.rows) {
+        if (row.label) {
+          lines.push(`    ${theme.dim(`${row.label}:`)} ${row.value}`)
+        } else {
+          lines.push(`    ${row.value}`)
+        }
+      }
+    }
+
+    if (lines.length > 1) {
+      renderedGroups.push(lines.join('\n'))
+    }
+  }
+
+  return renderedGroups.join('\n\n')
+}
+
+function defaultSourceLoader(location) {
+  if (!location?.file || !fs.existsSync(location.file)) {
+    return null
+  }
+
+  return fs.readFileSync(location.file, 'utf8')
+}
+
+function normalizeSourceResult(sourceResult) {
+  if (!sourceResult) {
+    return null
+  }
+
+  if (typeof sourceResult === 'string') {
+    return sourceResult
+  }
+
+  if (Array.isArray(sourceResult)) {
+    return sourceResult.join('\n')
+  }
+
+  if (typeof sourceResult.source === 'string') {
+    return sourceResult.source
+  }
+
+  if (Array.isArray(sourceResult.lines)) {
+    return sourceResult.lines.join('\n')
+  }
+
+  return null
+}
+
+function createCodeFrame(location, options = {}) {
+  if (!location?.file || !location.line) {
+    return null
+  }
+
+  const sourceLoader = options.sourceLoader || defaultSourceLoader
+  const sourceText = normalizeSourceResult(sourceLoader(location))
+
+  if (!sourceText) {
+    return null
+  }
+
+  const source = sourceText.split(/\r?\n/)
+  const start = Math.max(1, location.line - 3)
+  const end = Math.min(source.length, location.line + 2)
+  const width = String(end).length
+  const lines = []
+
+  for (let lineNumber = start; lineNumber <= end; lineNumber += 1) {
+    lines.push({
+      highlighted: lineNumber === location.line,
+      lineNumber,
+      source: source[lineNumber - 1],
+    })
+  }
+
+  return {
+    location,
+    start,
+    end,
+    width,
+    lines,
+  }
+}
+
+function formatCodeFrame(codeFrame, theme) {
+  if (!codeFrame) {
+    return ''
+  }
+
+  return codeFrame.lines
+    .map((line) => {
+      const marker = line.highlighted ? '->' : '  '
+      const number = String(line.lineNumber).padStart(codeFrame.width, ' ')
+      const renderedMarker = line.highlighted ? theme.red(marker) : theme.dim(marker)
+      const renderedNumber = line.highlighted ? theme.red(number) : theme.dim(number)
+
+      return `  ${renderedMarker} ${renderedNumber}  ${line.source}`
+    })
+    .join('\n')
+}
+
+function serializeValue(value, depth = 0, seen = new Set()) {
+  if (value === null || typeof value !== 'object') {
+    if (typeof value === 'bigint') {
+      return value.toString()
+    }
+
+    if (typeof value === 'function') {
+      return `[Function ${value.name || 'anonymous'}]`
+    }
+
+    return value
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]'
+  }
+
+  if (depth >= 4) {
+    return '[MaxDepth]'
+  }
+
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    const output = value.map((item) => serializeValue(item, depth + 1, seen))
+    seen.delete(value)
+    return output
+  }
+
+  const output = {}
+
+  for (const key of Object.keys(value)) {
+    if (key === 'stack') {
+      continue
+    }
+
+    output[key] = serializeValue(value[key], depth + 1, seen)
+  }
+
+  seen.delete(value)
+  return output
+}
+
+function serializeError(error, seen = new Set()) {
+  if (!isObject(error)) {
+    return serializeValue(error, 0, seen)
+  }
+
+  if (seen.has(error)) {
+    return '[Circular]'
+  }
+
+  seen.add(error)
+
+  const output = {
+    name: error.name,
+    message: error.message,
+  }
+
+  for (const key of ['code', 'failureType', 'operator']) {
+    if (error[key] !== undefined) {
+      output[key] = serializeValue(error[key], 1, seen)
+    }
+  }
+
+  for (const key of ['actual', 'expected', 'details', 'sounding']) {
+    if (error[key] !== undefined) {
+      output[key] = serializeValue(error[key], 1, seen)
+    }
+  }
+
+  if (typeof error.stack === 'string') {
+    output.stack = error.stack
+  }
+
+  if (error.cause !== undefined) {
+    output.cause = serializeError(error.cause, seen)
+  }
+
+  seen.delete(error)
+  return output
+}
+
+function createRawPayload(failure) {
+  return {
+    event: {
+      name: failure.name,
+      file: failure.event.file,
+      line: failure.event.line,
+      column: failure.event.column,
+      failureType: failure.originalError?.failureType,
+    },
+    primaryFrame: failure.primaryFrame,
+    metadata: failure.metadataGroups,
+    error: serializeError(failure.originalError || failure.error),
+  }
+}
+
+function formatRawSection(payload, theme) {
+  return [`  ${theme.bold('Raw')}`, indentLines(JSON.stringify(payload, null, 2), '    ')].join('\n')
+}
+
+function summarizeErrorMessage(message) {
+  return stripTrailingBlankLines(String(message || ''))
+    .split(/\r?\n\r?\n/)[0]
+    .replace(/\s+/g, ' ')
+}
+
+function formatCauseChain(causeChain, theme) {
+  if (!causeChain || causeChain.length <= 1) {
+    return ''
+  }
+
+  return [
+    `  ${theme.bold('Caused by')}`,
+    ...causeChain.slice(1).map((error) => {
+      const name = error?.name || 'Error'
+      const message = summarizeErrorMessage(error?.message || String(error))
+      return `    ${name}: ${message}`
+    }),
+  ].join('\n')
+}
+
+function parseFailure(data, options = {}) {
+  const originalError = getOriginalError(data)
+  const error = getFailureError(data)
+  const rawMessage = error?.message || originalError?.message || 'Test failed.'
+  const parsedDiagnostics = parseSoundingDiagnostics(rawMessage)
+  const parsedBrowserArtifacts = parseBrowserArtifactDiagnostics(parsedDiagnostics.message)
+  const sounding = {
+    ...(isObject(originalError?.sounding) ? originalError.sounding : {}),
+    ...(isObject(error?.sounding) ? error.sounding : {}),
+  }
+  const browserArtifacts =
+    sounding.browserArtifacts ||
+    error?.details?.browserArtifacts ||
+    originalError?.details?.browserArtifacts ||
+    parsedBrowserArtifacts.browserArtifacts
+  const metadataGroups = createMetadataGroups({
+    diagnostics: parsedDiagnostics.diagnostics,
+    sounding,
+    browserArtifacts,
+  })
+  const primaryFrame = resolveFailureLocation(data)
+  const codeFrame = createCodeFrame(primaryFrame, {
+    sourceLoader: options.sourceLoader,
+  })
+  const causeChain = getErrorObjects(originalError || error)
+
+  return {
+    type: 'SoundingFailure',
+    name: data.name || 'anonymous trial',
+    event: data,
+    originalError,
+    error,
+    message: parsedBrowserArtifacts.message || 'Test failed.',
+    diagnostics: parsedDiagnostics.diagnostics,
+    metadataGroups,
+    browserArtifacts,
+    causeChain,
+    primaryFrame,
+    codeFrame,
+  }
+}
+
+function renderFailure(failure, options = {}) {
+  const theme = options.theme || createTheme()
+  const verbose = options.verbose ?? isVerbose()
+  const raw = options.raw ?? isRaw()
+  const relativeLocation = failure.primaryFrame?.file
+    ? `${formatPath(failure.primaryFrame.file)}${failure.primaryFrame.line ? `:${failure.primaryFrame.line}` : ''}`
+    : ''
+  const lines = [
+    `  ${theme.red('×')} ${theme.bold(failure.name)}`,
+    '',
+    indentLines(failure.message),
+  ]
+  const renderedMetadata = formatMetadataGroups(failure.metadataGroups, theme)
+  const codeFrame = formatCodeFrame(failure.codeFrame, theme)
+  const renderedCauseChain = formatCauseChain(failure.causeChain, theme)
+
+  if (renderedMetadata) {
+    lines.push('', renderedMetadata)
+  }
+
+  if (relativeLocation) {
+    lines.push('', `  ${theme.dim('at')} ${theme.cyan(relativeLocation)}`)
+  }
+
+  if (codeFrame) {
+    lines.push('', codeFrame)
+  }
+
+  if ((verbose || raw) && renderedCauseChain) {
+    lines.push('', renderedCauseChain)
+  }
+
+  if (verbose && failure.error?.stack) {
+    lines.push('', theme.dim(indentLines(failure.error.stack, '  ')))
+  }
+
+  if (raw) {
+    lines.push('', formatRawSection(createRawPayload(failure), theme))
+  }
+
+  return lines.join('\n')
+}
+
+function formatFailure(data, options = {}) {
+  return renderFailure(parseFailure(data, options), options)
+}
+
+function shouldReportFailure(data) {
+  const failureType = data?.details?.error?.failureType
+
+  return failureType !== 'subtestsFailed'
+}
+
+function formatSummary(summary, theme) {
+  const counts = summary?.counts || {}
+  const failed = counts.failed || 0
+  const passed = counts.passed || 0
+  const skipped = counts.skipped || 0
+  const todo = counts.todo || 0
+  const cancelled = counts.cancelled || 0
+  const total = counts.tests || 0
+  const parts = [
+    passed ? theme.green(`${passed} passed`) : '',
+    failed ? theme.red(`${failed} failed`) : '',
+    skipped ? `${skipped} skipped` : '',
+    todo ? `${todo} todo` : '',
+    cancelled ? theme.red(`${cancelled} cancelled`) : '',
+    `${total} total`,
+  ].filter(Boolean)
+  const duration = formatDuration(summary?.duration_ms)
+  const label = failed || cancelled ? theme.failBadge('FAIL') : theme.passBadge('PASS')
+
+  return [
+    `${label}  Tests: ${parts.join(', ')}`,
+    `${theme.dim('Duration:')} ${theme.bold(duration || 'unknown')}`,
+    '',
+  ].join('\n')
+}
+
+function formatPassLine(test, width, theme) {
+  const duration = formatDuration(test?.details?.duration_ms)
+  const name = test.name || 'anonymous trial'
+  const paddedName = duration && name.length < width ? name.padEnd(width, ' ') : name
+  const suffix = duration ? `  ${theme.dim(duration)}` : ''
+
+  return `  ${theme.green('✓')} ${paddedName}${suffix}`
+}
+
+function formatPassedGroups(passedTests, theme) {
+  if (passedTests.length === 0) {
+    return ''
+  }
+
+  const groups = new Map()
+  const maxNameLength = Math.min(
+    64,
+    Math.max(...passedTests.map((test) => String(test.name || '').length), 0)
+  )
+
+  for (const passedTest of passedTests) {
+    const file = formatPath(passedTest.file || passedTest.name)
+    const tests = groups.get(file) || []
+    tests.push(passedTest)
+    groups.set(file, tests)
+  }
+
+  return Array.from(groups.entries())
+    .map(([file, tests]) => {
+      const lines = [
+        `${theme.green(theme.bold('PASS'))}  ${file}`,
+        '',
+        ...tests.map((test) => formatPassLine(test, maxNameLength, theme)),
+      ]
+
+      return lines.join('\n')
+    })
+    .join('\n\n')
+}
+
+async function* soundingReporter(source) {
+  const theme = createTheme()
+  const reportedFiles = new Set()
+  const passedTests = []
+
+  for await (const event of source) {
+    if (event.type === 'test:stdout' || event.type === 'test:stderr') {
+      yield event.data.message
+      continue
+    }
+
+    if (event.type === 'test:fail' && shouldReportFailure(event.data)) {
+      const location = resolveFailureLocation(event.data)
+      const file = formatPath(location.file || event.data.file || event.data.name)
+
+      if (!reportedFiles.has(file)) {
+        reportedFiles.add(file)
+        yield `\n${theme.red(theme.bold('FAIL'))}  ${file}\n\n`
+      }
+
+      yield `${formatFailure(event.data, { theme })}\n\n`
+      continue
+    }
+
+    if (event.type === 'test:pass') {
+      passedTests.push(event.data)
+      continue
+    }
+
+    if (event.type === 'test:summary' && !event.data.file) {
+      if (event.data.success && shouldListPassedTests(event.data)) {
+        const passedGroups = formatPassedGroups(passedTests, theme)
+        if (passedGroups) {
+          yield `\n${passedGroups}\n\n`
+        }
+      }
+
+      yield `${formatSummary(event.data, theme)}`
+    }
+  }
+}
+
+module.exports = soundingReporter
+module.exports.createCodeFrame = createCodeFrame
+module.exports.createMetadataGroups = createMetadataGroups
+module.exports.defaultSourceLoader = defaultSourceLoader
+module.exports.formatFailure = formatFailure
+module.exports.formatMetadataGroups = formatMetadataGroups
+module.exports.formatPassedGroups = formatPassedGroups
+module.exports.formatSummary = formatSummary
+module.exports.parseFailure = parseFailure
+module.exports.parseSoundingDiagnostics = parseSoundingDiagnostics
+module.exports.renderFailure = renderFailure
+module.exports.resolveFailureLocation = resolveFailureLocation

--- a/lib/sounding-reporter.js
+++ b/lib/sounding-reporter.js
@@ -2,6 +2,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 
 const INTERNAL_FRAME_PATTERN = /(?:^|\/)(?:node:internal|internal\/|node_modules\/internal)/
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g
 
 function supportsColor() {
   if (process.env.NO_COLOR || process.env.FORCE_COLOR === '0') {
@@ -13,6 +14,10 @@ function supportsColor() {
 
 function colorize(enabled, code, value) {
   return enabled ? `\u001b[${code}m${value}\u001b[0m` : value
+}
+
+function visibleLength(value) {
+  return String(value).replace(ANSI_PATTERN, '').length
 }
 
 function createTheme() {
@@ -803,11 +808,12 @@ function formatSummary(summary, theme) {
   ].filter(Boolean)
   const duration = formatDuration(summary?.duration_ms)
   const label = failed || cancelled ? theme.failBadge('FAIL') : theme.passBadge('PASS')
+  const summaryIndent = ' '.repeat(visibleLength(label) + 2)
 
   return [
     `${label}  Tests: ${parts.join(', ')}`,
     '',
-    `${theme.dim('Duration:')} ${theme.bold(duration || 'unknown')}`,
+    `${summaryIndent}${theme.dim('Duration:')} ${theme.bold(duration || 'unknown')}`,
     '',
   ].join('\n')
 }

--- a/lib/sounding-reporter.js
+++ b/lib/sounding-reporter.js
@@ -737,6 +737,40 @@ function parseFailure(data, options = {}) {
   }
 }
 
+function getTrialDuration(data) {
+  const duration = data?.details?.duration_ms
+  return typeof duration === 'number' && !Number.isNaN(duration) ? duration : null
+}
+
+function parseTrial(data, status = 'unknown', options = {}) {
+  const trial = {
+    type: 'SoundingTrial',
+    status,
+    name: data?.name || 'anonymous trial',
+    file: data?.file,
+    line: data?.line,
+    column: data?.column,
+    durationMs: getTrialDuration(data),
+    event: data,
+    metadataGroups: [],
+  }
+
+  if (status === 'failed') {
+    const failure = parseFailure(data, options)
+
+    return {
+      ...trial,
+      file: failure.primaryFrame?.file || trial.file,
+      line: failure.primaryFrame?.line || trial.line,
+      column: failure.primaryFrame?.column || trial.column,
+      metadataGroups: failure.metadataGroups,
+      failure,
+    }
+  }
+
+  return trial
+}
+
 function renderFailure(failure, options = {}) {
   const theme = options.theme || createTheme()
   const verbose = options.verbose ?? isVerbose()
@@ -781,7 +815,7 @@ function renderFailure(failure, options = {}) {
 }
 
 function formatFailure(data, options = {}) {
-  return renderFailure(parseFailure(data, options), options)
+  return renderFailure(parseTrial(data, 'failed', options).failure, options)
 }
 
 function shouldReportFailure(data) {
@@ -818,31 +852,36 @@ function formatSummary(summary, theme) {
   ].join('\n')
 }
 
-function formatPassLine(test, width, theme) {
-  const duration = formatDuration(test?.details?.duration_ms)
-  const name = test.name || 'anonymous trial'
+function formatPassLine(trial, width, theme) {
+  const duration = formatDuration(trial.durationMs)
+  const name = trial.name || 'anonymous trial'
   const paddedName = duration && name.length < width ? name.padEnd(width, ' ') : name
   const suffix = duration ? `  ${theme.dim(duration)}` : ''
 
   return `  ${theme.green('✓')} ${paddedName}${suffix}`
 }
 
-function formatPassedGroups(passedTests, theme) {
-  if (passedTests.length === 0) {
+function normalizePassedTrial(value) {
+  return value?.type === 'SoundingTrial' ? value : parseTrial(value, 'passed')
+}
+
+function formatPassedGroups(passedTrials, theme) {
+  if (passedTrials.length === 0) {
     return ''
   }
 
+  const trials = passedTrials.map(normalizePassedTrial)
   const groups = new Map()
   const maxNameLength = Math.min(
     64,
-    Math.max(...passedTests.map((test) => String(test.name || '').length), 0)
+    Math.max(...trials.map((trial) => String(trial.name || '').length), 0)
   )
 
-  for (const passedTest of passedTests) {
-    const file = formatPath(passedTest.file || passedTest.name)
-    const tests = groups.get(file) || []
-    tests.push(passedTest)
-    groups.set(file, tests)
+  for (const passedTrial of trials) {
+    const file = formatPath(passedTrial.file || passedTrial.name)
+    const groupedTrials = groups.get(file) || []
+    groupedTrials.push(passedTrial)
+    groups.set(file, groupedTrials)
   }
 
   return Array.from(groups.entries())
@@ -861,7 +900,7 @@ function formatPassedGroups(passedTests, theme) {
 async function* soundingReporter(source) {
   const theme = createTheme()
   const reportedFiles = new Set()
-  const passedTests = []
+  const passedTrials = []
 
   for await (const event of source) {
     if (event.type === 'test:stdout' || event.type === 'test:stderr') {
@@ -870,26 +909,26 @@ async function* soundingReporter(source) {
     }
 
     if (event.type === 'test:fail' && shouldReportFailure(event.data)) {
-      const location = resolveFailureLocation(event.data)
-      const file = formatPath(location.file || event.data.file || event.data.name)
+      const trial = parseTrial(event.data, 'failed')
+      const file = formatPath(trial.file || event.data.file || event.data.name)
 
       if (!reportedFiles.has(file)) {
         reportedFiles.add(file)
         yield `\n${theme.red(theme.bold('FAIL'))}  ${file}\n\n`
       }
 
-      yield `${formatFailure(event.data, { theme })}\n\n`
+      yield `${renderFailure(trial.failure, { theme })}\n\n`
       continue
     }
 
     if (event.type === 'test:pass') {
-      passedTests.push(event.data)
+      passedTrials.push(parseTrial(event.data, 'passed'))
       continue
     }
 
     if (event.type === 'test:summary' && !event.data.file) {
       if (event.data.success && shouldListPassedTests(event.data)) {
-        const passedGroups = formatPassedGroups(passedTests, theme)
+        const passedGroups = formatPassedGroups(passedTrials, theme)
         if (passedGroups) {
           yield `\n${passedGroups}\n\n`
         }
@@ -910,5 +949,6 @@ module.exports.formatPassedGroups = formatPassedGroups
 module.exports.formatSummary = formatSummary
 module.exports.parseFailure = parseFailure
 module.exports.parseSoundingDiagnostics = parseSoundingDiagnostics
+module.exports.parseTrial = parseTrial
 module.exports.renderFailure = renderFailure
 module.exports.resolveFailureLocation = resolveFailureLocation

--- a/lib/sounding-reporter.js
+++ b/lib/sounding-reporter.js
@@ -806,6 +806,7 @@ function formatSummary(summary, theme) {
 
   return [
     `${label}  Tests: ${parts.join(', ')}`,
+    '',
     `${theme.dim('Duration:')} ${theme.bold(duration || 'unknown')}`,
     '',
   ].join('\n')

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -4,6 +4,7 @@ const { execFileSync, spawn } = require('node:child_process')
 
 const DEFAULT_TEST_DIRECTORIES = ['tests', 'test']
 const DEFAULT_JUNIT_DESTINATION = 'reports/sounding-junit.xml'
+const DEFAULT_REPORTER_PATH = path.join(__dirname, 'sounding-reporter.js')
 const NODE_VALUE_FLAGS = new Set([
   '--test-name-pattern',
   '--test-reporter',
@@ -25,6 +26,7 @@ const NODE_VALUE_FLAGS = new Set([
  *   command: string,
  *   args: string[],
  *   cwd: string,
+ *   env: Record<string, string>,
  *   files: string[],
  *   dryRun: boolean,
  * }} SoundingTestCommand
@@ -226,6 +228,8 @@ function resolveTestFiles(appPath, targets) {
  * @returns {{
  *   appPath: string,
  *   dryRun: boolean,
+ *   env: Record<string, string>,
+ *   usesCustomReporter: boolean,
  *   targets: string[],
  *   nodeArgs: string[],
  * }}
@@ -234,8 +238,11 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
   const args = [...argv]
   const targets = []
   const nodeArgs = []
+  /** @type {Record<string, string>} */
+  const env = {}
   let dryRun = false
   let useChanged = false
+  let usesCustomReporter = false
   let resolvedAppPath = path.resolve(appPath)
 
   function readValue(flag) {
@@ -253,6 +260,22 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
 
     if (arg === '--dry-run') {
       dryRun = true
+      continue
+    }
+
+    if (arg === '--compact') {
+      env.SOUNDING_REPORTER_COMPACT = '1'
+      continue
+    }
+
+    if (arg === '--verbose') {
+      env.SOUNDING_REPORTER_VERBOSE = '1'
+      env.SOUNDING_DIAGNOSTICS = 'verbose'
+      continue
+    }
+
+    if (arg === '--raw-error') {
+      env.SOUNDING_RAW = '1'
       continue
     }
 
@@ -284,7 +307,9 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
     }
 
     if (arg === '--reporter') {
-      nodeArgs.push('--test-reporter', readValue(arg))
+      usesCustomReporter = true
+      const reporter = readValue(arg)
+      nodeArgs.push('--test-reporter', reporter === 'sounding' ? DEFAULT_REPORTER_PATH : reporter)
       continue
     }
 
@@ -294,6 +319,7 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
     }
 
     if (arg === '--junit') {
+      usesCustomReporter = true
       nodeArgs.push('--test-reporter', 'junit')
 
       if (args[0] && !args[0].startsWith('-')) {
@@ -306,6 +332,7 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
     }
 
     if (arg === '--json') {
+      usesCustomReporter = true
       nodeArgs.push('--test-reporter', 'json')
       continue
     }
@@ -326,7 +353,16 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
     }
 
     if (NODE_VALUE_FLAGS.has(arg)) {
+      if (arg === '--test-reporter') {
+        usesCustomReporter = true
+      }
       nodeArgs.push(arg, readValue(arg))
+      continue
+    }
+
+    if (arg.startsWith('--test-reporter=')) {
+      usesCustomReporter = true
+      nodeArgs.push(arg)
       continue
     }
 
@@ -345,6 +381,8 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
   return {
     appPath: resolvedAppPath,
     dryRun,
+    env,
+    usesCustomReporter,
     targets,
     nodeArgs,
   }
@@ -357,11 +395,15 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
 function buildTestCommand(options = {}) {
   const parsed = parseTestArgs(options.argv || [], options.appPath)
   const files = resolveTestFiles(parsed.appPath, parsed.targets)
+  const reporterArgs = parsed.usesCustomReporter
+    ? []
+    : ['--test-reporter', DEFAULT_REPORTER_PATH]
 
   return {
     command: options.nodeExecutable || process.execPath,
-    args: ['--test', ...parsed.nodeArgs, ...files],
+    args: ['--test', ...reporterArgs, ...parsed.nodeArgs, ...files],
     cwd: parsed.appPath,
+    env: parsed.env,
     files,
     dryRun: parsed.dryRun,
   }
@@ -384,7 +426,8 @@ function quoteShell(value) {
  * @returns {string}
  */
 function formatTestCommand(command) {
-  return [command.command, ...command.args].map(quoteShell).join(' ')
+  const env = Object.entries(command.env || {}).map(([key, value]) => `${key}=${quoteShell(value)}`)
+  return [...env, command.command, ...command.args].map(quoteShell).join(' ')
 }
 
 /**
@@ -404,6 +447,10 @@ function runTests(options = {}) {
   return new Promise((resolve) => {
     const child = spawn(command.command, command.args, {
       cwd: command.cwd,
+      env: {
+        ...process.env,
+        ...(command.env || {}),
+      },
       stdio: options.stdio || 'inherit',
     })
 
@@ -419,6 +466,7 @@ function runTests(options = {}) {
 module.exports = {
   DEFAULT_JUNIT_DESTINATION,
   DEFAULT_TEST_DIRECTORIES,
+  DEFAULT_REPORTER_PATH,
   buildTestCommand,
   formatTestCommand,
   parseTestArgs,

--- a/test/init-project.test.js
+++ b/test/init-project.test.js
@@ -5,6 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 
+const packageJson = require('../package.json')
 const { TEST_COMMAND, initProject } = require('../lib/init-project')
 
 function createTempApp(prefix = 'sounding-init-') {
@@ -33,7 +34,7 @@ test('initProject scaffolds package scripts, dependencies, worlds, and examples'
   assert.equal(result.auth.identity, 'user')
   assert.equal(result.auth.detected, true)
   assert.equal(pkg.scripts.test, TEST_COMMAND)
-  assert.match(pkg.devDependencies.sounding, /^\^0\.0\./)
+  assert.equal(pkg.devDependencies.sounding, `^${packageJson.version}`)
   assert.equal(pkg.devDependencies['sails-sqlite'], '^0.2.6')
   assert.equal(fs.existsSync(path.join(appPath, 'tests', 'factories')), true)
   assert.equal(fs.existsSync(path.join(appPath, 'tests', 'scenarios')), true)

--- a/test/sounding-reporter.test.js
+++ b/test/sounding-reporter.test.js
@@ -1,0 +1,105 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const reporter = require('../lib/sounding-reporter')
+
+test('parseFailure builds a structured SoundingFailure before terminal rendering', () => {
+  const cause = new Error(
+    [
+      'Expected response status 200, received 500.',
+      '',
+      'Sounding response diagnostics:',
+      '- Request: GET /api/billing/summary (http)',
+      '- Request headers: accept=application/json',
+      '- Response: 500 Server Error',
+      '- Headers: content-type=application/json',
+      '- Body: {"message":"boom"}',
+    ].join('\n')
+  )
+  cause.sounding = {
+    world: {
+      name: 'signed-in-creator',
+      actor: 'owner',
+      context: {
+        plan: 'pro',
+      },
+    },
+    browserArtifacts: {
+      project: 'mobile',
+      screenshot: '.tmp/sounding/artifacts/billing/mobile/screenshot.png',
+    },
+  }
+  cause.stack = ''
+
+  const wrapper = new Error('test code failure')
+  wrapper.code = 'ERR_TEST_FAILURE'
+  wrapper.failureType = 'testCodeFailure'
+  wrapper.cause = cause
+  wrapper.stack = ''
+
+  const failure = reporter.parseFailure(
+    {
+      name: 'creator sees billing summary',
+      file: path.join(process.cwd(), 'tests', 'billing.test.js'),
+      line: 4,
+      column: 3,
+      details: {
+        error: wrapper,
+      },
+    },
+    {
+      sourceLoader() {
+        return [
+          "const { test } = require('sounding')",
+          '',
+          "test('creator sees billing summary', async ({ expect }) => {",
+          '  expect(response).toHaveStatus(200)',
+          '})',
+        ].join('\n')
+      },
+    }
+  )
+
+  assert.equal(failure.type, 'SoundingFailure')
+  assert.equal(failure.message, 'Expected response status 200, received 500.')
+  assert.deepEqual(failure.metadataGroups.map((group) => group.title), [
+    'World',
+    'Request',
+    'Response',
+    'Body',
+    'Browser',
+  ])
+  assert.equal(failure.causeChain.length, 2)
+  assert.equal(
+    failure.codeFrame.lines.find((line) => line.highlighted).source,
+    '  expect(response).toHaveStatus(200)'
+  )
+})
+
+test('renderFailure can include raw wrapper error details and cause chains', () => {
+  const cause = new Error('expected 2 to equal 3')
+  const wrapper = new Error('test failed')
+  wrapper.code = 'ERR_TEST_FAILURE'
+  wrapper.failureType = 'testCodeFailure'
+  wrapper.cause = cause
+
+  const failure = reporter.parseFailure({
+    name: 'adds numbers',
+    file: path.join(process.cwd(), 'tests', 'math.test.js'),
+    line: 3,
+    details: {
+      error: wrapper,
+    },
+  })
+  const rendered = reporter.renderFailure(failure, {
+    raw: true,
+    verbose: false,
+  })
+
+  assert.match(rendered, /Caused by/)
+  assert.match(rendered, /Error: expected 2 to equal 3/)
+  assert.match(rendered, /Raw/)
+  assert.match(rendered, /"code": "ERR_TEST_FAILURE"/)
+  assert.match(rendered, /"cause":/)
+})

--- a/test/sounding-reporter.test.js
+++ b/test/sounding-reporter.test.js
@@ -4,7 +4,7 @@ const path = require('node:path')
 
 const reporter = require('../lib/sounding-reporter')
 
-test('parseFailure builds a structured SoundingFailure before terminal rendering', () => {
+test('parseTrial builds a SoundingTrial with a structured failure payload', () => {
   const cause = new Error(
     [
       'Expected response status 200, received 500.',
@@ -38,7 +38,7 @@ test('parseFailure builds a structured SoundingFailure before terminal rendering
   wrapper.cause = cause
   wrapper.stack = ''
 
-  const failure = reporter.parseFailure(
+  const trial = reporter.parseTrial(
     {
       name: 'creator sees billing summary',
       file: path.join(process.cwd(), 'tests', 'billing.test.js'),
@@ -48,6 +48,7 @@ test('parseFailure builds a structured SoundingFailure before terminal rendering
         error: wrapper,
       },
     },
+    'failed',
     {
       sourceLoader() {
         return [
@@ -61,20 +62,75 @@ test('parseFailure builds a structured SoundingFailure before terminal rendering
     }
   )
 
-  assert.equal(failure.type, 'SoundingFailure')
-  assert.equal(failure.message, 'Expected response status 200, received 500.')
-  assert.deepEqual(failure.metadataGroups.map((group) => group.title), [
+  assert.equal(trial.type, 'SoundingTrial')
+  assert.equal(trial.status, 'failed')
+  assert.equal(trial.failure.type, 'SoundingFailure')
+  assert.equal(trial.failure.message, 'Expected response status 200, received 500.')
+  assert.deepEqual(trial.metadataGroups.map((group) => group.title), [
     'World',
     'Request',
     'Response',
     'Body',
     'Browser',
   ])
-  assert.equal(failure.causeChain.length, 2)
+  assert.equal(trial.failure.causeChain.length, 2)
   assert.equal(
-    failure.codeFrame.lines.find((line) => line.highlighted).source,
+    trial.failure.codeFrame.lines.find((line) => line.highlighted).source,
     '  expect(response).toHaveStatus(200)'
   )
+})
+
+test('parseTrial keeps passed trials lightweight', () => {
+  const trial = reporter.parseTrial(
+    {
+      name: 'JSON paths read like product facts',
+      file: path.join(process.cwd(), 'tests', 'arch.test.js'),
+      details: {
+        duration_ms: 1.4,
+      },
+    },
+    'passed'
+  )
+
+  assert.deepEqual(trial, {
+    type: 'SoundingTrial',
+    status: 'passed',
+    name: 'JSON paths read like product facts',
+    file: path.join(process.cwd(), 'tests', 'arch.test.js'),
+    line: undefined,
+    column: undefined,
+    durationMs: 1.4,
+    event: {
+      name: 'JSON paths read like product facts',
+      file: path.join(process.cwd(), 'tests', 'arch.test.js'),
+      details: {
+        duration_ms: 1.4,
+      },
+    },
+    metadataGroups: [],
+  })
+})
+
+test('formatPassedGroups accepts raw Node pass events', () => {
+  const rendered = reporter.formatPassedGroups(
+    [
+      {
+        name: 'JSON paths read like product facts',
+        file: path.join(process.cwd(), 'tests', 'arch.test.js'),
+        details: {
+          duration_ms: 2,
+        },
+      },
+    ],
+    {
+      green: (value) => value,
+      bold: (value) => value,
+      dim: (value) => value,
+    }
+  )
+
+  assert.match(rendered, /PASS\s+tests\/arch\.test\.js/)
+  assert.match(rendered, /✓ JSON paths read like product facts\s+2ms/)
 })
 
 test('renderFailure can include raw wrapper error details and cause chains', () => {

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -7,6 +7,7 @@ const { spawnSync } = require('node:child_process')
 
 const {
   DEFAULT_JUNIT_DESTINATION,
+  DEFAULT_REPORTER_PATH,
   buildTestCommand,
   formatTestCommand,
   resolveTestFiles,
@@ -21,6 +22,12 @@ function createTempApp() {
   fs.writeFileSync(path.join(appPath, 'test', 'legacy.test.js'), "require('node:test')('legacy', () => {})\n")
   fs.writeFileSync(path.join(appPath, 'tests', 'readme.md'), '# ignored\n')
   return appPath
+}
+
+function createChildEnv() {
+  const env = { ...process.env }
+  delete env.NODE_TEST_CONTEXT
+  return env
 }
 
 test('resolveTestFiles discovers tests and test directories by default', () => {
@@ -104,18 +111,75 @@ test('buildTestCommand preserves Node test runner pass-through flags', () => {
   ])
 })
 
+test('buildTestCommand uses the Sounding reporter by default', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: ['tests/account.test.js'],
+  })
+
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-reporter',
+    DEFAULT_REPORTER_PATH,
+    'tests/account.test.js',
+  ])
+})
+
+test('buildTestCommand maps Sounding reporter mode flags to environment', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: ['--compact', '--verbose', '--raw-error', 'tests/account.test.js'],
+  })
+
+  assert.deepEqual(command.env, {
+    SOUNDING_REPORTER_COMPACT: '1',
+    SOUNDING_REPORTER_VERBOSE: '1',
+    SOUNDING_DIAGNOSTICS: 'verbose',
+    SOUNDING_RAW: '1',
+  })
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-reporter',
+    DEFAULT_REPORTER_PATH,
+    'tests/account.test.js',
+  ])
+})
+
+test('buildTestCommand can request the Sounding reporter explicitly', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: ['--reporter', 'sounding', 'tests/account.test.js'],
+  })
+
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-reporter',
+    DEFAULT_REPORTER_PATH,
+    'tests/account.test.js',
+  ])
+})
+
 test('formatTestCommand produces a copyable dry-run command', () => {
   const command = {
     command: 'node',
     args: ['--test', '--test-name-pattern', 'sign in', 'tests/account.test.js'],
     cwd: process.cwd(),
+    env: {
+      SOUNDING_REPORTER_VERBOSE: '1',
+    },
     files: ['tests/account.test.js'],
     dryRun: true,
   }
 
   assert.equal(
     formatTestCommand(command),
-    'node --test --test-name-pattern "sign in" tests/account.test.js'
+    'SOUNDING_REPORTER_VERBOSE=1 node --test --test-name-pattern "sign in" tests/account.test.js'
   )
 })
 
@@ -129,7 +193,7 @@ test('bin/sounding.js can dry-run the test command', () => {
     '--grep',
     'account',
     '--dry-run',
-  ])
+  ], { env: createChildEnv() })
 
   assert.equal(result.status, 0, result.stderr.toString())
   assert.match(result.stdout.toString(), /--test-name-pattern account/)
@@ -145,7 +209,108 @@ test('bin/sounding.js can run a selected test file', () => {
     appPath,
     '--file',
     'tests/account.test.js',
-  ])
+  ], { env: createChildEnv() })
 
   assert.equal(result.status, 0, result.stderr.toString())
+})
+
+test('bin/sounding.js shows a readable PASS block for small successful runs', () => {
+  const appPath = createTempApp()
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'test',
+    '--app',
+    appPath,
+    '--file',
+    'tests/account.test.js',
+  ], { env: createChildEnv() })
+  const stdout = result.stdout.toString()
+
+  assert.equal(result.status, 0, result.stderr.toString())
+  assert.match(stdout, /PASS\s+tests\/account\.test\.js/)
+  assert.match(stdout, /✓ account/)
+  assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total/)
+  assert.doesNotMatch(stdout, /Tests:\s{2,}\d/)
+  assert.match(stdout, /\nDuration: \d+ms/)
+  assert.doesNotMatch(stdout, /\n\s+Duration:/)
+})
+
+test('bin/sounding.js uses the Sounding reporter for failures by default', () => {
+  const appPath = createTempApp()
+  const testPath = path.join(appPath, 'tests', 'billing.test.js')
+  fs.writeFileSync(
+    testPath,
+    `const test = require('node:test')
+const { createExpect: expect } = require(${JSON.stringify(path.join(__dirname, '..'))})
+
+test('creator sees billing summary', () => {
+  const response = {
+    status: 500,
+    statusText: 'Server Error',
+    headers: { 'content-type': 'application/json' },
+    data: { message: 'boom' },
+    request: {
+      method: 'GET',
+      target: '/api/billing/summary',
+      transport: 'http',
+      url: 'http://localhost:1337/api/billing/summary',
+      headers: { accept: 'application/json' }
+    }
+  }
+
+  expect(response).toHaveStatus(200)
+})
+`
+  )
+
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'test',
+    '--app',
+    appPath,
+    '--file',
+    'tests/billing.test.js',
+  ], { env: createChildEnv() })
+  const stdout = result.stdout.toString()
+
+  assert.equal(result.status, 1, `${stdout}\n${result.stderr.toString()}`)
+  assert.match(stdout, /FAIL\s+tests\/billing\.test\.js/)
+  assert.match(stdout, /× creator sees billing summary/)
+  assert.match(stdout, /Expected response status 200, received 500\./)
+  assert.match(stdout, /Request\n\s+GET \/api\/billing\/summary/)
+  assert.match(stdout, /Response\n\s+500 Server Error/)
+  assert.match(stdout, /Body\n\s+\{"message":"boom"\}/)
+  assert.match(stdout, /->\s+\d+\s+expect\(response\)\.toHaveStatus\(200\)/)
+  assert.doesNotMatch(stdout, /AssertionError/)
+})
+
+test('bin/sounding.js can include raw error details on demand', () => {
+  const appPath = createTempApp()
+  const testPath = path.join(appPath, 'tests', 'math.test.js')
+  fs.writeFileSync(
+    testPath,
+    `const test = require('node:test')
+const assert = require('node:assert/strict')
+
+test('adds numbers', () => {
+  assert.equal(1 + 1, 3)
+})
+`
+  )
+
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'test',
+    '--app',
+    appPath,
+    '--file',
+    'tests/math.test.js',
+    '--raw-error',
+  ], { env: createChildEnv() })
+  const stdout = result.stdout.toString()
+
+  assert.equal(result.status, 1, `${stdout}\n${result.stderr.toString()}`)
+  assert.match(stdout, /Raw/)
+  assert.match(stdout, /"cause":/)
+  assert.match(stdout, /ERR_TEST_FAILURE|ERR_ASSERTION|AssertionError/)
 })

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -231,8 +231,8 @@ test('bin/sounding.js shows a readable PASS block for small successful runs', ()
   assert.match(stdout, /✓ account/)
   assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total/)
   assert.doesNotMatch(stdout, /Tests:\s{2,}\d/)
-  assert.match(stdout, /\n\nDuration: \d+ms/)
-  assert.doesNotMatch(stdout, /\n[^\S\r\n]+Duration:/)
+  assert.match(stdout, /\n\n {6}Duration: \d+ms/)
+  assert.doesNotMatch(stdout, /\n\n {0,5}Duration:/)
 })
 
 test('bin/sounding.js uses the Sounding reporter for failures by default', () => {

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -231,8 +231,8 @@ test('bin/sounding.js shows a readable PASS block for small successful runs', ()
   assert.match(stdout, /✓ account/)
   assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total/)
   assert.doesNotMatch(stdout, /Tests:\s{2,}\d/)
-  assert.match(stdout, /\nDuration: \d+ms/)
-  assert.doesNotMatch(stdout, /\n\s+Duration:/)
+  assert.match(stdout, /\n\nDuration: \d+ms/)
+  assert.doesNotMatch(stdout, /\n[^\S\r\n]+Duration:/)
 })
 
 test('bin/sounding.js uses the Sounding reporter for failures by default', () => {


### PR DESCRIPTION
## Summary
- add Sounding's default Node test reporter with PASS/FAIL groups, code frames, and compact summaries
- parse Node test events into a structured `SoundingFailure` before terminal rendering
- add grouped failure metadata, primary app frame spotlighting, `--compact`, `--verbose`, and `--raw-error` modes
- add pass/fail screenshot fixtures and reporter coverage

## Validation
- `node ./bin/sounding.js test --app examples/pretty-output-success`
- `node ./bin/sounding.js test --app examples/pretty-output-demo`
- `node ./bin/sounding.js test --app examples/pretty-output-demo --raw-error`
- `npm test`
- `npm run typecheck`
- `git diff --check`

Closes #88

Related docs issue: sailscastshq/docs.sailscasts.com#89.