### PR TITLE
feat: add runner sharding and profiling flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ The command discovers `.test.js` files under `tests/` and `test/`, then runs Nod
 npx sounding test --grep "dashboard"
 npx sounding test --file tests/sounding/examples.test.js
 npx sounding test --lane browser
+npx sounding test --shard=1/4
+npx sounding test --parallel
 npx sounding test --watch
 ```
 
@@ -194,7 +196,30 @@ npx sounding test --json
 npx sounding test --coverage
 ```
 
-When no reporter is specified, `sounding test` uses Sounding's readable reporter. Failed response assertions group the request, response, body, file location, and code frame so the behavior is visible without digging through a raw stack trace. Use `--verbose` when you want full stacks and expanded Sounding diagnostics:
+When no reporter is specified, `sounding test` uses Sounding's readable reporter. Failed response assertions group the request, response, body, file location, and code frame so the behavior is visible without digging through a raw stack trace. Use `--compact` for failure-focused output, `--profile` to print the slowest trials before the final summary, and `--slow=N` to control how many profiled trials are shown:
+
+```sh
+npx sounding test --compact
+npx sounding test --profile --slow=10
+```
+
+For larger suites in CI, split the same discovered file list across matrix jobs with `--shard=part/total`. Sharding composes with lanes and explicit files:
+
+```sh
+npx sounding test --lane browser --shard=1/4
+npx sounding test --file tests/sounding/examples.test.js --shard=2/4
+```
+
+```yaml
+strategy:
+  matrix:
+    shard: [1, 2, 3, 4]
+
+steps:
+  - run: npx sounding test --shard=${{ matrix.shard }}/4 --profile --slow=10
+```
+
+Use `--verbose` when you want full stacks and expanded Sounding diagnostics:
 
 ```sh
 npx sounding test --verbose

--- a/bin/sounding.js
+++ b/bin/sounding.js
@@ -33,10 +33,14 @@ Options:
   --file <path>                  Run one file. May be repeated.
   --lane <name>                  Run tests under tests/<name> or test/<name>.
   --changed                      Run changed .test.js files when git metadata is available.
+  --shard <part/total>           Run one shard, for example --shard=1/4.
+  --parallel                     Run test files with Node test concurrency enabled.
   --watch                        Forward to Node watch mode.
   --reporter <name>              Use a Node reporter, or "sounding" for Sounding output.
   --reporter-destination <path>  Forward to --test-reporter-destination.
   --compact                      Keep Sounding reporter output failure-focused.
+  --profile                      Print the slowest trials before the final summary.
+  --slow <count>                 Control how many profiled trials are shown. Implies --profile.
   --verbose                      Show full stacks and verbose Sounding diagnostics.
   --raw-error                    Show raw Node/Sounding error details after formatted failures.
   --junit [path]                 Use the junit reporter.

--- a/lib/sounding-reporter.js
+++ b/lib/sounding-reporter.js
@@ -57,6 +57,10 @@ function isCompact() {
   return process.env.SOUNDING_REPORTER_COMPACT === '1'
 }
 
+function isProfile() {
+  return process.env.SOUNDING_REPORTER_PROFILE === '1'
+}
+
 function isRaw() {
   return process.env.SOUNDING_RAW === '1' || process.env.SOUNDING_RAW_ERROR === '1'
 }
@@ -83,6 +87,15 @@ function formatDuration(durationMs) {
   }
 
   return `${(durationMs / 1000).toFixed(2)}s`
+}
+
+function getProfileLimit(value = process.env.SOUNDING_REPORTER_SLOW_LIMIT) {
+  if (value === undefined || value === null || value === '') {
+    return 10
+  }
+
+  const limit = Number(value)
+  return Number.isInteger(limit) && limit > 0 ? limit : 10
 }
 
 function safeRealpath(filePath) {
@@ -861,6 +874,49 @@ function formatPassLine(trial, width, theme) {
   return `  ${theme.green('✓')} ${paddedName}${suffix}`
 }
 
+function formatProfileStatus(status, theme) {
+  if (status === 'failed') {
+    return theme.red('failed')
+  }
+
+  if (status === 'passed') {
+    return theme.green('passed')
+  }
+
+  return theme.dim(status || 'unknown')
+}
+
+function formatProfileTrials(trials, theme, options = {}) {
+  const limit = getProfileLimit(options.limit)
+  const slowestTrials = trials
+    .filter((trial) => typeof trial?.durationMs === 'number' && !Number.isNaN(trial.durationMs))
+    .sort((left, right) => right.durationMs - left.durationMs)
+    .slice(0, limit)
+
+  if (slowestTrials.length === 0) {
+    return ''
+  }
+
+  const rankWidth = String(slowestTrials.length).length
+  const durationWidth = Math.max(
+    ...slowestTrials.map((trial) => visibleLength(formatDuration(trial.durationMs)))
+  )
+  const lines = [`${theme.cyan(theme.bold('PROFILE'))}  Slowest trials`, '']
+
+  for (let index = 0; index < slowestTrials.length; index += 1) {
+    const trial = slowestTrials[index]
+    const rank = `${index + 1}.`.padStart(rankWidth + 1, ' ')
+    const duration = formatDuration(trial.durationMs).padStart(durationWidth, ' ')
+    const file = formatPath(trial.file || '')
+    const status = formatProfileStatus(trial.status, theme)
+
+    lines.push(`  ${rank} ${theme.bold(duration)}  ${status}  ${file}`)
+    lines.push(`     ${trial.name || 'anonymous trial'}`)
+  }
+
+  return lines.join('\n')
+}
+
 function normalizePassedTrial(value) {
   return value?.type === 'SoundingTrial' ? value : parseTrial(value, 'passed')
 }
@@ -901,6 +957,7 @@ async function* soundingReporter(source) {
   const theme = createTheme()
   const reportedFiles = new Set()
   const passedTrials = []
+  const profileTrials = []
 
   for await (const event of source) {
     if (event.type === 'test:stdout' || event.type === 'test:stderr') {
@@ -911,6 +968,7 @@ async function* soundingReporter(source) {
     if (event.type === 'test:fail' && shouldReportFailure(event.data)) {
       const trial = parseTrial(event.data, 'failed')
       const file = formatPath(trial.file || event.data.file || event.data.name)
+      profileTrials.push(trial)
 
       if (!reportedFiles.has(file)) {
         reportedFiles.add(file)
@@ -922,7 +980,9 @@ async function* soundingReporter(source) {
     }
 
     if (event.type === 'test:pass') {
-      passedTrials.push(parseTrial(event.data, 'passed'))
+      const trial = parseTrial(event.data, 'passed')
+      passedTrials.push(trial)
+      profileTrials.push(trial)
       continue
     }
 
@@ -931,6 +991,13 @@ async function* soundingReporter(source) {
         const passedGroups = formatPassedGroups(passedTrials, theme)
         if (passedGroups) {
           yield `\n${passedGroups}\n\n`
+        }
+      }
+
+      if (isProfile()) {
+        const profile = formatProfileTrials(profileTrials, theme)
+        if (profile) {
+          yield `\n${profile}\n\n`
         }
       }
 
@@ -946,6 +1013,7 @@ module.exports.defaultSourceLoader = defaultSourceLoader
 module.exports.formatFailure = formatFailure
 module.exports.formatMetadataGroups = formatMetadataGroups
 module.exports.formatPassedGroups = formatPassedGroups
+module.exports.formatProfileTrials = formatProfileTrials
 module.exports.formatSummary = formatSummary
 module.exports.parseFailure = parseFailure
 module.exports.parseSoundingDiagnostics = parseSoundingDiagnostics

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -201,6 +201,43 @@ function getChangedTestFiles(appPath) {
 }
 
 /**
+ * @param {string} value
+ * @param {string} flag
+ * @returns {string}
+ */
+function normalizeShardValue(value, flag = '--shard') {
+  const match = String(value || '').match(/^(\d+)\/(\d+)$/)
+
+  if (!match) {
+    throw new Error(`Sounding test option \`${flag}\` must use part/total, for example \`--shard=1/4\`.`)
+  }
+
+  const part = Number(match[1])
+  const total = Number(match[2])
+
+  if (part < 1 || total < 1 || part > total) {
+    throw new Error(`Sounding test option \`${flag}\` must use a valid part/total shard, for example \`--shard=1/4\`.`)
+  }
+
+  return `${part}/${total}`
+}
+
+/**
+ * @param {string} value
+ * @param {string} flag
+ * @returns {string}
+ */
+function normalizeSlowLimit(value, flag = '--slow') {
+  const limit = Number(value)
+
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error(`Sounding test option \`${flag}\` must be a positive integer.`)
+  }
+
+  return String(limit)
+}
+
+/**
  * @param {string} appPath
  * @param {string[]} targets
  * @returns {string[]}
@@ -268,6 +305,23 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
       continue
     }
 
+    if (arg === '--profile') {
+      env.SOUNDING_REPORTER_PROFILE = '1'
+      continue
+    }
+
+    if (arg === '--slow') {
+      env.SOUNDING_REPORTER_PROFILE = '1'
+      env.SOUNDING_REPORTER_SLOW_LIMIT = normalizeSlowLimit(readValue(arg), arg)
+      continue
+    }
+
+    if (arg.startsWith('--slow=')) {
+      env.SOUNDING_REPORTER_PROFILE = '1'
+      env.SOUNDING_REPORTER_SLOW_LIMIT = normalizeSlowLimit(arg.slice('--slow='.length), '--slow')
+      continue
+    }
+
     if (arg === '--verbose') {
       env.SOUNDING_REPORTER_VERBOSE = '1'
       env.SOUNDING_DIAGNOSTICS = 'verbose'
@@ -298,6 +352,21 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
       const lane = readValue(arg)
       targets.push(`tests/${lane}`)
       targets.push(`test/${lane}`)
+      continue
+    }
+
+    if (arg === '--shard') {
+      nodeArgs.push('--test-shard', normalizeShardValue(readValue(arg), arg))
+      continue
+    }
+
+    if (arg.startsWith('--shard=')) {
+      nodeArgs.push(`--test-shard=${normalizeShardValue(arg.slice('--shard='.length), '--shard')}`)
+      continue
+    }
+
+    if (arg === '--parallel') {
+      nodeArgs.push('--test-concurrency=true')
       continue
     }
 

--- a/test/sounding-reporter.test.js
+++ b/test/sounding-reporter.test.js
@@ -133,6 +133,64 @@ test('formatPassedGroups accepts raw Node pass events', () => {
   assert.match(rendered, /✓ JSON paths read like product facts\s+2ms/)
 })
 
+test('formatProfileTrials renders the slowest trials in duration order', () => {
+  const rendered = reporter.formatProfileTrials(
+    [
+      reporter.parseTrial(
+        {
+          name: 'fast endpoint response',
+          file: path.join(process.cwd(), 'tests', 'api.test.js'),
+          details: {
+            duration_ms: 4,
+          },
+        },
+        'passed'
+      ),
+      reporter.parseTrial(
+        {
+          name: 'browser checkout flow',
+          file: path.join(process.cwd(), 'tests', 'browser', 'checkout.test.js'),
+          details: {
+            duration_ms: 42,
+          },
+        },
+        'passed'
+      ),
+      reporter.parseTrial(
+        {
+          name: 'failing billing request',
+          file: path.join(process.cwd(), 'tests', 'billing.test.js'),
+          details: {
+            duration_ms: 18,
+          },
+        },
+        'failed',
+        {
+          sourceLoader() {
+            return ''
+          },
+        }
+      ),
+    ],
+    {
+      red: (value) => value,
+      green: (value) => value,
+      bold: (value) => value,
+      dim: (value) => value,
+      cyan: (value) => value,
+    },
+    {
+      limit: 2,
+    }
+  )
+
+  assert.match(rendered, /PROFILE\s+Slowest trials/)
+  assert.match(rendered, /1\. 42ms\s+passed\s+tests\/browser\/checkout\.test\.js/)
+  assert.match(rendered, /browser checkout flow/)
+  assert.match(rendered, /2\. 18ms\s+failed\s+tests\/billing\.test\.js/)
+  assert.doesNotMatch(rendered, /fast endpoint response/)
+})
+
 test('renderFailure can include raw wrapper error details and cause chains', () => {
   const cause = new Error('expected 2 to equal 3')
   const wrapper = new Error('test failed')

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -149,6 +149,72 @@ test('buildTestCommand maps Sounding reporter mode flags to environment', () => 
   ])
 })
 
+test('buildTestCommand maps sharding, parallel, and profiling flags', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: ['--lane', 'browser', '--shard=1/3', '--parallel', '--profile', '--slow=2'],
+  })
+
+  assert.deepEqual(command.env, {
+    SOUNDING_REPORTER_PROFILE: '1',
+    SOUNDING_REPORTER_SLOW_LIMIT: '2',
+  })
+  assert.deepEqual(command.files, ['tests/browser/login.test.js'])
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-reporter',
+    DEFAULT_REPORTER_PATH,
+    '--test-shard=1/3',
+    '--test-concurrency=true',
+    'tests/browser/login.test.js',
+  ])
+})
+
+test('buildTestCommand accepts separated shard and slow values', () => {
+  const appPath = createTempApp()
+  const command = buildTestCommand({
+    appPath,
+    nodeExecutable: 'node',
+    argv: ['--shard', '2/4', '--slow', '3', '--file', 'tests/account.test.js'],
+  })
+
+  assert.deepEqual(command.env, {
+    SOUNDING_REPORTER_PROFILE: '1',
+    SOUNDING_REPORTER_SLOW_LIMIT: '3',
+  })
+  assert.deepEqual(command.args, [
+    '--test',
+    '--test-reporter',
+    DEFAULT_REPORTER_PATH,
+    '--test-shard',
+    '2/4',
+    'tests/account.test.js',
+  ])
+})
+
+test('buildTestCommand validates friendly sharding and slow profile values', () => {
+  const appPath = createTempApp()
+
+  assert.throws(
+    () => buildTestCommand({ appPath, argv: ['--shard=0/2'] }),
+    /must use a valid part\/total shard/
+  )
+  assert.throws(
+    () => buildTestCommand({ appPath, argv: ['--shard=3/2'] }),
+    /must use a valid part\/total shard/
+  )
+  assert.throws(
+    () => buildTestCommand({ appPath, argv: ['--shard=first/second'] }),
+    /must use part\/total/
+  )
+  assert.throws(
+    () => buildTestCommand({ appPath, argv: ['--slow=0'] }),
+    /must be a positive integer/
+  )
+})
+
 test('buildTestCommand can request the Sounding reporter explicitly', () => {
   const appPath = createTempApp()
   const command = buildTestCommand({
@@ -233,6 +299,27 @@ test('bin/sounding.js shows a readable PASS block for small successful runs', ()
   assert.doesNotMatch(stdout, /Tests:\s{2,}\d/)
   assert.match(stdout, /\n\n {6}Duration: \d+ms/)
   assert.doesNotMatch(stdout, /\n\n {0,5}Duration:/)
+})
+
+test('bin/sounding.js can print the slowest trial profile', () => {
+  const appPath = createTempApp()
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, '..', 'bin', 'sounding.js'),
+    'test',
+    '--app',
+    appPath,
+    '--file',
+    'tests/account.test.js',
+    '--profile',
+    '--slow=1',
+  ], { env: createChildEnv() })
+  const stdout = result.stdout.toString()
+
+  assert.equal(result.status, 0, result.stderr.toString())
+  assert.match(stdout, /PROFILE\s+Slowest trials/)
+  assert.match(stdout, /\bpassed\s+tests\/account\.test\.js/)
+  assert.match(stdout, /account/)
+  assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total/)
 })
 
 test('bin/sounding.js uses the Sounding reporter for failures by default', () => {


### PR DESCRIPTION
## Summary

- add Sounding-friendly `--shard`, `--parallel`, `--profile`, and `--slow` runner flags
- map sharding and parallel execution to Node's native test runner flags
- render an opt-in slowest-trials profile block in the Sounding reporter
- document the new flags in the package README, including a GitHub Actions matrix example

## Validation

- `node --test test/test-runner.test.js test/sounding-reporter.test.js`
- `npm test`
- `npm run typecheck`
- `node ./bin/sounding.js test --app examples/pretty-output-success --profile --slow=1`
- `node ./bin/sounding.js test --app examples/pretty-output-success --lane browser --shard=1/4 --parallel --dry-run`

Closes #87.

Docs-site follow-up: sailscastshq/docs.sailscasts.com#91.