### PR TITLE
feat: add expect-first browser page wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,18 +317,196 @@ Sounding does not ship hand-written `.d.ts` files right now. If TypeScript consu
 Browser trials start on the `desktop` project:
 
 ```js
-test('subscriber can read a gated issue', { browser: true }, async ({ page }) => {
-  await page.goto('/issues/the-nerve-to-build')
+test('subscriber can read a gated issue', { browser: true }, async ({ visit, expect }) => {
+  const page = await visit('/issues/the-nerve-to-build')
+
+  await expect(page).toSee('The rest of the story')
+  expect(page).toHaveNoSmoke()
 })
 ```
 
 Use a string when a trial needs a named project:
 
 ```js
-test('mobile navigation opens the account menu', { browser: 'mobile' }, async ({ page }) => {
-  await page.goto('/dashboard')
+test('mobile navigation opens the account menu', { browser: 'mobile' }, async ({ visit, expect }) => {
+  const page = await visit('/dashboard').inDarkMode()
+
+  await page.click('Account')
+  await expect(page).toSee('Settings')
 })
 ```
+
+Browser `page` is a Sounding wrapper around the Playwright page. It keeps common
+actions fluent while assertions stay under `expect(page)`:
+
+```js
+await page
+  .click('@send-link')
+  .type('email', 'creator@example.com')
+  .press('Send link')
+
+await expect(page).toSee('Check your email')
+await expect(page).not.toSee('Invalid email')
+expect(page).toHavePath('/check-email')
+```
+
+### Browser test handles
+
+Use `@name` for stable test handles. This is a Sounding convention inspired by
+Pest's browser-testing ergonomics: the `@` prefix does not mean CSS, id, or a
+JavaScript decorator. It means "find this element by its test handle."
+
+Sounding maps `@send-link` to elements with `data-test="send-link"` or
+`data-testid="send-link"`:
+
+```html
+<button data-test="send-link">Email me a link</button>
+```
+
+```js
+await page.click('@send-link')
+```
+
+Prefer test handles for controls whose visible copy may change, repeated UI, or
+elements that do not have a natural accessible label. Plain text and normal CSS
+selectors still work:
+
+```js
+await page.click('Email me a link')
+await page.click('#send-link')
+await page.fill('input[name="email"]', 'creator@example.com')
+```
+
+### Host-aware browser visits
+
+Use `withHost()` when the host matters to the app:
+
+```js
+const page = await visit('/dashboard')
+  .withHost('app.test')
+  .inDarkMode()
+```
+
+That resolves the relative visit target to `http://app.test/dashboard`. If the
+host includes a scheme, Sounding preserves it:
+
+```js
+await visit('/dashboard').withHost('https://creator.example.com')
+```
+
+This is useful for tenant domains, custom host routing, signed-link hosts, and
+apps that branch on the request `Host` header.
+
+Use the trial option for browser projects:
+
+```js
+test('mobile nav works', { browser: 'mobile' }, async ({ visit }) => {
+  await visit('/dashboard')
+})
+```
+
+Use `visit().on()` when one visit inside a browser trial needs a different
+project before navigation:
+
+```js
+test('mobile nav works', { browser: true }, async ({ visit }) => {
+  await visit('/dashboard').onMobile()
+  await visit('/dashboard').on('safari')
+})
+```
+
+For a whole trial, prefer `{ browser: 'mobile' }`. For one specific visit,
+`visit('/path').onMobile()` closes the current browser session, opens the named
+project, then applies actor login, color scheme, locale, host, and other setup
+before it navigates.
+
+The wrapper also includes common browser journey verbs:
+
+```js
+await visit('/settings')
+  .as('owner')
+  .inDarkMode()
+  .withGeolocation(6.5244, 3.3792)
+  .click('@avatar')
+  .attach('@avatar-file', 'fixtures/avatar.png')
+  .typeSlowly('@display-name', 'Kelvin')
+  .clear('@tagline')
+  .append('@tagline', 'Building in public')
+  .key('Enter')
+
+await page.withinFrame('@billing-frame', async (frame) => {
+  await frame.click('@save-card')
+})
+
+await page.screenshotElement('@receipt', '.tmp/receipt.png')
+
+expect(page).toHaveNoConsoleErrors()
+expect(page).toHaveNoSmoke()
+```
+
+Supported browser page actions:
+
+| API | Purpose |
+| --- | --- |
+| `page.click(target)` | Click visible text, a test handle, or selector. |
+| `page.type(target, value)` / `page.fill(target, value)` | Fill an input by label, test handle, or selector. |
+| `page.typeSlowly(target, value)` | Type with a small delay for search boxes, masks, and key-driven UI. |
+| `page.append(target, value)` | Add text to the current input value. |
+| `page.clear(target)` | Empty an input. |
+| `page.press(target, key)` | Press a key while focused on a target. |
+| `page.select(target, value)` | Select an option. |
+| `page.check(target)` / `page.uncheck(target)` | Toggle checkboxes and radios. |
+| `page.hover(target)` | Hover over a target. |
+| `page.attach(target, files)` | Attach one or more files to an upload input. |
+| `page.drag(source, target)` | Drag one target onto another. |
+| `page.scroll(target)` | Scroll an element into view, or scroll the page with numeric coordinates. |
+| `page.wait(target)` | Wait for a timeout, selector, test handle, or load state. |
+| `page.resize(width, height)` | Resize the page viewport. |
+| `page.key(key)` / `page.keys(keys)` | Press keyboard shortcuts. |
+| `page.back()` / `page.forward()` / `page.reload()` | Navigate browser history or reload. |
+| `page.debug()` | Pause in Playwright when the runtime supports it. |
+| `page.withinFrame(target, callback)` | Scope actions to an iframe. |
+
+Supported browser setup helpers:
+
+| API | Purpose |
+| --- | --- |
+| `visit('/path').as(actor)` | Log in as a world actor before navigation. |
+| `visit('/path').on(project)` / `onMobile()` | Open a named browser project before navigation. |
+| `visit('/path').withHost(host)` | Resolve relative paths against a specific host. |
+| `visit('/path').inDarkMode()` / `inLightMode()` | Emulate color scheme before navigation. |
+| `visit('/path').withLocale(locale)` | Override browser locale signals where possible. |
+| `visit('/path').withTimezone(timezone)` | Store timezone intent for browser metadata and future context support. |
+| `visit('/path').withUserAgent(userAgent)` | Set the page user-agent header where possible. |
+| `visit('/path').withGeolocation(lat, lon)` | Grant geolocation permission and set coordinates where possible. |
+
+Supported browser read and capture helpers:
+
+| API | Purpose |
+| --- | --- |
+| `page.url()` | Read the current URL. |
+| `page.text()` / `page.text(target)` | Read full-page text or target text. |
+| `page.html()` / `page.content()` | Read the page HTML. |
+| `page.script(fn, arg)` | Evaluate code in the browser. |
+| `page.screenshot(pathOrOptions)` | Capture a page screenshot. |
+| `page.screenshotElement(target, pathOrOptions)` | Capture one element. |
+
+Supported browser expectations:
+
+| API | Purpose |
+| --- | --- |
+| `expect(page).toSee(text)` | Assert page text is visible in the document text. |
+| `expect(page).not.toSee(text)` | Assert page text is absent. |
+| `expect(page).toHaveUrl(url)` | Assert the full URL, or path when the expected value starts with `/`. |
+| `expect(page).toHavePath(path)` | Assert path, query, and hash. |
+| `expect(page).toHaveTitle(title)` | Assert document title. |
+| `expect(page).toHaveNoJavascriptErrors()` | Fail on browser runtime errors. |
+| `expect(page).toHaveNoConsoleLogs()` | Fail on any console message, including `log`, `warn`, `info`, and `error`. |
+| `expect(page).toHaveNoConsoleErrors()` | Fail only on `console.error`. |
+| `expect(page).toHaveNoSmoke()` | Fail on JavaScript errors or console errors. |
+
+Raw Playwright access remains available through `page.raw` or
+`page.playwrightPage` when a browser flow needs a lower-level escape hatch.
 
 Configure named projects in `config/sounding.js` when an app needs mobile devices, WebKit, or custom context options:
 
@@ -407,7 +585,8 @@ test(
     await page.goto('/checkout')
     await page.reload()
 
-    await expect(page.getByText('Your cart')).toBeVisible()
+    await expect(page).toSee('Your cart')
+    expect(page).toHaveNoSmoke()
   }
 )
 ```
@@ -415,8 +594,10 @@ test(
 Use `false` as a concise off switch:
 
 ```js
-test('fast smoke flow', { browser: { artifacts: false } }, async ({ page }) => {
-  await page.goto('/health')
+test('fast smoke flow', { browser: { artifacts: false } }, async ({ visit, expect }) => {
+  const page = await visit('/health')
+
+  await expect(page).toSee('OK')
 })
 ```
 

--- a/lib/create-browser-manager.js
+++ b/lib/create-browser-manager.js
@@ -3,6 +3,7 @@ const path = require('node:path')
 
 const { resolveBaseUrl } = require('./create-request-client')
 const { createSoundingError } = require('./create-error')
+const { createSoundingBrowserPage } = require('./create-browser-page')
 const { loadDependencyFromApp } = require('./resolve-dependency')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
@@ -454,7 +455,11 @@ function createBrowserManager({
       ...contextOptions,
     })
 
-    const page = await context.newPage()
+    const rawPage = await context.newPage()
+    const page = createSoundingBrowserPage(rawPage, {
+      project: project.name,
+      getArtifacts: () => latestArtifacts,
+    })
     let contextClosed = false
     let traceStarted = false
     let traceStopped = false
@@ -499,7 +504,7 @@ function createBrowserManager({
      * @param {boolean} keepVideo
      */
     async function finalizeVideo(collected, keepVideo) {
-      const video = typeof page.video === 'function' ? page.video() : null
+      const video = typeof rawPage.video === 'function' ? rawPage.video() : null
 
       if (!video) {
         return
@@ -572,9 +577,9 @@ function createBrowserManager({
     async function captureFailureArtifacts() {
       const collected = createArtifactsMetadata()
 
-      if (artifacts.currentUrl && typeof page.url === 'function') {
+      if (artifacts.currentUrl && typeof rawPage.url === 'function') {
         try {
-          const currentUrl = page.url()
+          const currentUrl = rawPage.url()
           if (currentUrl) {
             await fs.mkdir(artifactPaths.directory, { recursive: true })
             await fs.writeFile(artifactPaths.currentUrl, `${currentUrl}\n`)
@@ -586,10 +591,10 @@ function createBrowserManager({
         }
       }
 
-      if (capturesFailureArtifact(artifacts.screenshot) && typeof page.screenshot === 'function') {
+      if (capturesFailureArtifact(artifacts.screenshot) && typeof rawPage.screenshot === 'function') {
         try {
           await fs.mkdir(artifactPaths.directory, { recursive: true })
-          await page.screenshot({
+          await rawPage.screenshot({
             path: artifactPaths.screenshot,
             fullPage: true,
           })
@@ -625,6 +630,7 @@ function createBrowserManager({
       browser,
       context,
       page,
+      rawPage,
       expect: playwrightTest?.expect,
       project: project.name,
       artifacts,

--- a/lib/create-browser-page.js
+++ b/lib/create-browser-page.js
@@ -1,0 +1,1248 @@
+const assert = require('node:assert/strict')
+
+const SOUNDING_BROWSER_PAGE = Symbol.for('sounding.browserPage')
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function formatUnknown(value) {
+  if (value instanceof Error) {
+    return value.message
+  }
+
+  return String(value)
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function looksLikeSelector(value) {
+  return /^(#|\.|@|\[|\/\/|\/|\w+\[|[a-z]+[.#:]|text=|role=|css=|xpath=)/i.test(value)
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeAttributeValue(value) {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+/**
+ * @param {any} target
+ * @returns {any}
+ */
+function normalizeSelectorTarget(target) {
+  if (typeof target !== 'string' || !target.startsWith('@')) {
+    return target
+  }
+
+  const handle = escapeAttributeValue(target.slice(1))
+  return `[data-test="${handle}"], [data-testid="${handle}"]`
+}
+
+/**
+ * @param {any} message
+ * @returns {{ type: string, text: string, raw: any }}
+ */
+function normalizeConsoleMessage(message) {
+  const type = typeof message?.type === 'function' ? message.type() : message?.type || 'log'
+  const text = typeof message?.text === 'function' ? message.text() : message?.text || String(message)
+
+  return {
+    type,
+    text,
+    raw: message,
+  }
+}
+
+/**
+ * @param {any} rawPage
+ * @param {any} target
+ * @returns {any}
+ */
+function locatorForTarget(rawPage, target) {
+  if (typeof target !== 'string' || looksLikeSelector(target)) {
+    return null
+  }
+
+  if (typeof rawPage.getByLabel === 'function') {
+    return rawPage.getByLabel(target)
+  }
+
+  if (typeof rawPage.getByText === 'function') {
+    return rawPage.getByText(target)
+  }
+
+  return null
+}
+
+/**
+ * @param {any} rawPage
+ * @param {any} target
+ * @returns {any}
+ */
+function textLocatorForTarget(rawPage, target) {
+  if (typeof target !== 'string' || looksLikeSelector(target)) {
+    return null
+  }
+
+  if (typeof rawPage.getByText === 'function') {
+    return rawPage.getByText(target)
+  }
+
+  return null
+}
+
+/**
+ * @param {any} locator
+ * @param {string} action
+ * @param {any[]} args
+ * @returns {Promise<any>}
+ */
+async function callLocatorValue(locator, action, args = []) {
+  const target = typeof locator?.first === 'function' ? locator.first() : locator
+
+  if (typeof target?.[action] !== 'function') {
+    return undefined
+  }
+
+  return target[action](...args)
+}
+
+/**
+ * @param {any} locator
+ * @param {string} action
+ * @param {any[]} args
+ * @returns {Promise<boolean>}
+ */
+async function callLocatorAction(locator, action, args = []) {
+  const target = typeof locator?.first === 'function' ? locator.first() : locator
+
+  if (typeof target?.[action] !== 'function') {
+    return false
+  }
+
+  await target[action](...args)
+  return true
+}
+
+/**
+ * @param {string} host
+ * @returns {string}
+ */
+function normalizeHost(host) {
+  if (/^https?:\/\//i.test(host)) {
+    return host
+  }
+
+  return `http://${host}`
+}
+
+/**
+ * @param {any} frame
+ * @param {any} parentRawPage
+ * @returns {any}
+ */
+function createFrameAdapter(frame, parentRawPage) {
+  if (typeof frame?.click === 'function' || typeof frame?.goto === 'function') {
+    return frame
+  }
+
+  const locatorAction = async (selector, action, args = []) => {
+    const locator = frame?.locator?.(normalizeSelectorTarget(selector))
+    if (typeof locator?.[action] !== 'function') {
+      throw new TypeError(`Sounding browser frame does not support ${action}().`)
+    }
+
+    return locator[action](...args)
+  }
+
+  return {
+    locator: typeof frame?.locator === 'function' ? frame.locator.bind(frame) : undefined,
+    getByText: typeof frame?.getByText === 'function' ? frame.getByText.bind(frame) : undefined,
+    getByLabel: typeof frame?.getByLabel === 'function' ? frame.getByLabel.bind(frame) : undefined,
+    url: typeof parentRawPage?.url === 'function' ? parentRawPage.url.bind(parentRawPage) : undefined,
+    title: typeof parentRawPage?.title === 'function' ? parentRawPage.title.bind(parentRawPage) : undefined,
+    click: (selector, options) => locatorAction(selector, 'click', [options]),
+    fill: (selector, value, options) => locatorAction(selector, 'fill', [value, options]),
+    type: (selector, value, options) => locatorAction(selector, 'type', [value, options]),
+    press: (selector, key, options) => locatorAction(selector, 'press', [key, options]),
+    selectOption: (selector, value, options) => locatorAction(selector, 'selectOption', [value, options]),
+    check: (selector, options) => locatorAction(selector, 'check', [options]),
+    uncheck: (selector, options) => locatorAction(selector, 'uncheck', [options]),
+    hover: (selector, options) => locatorAction(selector, 'hover', [options]),
+    setInputFiles: (selector, files, options) => locatorAction(selector, 'setInputFiles', [files, options]),
+    waitForSelector: (selector, options) => locatorAction(selector, 'waitFor', [options]),
+    evaluate: typeof parentRawPage?.evaluate === 'function' ? parentRawPage.evaluate.bind(parentRawPage) : undefined,
+    keyboard: parentRawPage?.keyboard,
+    screenshot: typeof parentRawPage?.screenshot === 'function' ? parentRawPage.screenshot.bind(parentRawPage) : undefined,
+  }
+}
+
+/**
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isSoundingBrowserPage(value) {
+  return Boolean(value?.[SOUNDING_BROWSER_PAGE])
+}
+
+/**
+ * @param {any} page
+ * @returns {any}
+ */
+function getRawPage(page) {
+  return isSoundingBrowserPage(page) ? page.raw : page
+}
+
+/**
+ * @param {any} page
+ * @returns {any}
+ */
+function getBrowserPageState(page) {
+  return isSoundingBrowserPage(page) ? page.__soundingState : null
+}
+
+/**
+ * @param {any} page
+ * @returns {string}
+ */
+function getBrowserPageUrl(page) {
+  const rawPage = getRawPage(page)
+  return typeof rawPage?.url === 'function' ? rawPage.url() : ''
+}
+
+/**
+ * @param {any} page
+ * @returns {string}
+ */
+function formatBrowserPageDiagnostics(page) {
+  const url = getBrowserPageUrl(page)
+  const state = getBrowserPageState(page)
+  const lines = []
+
+  if (url) {
+    lines.push(`Current URL: ${url}`)
+  }
+
+  const artifacts = state?.getArtifacts?.()
+  if (artifacts?.screenshot) {
+    lines.push(`Screenshot: ${artifacts.screenshot}`)
+  }
+
+  if (artifacts?.trace) {
+    lines.push(`Trace: ${artifacts.trace}`)
+  }
+
+  if (artifacts?.video) {
+    lines.push(`Video: ${artifacts.video}`)
+  }
+
+  return lines.length ? `\n\nSounding browser diagnostics:\n${lines.map((line) => `- ${line}`).join('\n')}` : ''
+}
+
+/**
+ * @param {string} message
+ * @param {any} page
+ */
+function failWithBrowserDiagnostics(message, page) {
+  assert.fail(`${message}${formatBrowserPageDiagnostics(page)}`)
+}
+
+/**
+ * @param {any} rawPage
+ * @param {{
+ *   project?: string,
+ *   login?: { as?: Function, withPassword?: Function },
+ *   getArtifacts?: () => any,
+ * }} [options]
+ * @returns {any}
+ */
+function createSoundingBrowserPage(rawPage, options = {}) {
+  if (isSoundingBrowserPage(rawPage)) {
+    return rawPage
+  }
+
+  const state = {
+    host: null,
+    project: options.project,
+    login: options.login,
+    javascriptErrors: [],
+    consoleMessages: [],
+    consoleErrors: [],
+    getArtifacts: options.getArtifacts || (() => null),
+  }
+  let wrapper = null
+
+  if (typeof rawPage?.on === 'function') {
+    rawPage.on('pageerror', (error) => {
+      state.javascriptErrors.push(error)
+    })
+    rawPage.on('console', (message) => {
+      const normalized = normalizeConsoleMessage(message)
+      state.consoleMessages.push(normalized)
+
+      if (normalized.type === 'error') {
+        state.consoleErrors.push(normalized)
+      }
+    })
+  }
+
+  function resolveNavigationTarget(target) {
+    if (!state.host || typeof target !== 'string' || !target.startsWith('/')) {
+      return target
+    }
+
+    return new URL(target, normalizeHost(state.host)).toString()
+  }
+
+  async function performNavigate(target, navigationOptions) {
+    if (typeof rawPage?.goto !== 'function') {
+      throw new TypeError('Sounding browser page navigation requires a Playwright page with goto().')
+    }
+
+    await rawPage.goto(resolveNavigationTarget(target), navigationOptions)
+  }
+
+  async function performClick(target, actionOptions) {
+    const locator = textLocatorForTarget(rawPage, target)
+
+    if (locator && (await callLocatorAction(locator, 'click', [actionOptions]))) {
+      return
+    }
+
+    await rawPage.click(normalizeSelectorTarget(target), actionOptions)
+  }
+
+  async function performFill(target, value, actionOptions) {
+    const locator = locatorForTarget(rawPage, target)
+
+    if (locator && (await callLocatorAction(locator, 'fill', [value, actionOptions]))) {
+      return
+    }
+
+    await rawPage.fill(normalizeSelectorTarget(target), value, actionOptions)
+  }
+
+  async function performTypeSlowly(target, value, actionOptions = {}) {
+    const optionsWithDelay = {
+      delay: 50,
+      ...actionOptions,
+    }
+    const locator = locatorForTarget(rawPage, target)
+
+    if (locator && (await callLocatorAction(locator, 'pressSequentially', [value, optionsWithDelay]))) {
+      return
+    }
+
+    if (locator && (await callLocatorAction(locator, 'type', [value, optionsWithDelay]))) {
+      return
+    }
+
+    if (typeof rawPage?.type === 'function') {
+      await rawPage.type(normalizeSelectorTarget(target), value, optionsWithDelay)
+      return
+    }
+
+    await performFill(target, value, actionOptions)
+  }
+
+  async function performClear(target, actionOptions) {
+    await performFill(target, '', actionOptions)
+  }
+
+  async function performAppend(target, value, actionOptions) {
+    const locator = locatorForTarget(rawPage, target)
+    const currentValue =
+      (locator && (await callLocatorValue(locator, 'inputValue'))) ||
+      (typeof rawPage?.inputValue === 'function'
+        ? await rawPage.inputValue(normalizeSelectorTarget(target))
+        : '')
+
+    await performFill(target, `${currentValue}${value}`, actionOptions)
+  }
+
+  async function performPress(target, key, actionOptions) {
+    if (key === undefined) {
+      await performClick(target, actionOptions)
+      return
+    }
+
+    await rawPage.press(normalizeSelectorTarget(target), key, actionOptions)
+  }
+
+  async function performSelect(target, value, actionOptions) {
+    await rawPage.selectOption(normalizeSelectorTarget(target), value, actionOptions)
+  }
+
+  async function performCheck(target, actionOptions) {
+    const locator = locatorForTarget(rawPage, target)
+
+    if (locator && (await callLocatorAction(locator, 'check', [actionOptions]))) {
+      return
+    }
+
+    await rawPage.check(normalizeSelectorTarget(target), actionOptions)
+  }
+
+  async function performUncheck(target, actionOptions) {
+    const locator = locatorForTarget(rawPage, target)
+
+    if (locator && (await callLocatorAction(locator, 'uncheck', [actionOptions]))) {
+      return
+    }
+
+    await rawPage.uncheck(normalizeSelectorTarget(target), actionOptions)
+  }
+
+  async function performHover(target, actionOptions) {
+    await rawPage.hover(normalizeSelectorTarget(target), actionOptions)
+  }
+
+  async function performAttach(target, files, actionOptions) {
+    const locator = locatorForTarget(rawPage, target)
+
+    if (locator && (await callLocatorAction(locator, 'setInputFiles', [files, actionOptions]))) {
+      return
+    }
+
+    await rawPage.setInputFiles(normalizeSelectorTarget(target), files, actionOptions)
+  }
+
+  async function performDrag(source, target, actionOptions) {
+    const sourceLocator = locatorForTarget(rawPage, source)
+    const targetLocator = locatorForTarget(rawPage, target)
+
+    if (
+      sourceLocator &&
+      targetLocator &&
+      (await callLocatorAction(sourceLocator, 'dragTo', [targetLocator, actionOptions]))
+    ) {
+      return
+    }
+
+    await rawPage.dragAndDrop(
+      normalizeSelectorTarget(source),
+      normalizeSelectorTarget(target),
+      actionOptions
+    )
+  }
+
+  async function performScroll(target, y) {
+    if (typeof target === 'string' && typeof rawPage.locator === 'function') {
+      const locator = rawPage.locator(normalizeSelectorTarget(target))
+      if (typeof locator?.scrollIntoViewIfNeeded === 'function') {
+        await locator.scrollIntoViewIfNeeded()
+        return
+      }
+    }
+
+    const x = typeof target === 'number' ? target : 0
+    const nextY = typeof y === 'number' ? y : typeof target === 'number' ? 0 : target || 0
+
+    if (typeof rawPage.evaluate === 'function') {
+      await rawPage.evaluate(([left, top]) => window.scrollTo(left, top), [x, nextY])
+    }
+  }
+
+  async function performWait(target, options) {
+    if (typeof target === 'number' && typeof rawPage.waitForTimeout === 'function') {
+      await rawPage.waitForTimeout(target)
+      return
+    }
+
+    if (typeof target === 'string' && typeof rawPage.waitForSelector === 'function') {
+      await rawPage.waitForSelector(normalizeSelectorTarget(target), options)
+      return
+    }
+
+    if (typeof rawPage.waitForLoadState === 'function') {
+      await rawPage.waitForLoadState(target || 'load', options)
+    }
+  }
+
+  async function performResize(widthOrViewport, height) {
+    if (typeof rawPage?.setViewportSize !== 'function') {
+      throw new TypeError('Sounding browser page resize() requires a Playwright page with setViewportSize().')
+    }
+
+    const viewport =
+      typeof widthOrViewport === 'object'
+        ? widthOrViewport
+        : {
+            width: widthOrViewport,
+            height,
+          }
+
+    await rawPage.setViewportSize(viewport)
+  }
+
+  async function performKey(key, options) {
+    if (typeof rawPage?.keyboard?.press !== 'function') {
+      throw new TypeError('Sounding browser page key() requires a Playwright page keyboard.')
+    }
+
+    await rawPage.keyboard.press(key, options)
+  }
+
+  async function performKeys(keys, options) {
+    const entries = Array.isArray(keys) ? keys : [keys]
+
+    for (const key of entries) {
+      await performKey(key, options)
+    }
+  }
+
+  async function performBack(options) {
+    await rawPage.goBack(options)
+  }
+
+  async function performForward(options) {
+    await rawPage.goForward(options)
+  }
+
+  async function performReload(options) {
+    await rawPage.reload(options)
+  }
+
+  async function performDebug() {
+    if (typeof rawPage?.pause === 'function') {
+      await rawPage.pause()
+    }
+  }
+
+  async function performWithinFrame(target, callback) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('Sounding browser page withinFrame() requires a callback.')
+    }
+
+    const frame =
+      typeof target === 'string' && typeof rawPage?.frameLocator === 'function'
+        ? rawPage.frameLocator(normalizeSelectorTarget(target))
+        : typeof target === 'string' && typeof rawPage?.frame === 'function'
+          ? rawPage.frame(target)
+          : target
+
+    if (!frame) {
+      throw new TypeError(`Sounding browser page could not find frame ${formatUnknown(target)}.`)
+    }
+
+    const framePage = createSoundingBrowserPage(createFrameAdapter(frame, rawPage), {
+      project: state.project,
+      login: state.login,
+      getArtifacts: state.getArtifacts,
+    })
+
+    await callback(framePage)
+  }
+
+  async function readText(target) {
+    if (target === undefined) {
+      return getBrowserPageText(wrapper)
+    }
+
+    if (typeof rawPage?.locator === 'function') {
+      const locator = rawPage.locator(normalizeSelectorTarget(target))
+      if (typeof locator?.textContent === 'function') {
+        return (await locator.textContent()) || ''
+      }
+    }
+
+    if (typeof rawPage?.textContent === 'function') {
+      return (await rawPage.textContent(normalizeSelectorTarget(target))) || ''
+    }
+
+    return ''
+  }
+
+  async function readContent() {
+    return typeof rawPage?.content === 'function' ? rawPage.content() : ''
+  }
+
+  async function evaluateScript(pageFunction, arg) {
+    if (typeof rawPage?.evaluate !== 'function') {
+      throw new TypeError('Sounding browser page script() requires a Playwright page with evaluate().')
+    }
+
+    return rawPage.evaluate(pageFunction, arg)
+  }
+
+  async function captureScreenshot(pathOrOptions, screenshotOptions) {
+    if (typeof rawPage?.screenshot !== 'function') {
+      throw new TypeError('Sounding browser page screenshot() requires a Playwright page with screenshot().')
+    }
+
+    const options =
+      typeof pathOrOptions === 'string'
+        ? {
+            ...screenshotOptions,
+            path: pathOrOptions,
+          }
+        : pathOrOptions || {}
+
+    return rawPage.screenshot(options)
+  }
+
+  async function captureElementScreenshot(target, pathOrOptions, screenshotOptions) {
+    if (typeof rawPage?.locator !== 'function') {
+      throw new TypeError('Sounding browser page screenshotElement() requires a Playwright page with locator().')
+    }
+
+    const locator = rawPage.locator(normalizeSelectorTarget(target))
+    if (typeof locator?.screenshot !== 'function') {
+      throw new TypeError('Sounding browser page screenshotElement() requires a locator with screenshot().')
+    }
+
+    const options =
+      typeof pathOrOptions === 'string'
+        ? {
+            ...screenshotOptions,
+            path: pathOrOptions,
+          }
+        : pathOrOptions || {}
+
+    return locator.screenshot(options)
+  }
+
+  async function performColorScheme(colorScheme) {
+    if (typeof rawPage.emulateMedia === 'function') {
+      await rawPage.emulateMedia({ colorScheme })
+    }
+  }
+
+  async function performLocale(locale) {
+    state.locale = locale
+
+    if (typeof rawPage.addInitScript === 'function') {
+      await rawPage.addInitScript((nextLocale) => {
+        Object.defineProperty(window.navigator, 'language', { get: () => nextLocale })
+        Object.defineProperty(window.navigator, 'languages', { get: () => [nextLocale] })
+      }, locale)
+    }
+  }
+
+  async function performTimezone(timezone) {
+    state.timezone = timezone
+  }
+
+  async function performUserAgent(userAgent) {
+    state.userAgent = userAgent
+
+    if (typeof rawPage.setExtraHTTPHeaders === 'function') {
+      await rawPage.setExtraHTTPHeaders({ 'user-agent': userAgent })
+    }
+  }
+
+  async function performGeolocation(latitudeOrCoordinates, longitude, accuracy) {
+    const geolocation =
+      typeof latitudeOrCoordinates === 'object'
+        ? latitudeOrCoordinates
+        : {
+            latitude: latitudeOrCoordinates,
+            longitude,
+            ...(accuracy === undefined ? {} : { accuracy }),
+          }
+    state.geolocation = geolocation
+
+    const context = typeof rawPage?.context === 'function' ? rawPage.context() : rawPage?.context
+    if (typeof context?.grantPermissions === 'function') {
+      await context.grantPermissions(['geolocation'])
+    }
+
+    if (typeof context?.setGeolocation === 'function') {
+      await context.setGeolocation(geolocation)
+    }
+  }
+
+  async function performHost(host) {
+    state.host = host
+  }
+
+  async function performProject(project) {
+    state.project = project
+  }
+
+  async function performActorLogin(actor, loginOptions) {
+    const login = state.login || options.login
+
+    if (!login?.as) {
+      throw new TypeError('Sounding browser page actor login requires auth.login.as().')
+    }
+
+    await login.as(actor, wrapper, loginOptions)
+  }
+
+  function createActionChain(firstAction) {
+    let promise = Promise.resolve()
+
+    function enqueue(action) {
+      promise = promise.then(action)
+      return chain
+    }
+
+    const chain = {
+      click(target, actionOptions) {
+        return enqueue(() => performClick(target, actionOptions))
+      },
+      type(target, value, actionOptions) {
+        return enqueue(() => performFill(target, value, actionOptions))
+      },
+      fill(target, value, actionOptions) {
+        return enqueue(() => performFill(target, value, actionOptions))
+      },
+      typeSlowly(target, value, actionOptions) {
+        return enqueue(() => performTypeSlowly(target, value, actionOptions))
+      },
+      append(target, value, actionOptions) {
+        return enqueue(() => performAppend(target, value, actionOptions))
+      },
+      clear(target, actionOptions) {
+        return enqueue(() => performClear(target, actionOptions))
+      },
+      press(target, key, actionOptions) {
+        return enqueue(() => performPress(target, key, actionOptions))
+      },
+      select(target, value, actionOptions) {
+        return enqueue(() => performSelect(target, value, actionOptions))
+      },
+      check(target, actionOptions) {
+        return enqueue(() => performCheck(target, actionOptions))
+      },
+      uncheck(target, actionOptions) {
+        return enqueue(() => performUncheck(target, actionOptions))
+      },
+      hover(target, actionOptions) {
+        return enqueue(() => performHover(target, actionOptions))
+      },
+      attach(target, files, actionOptions) {
+        return enqueue(() => performAttach(target, files, actionOptions))
+      },
+      drag(source, target, actionOptions) {
+        return enqueue(() => performDrag(source, target, actionOptions))
+      },
+      scroll(target, y) {
+        return enqueue(() => performScroll(target, y))
+      },
+      wait(target, waitOptions) {
+        return enqueue(() => performWait(target, waitOptions))
+      },
+      resize(widthOrViewport, height) {
+        return enqueue(() => performResize(widthOrViewport, height))
+      },
+      key(key, keyOptions) {
+        return enqueue(() => performKey(key, keyOptions))
+      },
+      keys(keys, keyOptions) {
+        return enqueue(() => performKeys(keys, keyOptions))
+      },
+      navigate(target, navigationOptions) {
+        return enqueue(() => performNavigate(target, navigationOptions))
+      },
+      goto(target, navigationOptions) {
+        return enqueue(() => performNavigate(target, navigationOptions))
+      },
+      back(options) {
+        return enqueue(() => performBack(options))
+      },
+      forward(options) {
+        return enqueue(() => performForward(options))
+      },
+      reload(options) {
+        return enqueue(() => performReload(options))
+      },
+      debug() {
+        return enqueue(() => performDebug())
+      },
+      withinFrame(target, callback) {
+        return enqueue(() => performWithinFrame(target, callback))
+      },
+      as(actor, loginOptions) {
+        return enqueue(() => performActorLogin(actor, loginOptions))
+      },
+      on(project) {
+        return enqueue(() => performProject(project))
+      },
+      onMobile() {
+        return enqueue(() => performProject('mobile'))
+      },
+      inDarkMode() {
+        return enqueue(() => performColorScheme('dark'))
+      },
+      inLightMode() {
+        return enqueue(() => performColorScheme('light'))
+      },
+      withLocale(locale) {
+        return enqueue(() => performLocale(locale))
+      },
+      withTimezone(timezone) {
+        return enqueue(() => performTimezone(timezone))
+      },
+      withUserAgent(userAgent) {
+        return enqueue(() => performUserAgent(userAgent))
+      },
+      withGeolocation(latitudeOrCoordinates, longitude, accuracy) {
+        return enqueue(() => performGeolocation(latitudeOrCoordinates, longitude, accuracy))
+      },
+      withHost(host) {
+        return enqueue(() => performHost(host))
+      },
+      then(onFulfilled, onRejected) {
+        return promise.then(() => wrapper).then(onFulfilled, onRejected)
+      },
+      catch(onRejected) {
+        return chain.then(undefined, onRejected)
+      },
+      finally(onFinally) {
+        return promise.finally(onFinally).then(() => wrapper)
+      },
+    }
+
+    if (firstAction) {
+      enqueue(firstAction)
+    }
+
+    return chain
+  }
+
+  const api = {
+    [SOUNDING_BROWSER_PAGE]: true,
+    __soundingState: state,
+    raw: rawPage,
+    playwrightPage: rawPage,
+    get javascriptErrors() {
+      return state.javascriptErrors
+    },
+    get consoleMessages() {
+      return state.consoleMessages
+    },
+    get consoleErrors() {
+      return state.consoleErrors
+    },
+    navigate(target, navigationOptions) {
+      return createActionChain(() => performNavigate(target, navigationOptions))
+    },
+    goto(target, navigationOptions) {
+      return createActionChain(() => performNavigate(target, navigationOptions))
+    },
+    click(target, actionOptions) {
+      return createActionChain(() => performClick(target, actionOptions))
+    },
+    type(target, value, actionOptions) {
+      return createActionChain(() => performFill(target, value, actionOptions))
+    },
+    fill(target, value, actionOptions) {
+      return createActionChain(() => performFill(target, value, actionOptions))
+    },
+    typeSlowly(target, value, actionOptions) {
+      return createActionChain(() => performTypeSlowly(target, value, actionOptions))
+    },
+    append(target, value, actionOptions) {
+      return createActionChain(() => performAppend(target, value, actionOptions))
+    },
+    clear(target, actionOptions) {
+      return createActionChain(() => performClear(target, actionOptions))
+    },
+    press(target, key, actionOptions) {
+      return createActionChain(() => performPress(target, key, actionOptions))
+    },
+    select(target, value, actionOptions) {
+      return createActionChain(() => performSelect(target, value, actionOptions))
+    },
+    check(target, actionOptions) {
+      return createActionChain(() => performCheck(target, actionOptions))
+    },
+    uncheck(target, actionOptions) {
+      return createActionChain(() => performUncheck(target, actionOptions))
+    },
+    hover(target, actionOptions) {
+      return createActionChain(() => performHover(target, actionOptions))
+    },
+    attach(target, files, actionOptions) {
+      return createActionChain(() => performAttach(target, files, actionOptions))
+    },
+    drag(source, target, actionOptions) {
+      return createActionChain(() => performDrag(source, target, actionOptions))
+    },
+    scroll(target, y) {
+      return createActionChain(() => performScroll(target, y))
+    },
+    wait(target, waitOptions) {
+      return createActionChain(() => performWait(target, waitOptions))
+    },
+    resize(widthOrViewport, height) {
+      return createActionChain(() => performResize(widthOrViewport, height))
+    },
+    key(key, keyOptions) {
+      return createActionChain(() => performKey(key, keyOptions))
+    },
+    keys(keys, keyOptions) {
+      return createActionChain(() => performKeys(keys, keyOptions))
+    },
+    back(options) {
+      return createActionChain(() => performBack(options))
+    },
+    forward(options) {
+      return createActionChain(() => performForward(options))
+    },
+    reload(options) {
+      return createActionChain(() => performReload(options))
+    },
+    debug() {
+      return createActionChain(() => performDebug())
+    },
+    withinFrame(target, callback) {
+      return createActionChain(() => performWithinFrame(target, callback))
+    },
+    as(actor, loginOptions) {
+      return createActionChain(() => performActorLogin(actor, loginOptions))
+    },
+    on(project) {
+      return createActionChain(() => performProject(project))
+    },
+    onMobile() {
+      return createActionChain(() => performProject('mobile'))
+    },
+    inDarkMode() {
+      return createActionChain(() => performColorScheme('dark'))
+    },
+    inLightMode() {
+      return createActionChain(() => performColorScheme('light'))
+    },
+    withLocale(locale) {
+      return createActionChain(() => performLocale(locale))
+    },
+    withTimezone(timezone) {
+      return createActionChain(() => performTimezone(timezone))
+    },
+    withUserAgent(userAgent) {
+      return createActionChain(() => performUserAgent(userAgent))
+    },
+    withGeolocation(latitudeOrCoordinates, longitude, accuracy) {
+      return createActionChain(() => performGeolocation(latitudeOrCoordinates, longitude, accuracy))
+    },
+    withHost(host) {
+      return createActionChain(() => performHost(host))
+    },
+    url() {
+      return getBrowserPageUrl(wrapper)
+    },
+    text(target) {
+      return readText(target)
+    },
+    content() {
+      return readContent()
+    },
+    html() {
+      return readContent()
+    },
+    script(pageFunction, arg) {
+      return evaluateScript(pageFunction, arg)
+    },
+    screenshot(pathOrOptions, screenshotOptions) {
+      return captureScreenshot(pathOrOptions, screenshotOptions)
+    },
+    screenshotElement(target, pathOrOptions, screenshotOptions) {
+      return captureElementScreenshot(target, pathOrOptions, screenshotOptions)
+    },
+  }
+
+  wrapper = new Proxy(api, {
+    get(target, property, receiver) {
+      if (Reflect.has(target, property)) {
+        return Reflect.get(target, property, receiver)
+      }
+
+      const value = rawPage?.[property]
+      return typeof value === 'function' ? value.bind(rawPage) : value
+    },
+    set(target, property, value, receiver) {
+      if (Reflect.has(target, property)) {
+        return Reflect.set(target, property, value, receiver)
+      }
+
+      rawPage[property] = value
+      return true
+    },
+  })
+
+  return wrapper
+}
+
+/**
+ * @param {() => any} getPage
+ * @returns {any}
+ */
+function createMutableBrowserPage(getPage) {
+  function currentPage() {
+    const page = getPage()
+
+    if (!page) {
+      throw new TypeError('Sounding browser page is not open yet.')
+    }
+
+    return page
+  }
+
+  const api = {
+    [SOUNDING_BROWSER_PAGE]: true,
+    get __soundingState() {
+      return getBrowserPageState(currentPage())
+    },
+    get raw() {
+      return currentPage().raw
+    },
+    get playwrightPage() {
+      return currentPage().playwrightPage
+    },
+    get javascriptErrors() {
+      return currentPage().javascriptErrors
+    },
+    get consoleMessages() {
+      return currentPage().consoleMessages
+    },
+    get consoleErrors() {
+      return currentPage().consoleErrors
+    },
+  }
+
+  return new Proxy(api, {
+    get(target, property, receiver) {
+      if (Reflect.has(target, property)) {
+        return Reflect.get(target, property, receiver)
+      }
+
+      const value = currentPage()?.[property]
+      return typeof value === 'function' ? value.bind(currentPage()) : value
+    },
+    set(target, property, value, receiver) {
+      if (Reflect.has(target, property)) {
+        return Reflect.set(target, property, value, receiver)
+      }
+
+      currentPage()[property] = value
+      return true
+    },
+  })
+}
+
+/**
+ * @param {any} page
+ * @param {{ login?: { as?: Function }, transport?: string, switchProject?: (project: string) => Promise<any> }} [options]
+ * @returns {Function & { as(actor: any, options?: any): Function }}
+ */
+function createBrowserVisit(page, options = {}) {
+  const state = getBrowserPageState(page)
+  if (state && options.login) {
+    state.login = options.login
+  }
+
+  function createVisitChain(target, navigationOptions) {
+    const before = []
+    const after = []
+    let project = null
+
+    function enqueueBefore(action) {
+      before.push(action)
+      return chain
+    }
+
+    function enqueueAfter(action) {
+      after.push(action)
+      return chain
+    }
+
+    async function run() {
+      if (project) {
+        if (typeof options.switchProject === 'function') {
+          await options.switchProject(project)
+        } else {
+          await page.on(project)
+        }
+      }
+
+      for (const action of before) {
+        await action()
+      }
+
+      await page.navigate(target, navigationOptions)
+
+      for (const action of after) {
+        await action()
+      }
+
+      return page
+    }
+
+    const chain = {
+      click(actionTarget, actionOptions) {
+        return enqueueAfter(() => page.click(actionTarget, actionOptions))
+      },
+      type(actionTarget, value, actionOptions) {
+        return enqueueAfter(() => page.type(actionTarget, value, actionOptions))
+      },
+      fill(actionTarget, value, actionOptions) {
+        return enqueueAfter(() => page.fill(actionTarget, value, actionOptions))
+      },
+      typeSlowly(actionTarget, value, actionOptions) {
+        return enqueueAfter(() => page.typeSlowly(actionTarget, value, actionOptions))
+      },
+      append(actionTarget, value, actionOptions) {
+        return enqueueAfter(() => page.append(actionTarget, value, actionOptions))
+      },
+      clear(actionTarget, actionOptions) {
+        return enqueueAfter(() => page.clear(actionTarget, actionOptions))
+      },
+      press(actionTarget, key, actionOptions) {
+        return enqueueAfter(() => page.press(actionTarget, key, actionOptions))
+      },
+      select(actionTarget, value, actionOptions) {
+        return enqueueAfter(() => page.select(actionTarget, value, actionOptions))
+      },
+      check(actionTarget, actionOptions) {
+        return enqueueAfter(() => page.check(actionTarget, actionOptions))
+      },
+      uncheck(actionTarget, actionOptions) {
+        return enqueueAfter(() => page.uncheck(actionTarget, actionOptions))
+      },
+      hover(actionTarget, actionOptions) {
+        return enqueueAfter(() => page.hover(actionTarget, actionOptions))
+      },
+      attach(actionTarget, files, actionOptions) {
+        return enqueueAfter(() => page.attach(actionTarget, files, actionOptions))
+      },
+      drag(source, actionTarget, actionOptions) {
+        return enqueueAfter(() => page.drag(source, actionTarget, actionOptions))
+      },
+      scroll(actionTarget, y) {
+        return enqueueAfter(() => page.scroll(actionTarget, y))
+      },
+      wait(actionTarget, waitOptions) {
+        return enqueueAfter(() => page.wait(actionTarget, waitOptions))
+      },
+      resize(widthOrViewport, height) {
+        return enqueueBefore(() => page.resize(widthOrViewport, height))
+      },
+      key(key, keyOptions) {
+        return enqueueAfter(() => page.key(key, keyOptions))
+      },
+      keys(keys, keyOptions) {
+        return enqueueAfter(() => page.keys(keys, keyOptions))
+      },
+      back(options) {
+        return enqueueAfter(() => page.back(options))
+      },
+      forward(options) {
+        return enqueueAfter(() => page.forward(options))
+      },
+      reload(options) {
+        return enqueueAfter(() => page.reload(options))
+      },
+      debug() {
+        return enqueueAfter(() => page.debug())
+      },
+      withinFrame(frameTarget, callback) {
+        return enqueueAfter(() => page.withinFrame(frameTarget, callback))
+      },
+      as(actor, loginOptions) {
+        return enqueueBefore(() => page.as(actor, loginOptions))
+      },
+      on(projectName) {
+        project = String(projectName)
+        return chain
+      },
+      onMobile() {
+        project = 'mobile'
+        return chain
+      },
+      inDarkMode() {
+        return enqueueBefore(() => page.inDarkMode())
+      },
+      inLightMode() {
+        return enqueueBefore(() => page.inLightMode())
+      },
+      withLocale(locale) {
+        return enqueueBefore(() => page.withLocale(locale))
+      },
+      withTimezone(timezone) {
+        return enqueueBefore(() => page.withTimezone(timezone))
+      },
+      withUserAgent(userAgent) {
+        return enqueueBefore(() => page.withUserAgent(userAgent))
+      },
+      withGeolocation(latitudeOrCoordinates, longitude, accuracy) {
+        return enqueueBefore(() =>
+          page.withGeolocation(latitudeOrCoordinates, longitude, accuracy)
+        )
+      },
+      withHost(host) {
+        return enqueueBefore(() => page.withHost(host))
+      },
+      then(onFulfilled, onRejected) {
+        return run().then(onFulfilled, onRejected)
+      },
+      catch(onRejected) {
+        return chain.then(undefined, onRejected)
+      },
+      finally(onFinally) {
+        return run().finally(onFinally)
+      },
+    }
+
+    return chain
+  }
+
+  const visit = function visit(target, navigationOptions) {
+    return createVisitChain(target, navigationOptions)
+  }
+
+  Object.defineProperty(visit, 'transport', {
+    value: options.transport || 'browser',
+    enumerable: true,
+  })
+
+  visit.as = function as(actor, loginOptions) {
+    return function visitAsActor(target, navigationOptions) {
+      return createVisitChain(target, navigationOptions).as(actor, loginOptions)
+    }
+  }
+
+  return visit
+}
+
+async function getBrowserPageText(page) {
+  const rawPage = getRawPage(page)
+
+  if (typeof rawPage?.locator === 'function') {
+    const body = rawPage.locator('body')
+    if (typeof body?.textContent === 'function') {
+      return (await body.textContent()) || ''
+    }
+  }
+
+  if (typeof rawPage?.textContent === 'function') {
+    return (await rawPage.textContent('body')) || ''
+  }
+
+  if (typeof rawPage?.content === 'function') {
+    return (await rawPage.content()) || ''
+  }
+
+  return ''
+}
+
+module.exports = {
+  SOUNDING_BROWSER_PAGE,
+  createBrowserVisit,
+  createMutableBrowserPage,
+  createSoundingBrowserPage,
+  failWithBrowserDiagnostics,
+  formatBrowserPageDiagnostics,
+  getBrowserPageState,
+  getBrowserPageText,
+  getBrowserPageUrl,
+  getRawPage,
+  isSoundingBrowserPage,
+}

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -1,9 +1,28 @@
 const assert = require('node:assert/strict')
 
+const {
+  failWithBrowserDiagnostics,
+  getBrowserPageState,
+  getBrowserPageText,
+  getBrowserPageUrl,
+  isSoundingBrowserPage,
+} = require('./create-browser-page')
 const { createSoundingError } = require('./create-error')
 
 /** @typedef {import('./types').SoundingExpect} SoundingExpect */
 /** @typedef {import('./types').SoundingExpectation} SoundingExpectation */
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function formatUnknown(value) {
+  if (value instanceof Error) {
+    return value.message
+  }
+
+  return String(value)
+}
 
 /**
  * @param {any} target
@@ -110,6 +129,10 @@ function resolveStructuredValue(actual) {
  * @returns {boolean}
  */
 function shouldUseFallback(actual) {
+  if (isSoundingBrowserPage(actual)) {
+    return false
+  }
+
   if (typeof actual?.receive === 'function' && typeof actual?.events === 'function') {
     return false
   }
@@ -800,6 +823,192 @@ function assertNoInertiaErrors(actual) {
 }
 
 /**
+ * @param {string} actual
+ * @param {string | RegExp} expected
+ * @returns {boolean}
+ */
+function browserTextMatches(actual, expected) {
+  if (expected instanceof RegExp) {
+    return expected.test(actual)
+  }
+
+  return actual.includes(String(expected))
+}
+
+/**
+ * @param {string | RegExp} expected
+ * @returns {string}
+ */
+function describeBrowserText(expected) {
+  return expected instanceof RegExp ? String(expected) : describeExpected(String(expected))
+}
+
+/**
+ * @param {any} actual
+ */
+function assertBrowserPage(actual) {
+  if (!isSoundingBrowserPage(actual)) {
+    throw new TypeError('Sounding browser expectations require a Sounding browser page.')
+  }
+}
+
+/**
+ * @param {any} actual
+ * @param {string | RegExp} expected
+ * @param {boolean} [negated]
+ */
+async function assertBrowserText(actual, expected, negated = false) {
+  assertBrowserPage(actual)
+  const text = await getBrowserPageText(actual)
+  const matches = browserTextMatches(text, expected)
+
+  if (negated ? matches : !matches) {
+    failWithBrowserDiagnostics(
+      negated
+        ? `Expected browser page not to show ${describeBrowserText(expected)}.`
+        : `Expected browser page to show ${describeBrowserText(expected)}.`,
+      actual
+    )
+  }
+}
+
+/**
+ * @param {string} currentUrl
+ * @param {string | RegExp} expected
+ * @returns {boolean}
+ */
+function browserUrlMatches(currentUrl, expected) {
+  if (expected instanceof RegExp) {
+    return expected.test(currentUrl)
+  }
+
+  if (String(expected).startsWith('/')) {
+    try {
+      const parsed = new URL(currentUrl)
+      return `${parsed.pathname}${parsed.search}${parsed.hash}` === expected
+    } catch (_error) {
+      return currentUrl === expected
+    }
+  }
+
+  return currentUrl === expected
+}
+
+/**
+ * @param {any} actual
+ * @param {string | RegExp} expected
+ */
+function assertBrowserUrl(actual, expected) {
+  assertBrowserPage(actual)
+  const currentUrl = getBrowserPageUrl(actual)
+
+  if (!browserUrlMatches(currentUrl, expected)) {
+    failWithBrowserDiagnostics(
+      `Expected browser URL to match ${describeExpected(expected)}, received ${describeExpected(currentUrl)}.`,
+      actual
+    )
+  }
+}
+
+/**
+ * @param {any} actual
+ * @param {string | RegExp} expected
+ */
+function assertBrowserPath(actual, expected) {
+  assertBrowserPage(actual)
+  const currentUrl = getBrowserPageUrl(actual)
+  let currentPath = currentUrl
+
+  try {
+    const parsed = new URL(currentUrl)
+    currentPath = `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch (_error) {}
+
+  const matches = expected instanceof RegExp ? expected.test(currentPath) : currentPath === expected
+
+  if (!matches) {
+    failWithBrowserDiagnostics(
+      `Expected browser path to match ${describeExpected(expected)}, received ${describeExpected(currentPath)}.`,
+      actual
+    )
+  }
+}
+
+/**
+ * @param {any} actual
+ * @param {string | RegExp} expected
+ */
+async function assertBrowserTitle(actual, expected) {
+  assertBrowserPage(actual)
+  const rawPage = actual.raw
+  const title = typeof rawPage?.title === 'function' ? await rawPage.title() : ''
+  const matches = expected instanceof RegExp ? expected.test(title) : title === expected
+
+  if (!matches) {
+    failWithBrowserDiagnostics(
+      `Expected browser title to match ${describeExpected(expected)}, received ${describeExpected(title)}.`,
+      actual
+    )
+  }
+}
+
+/**
+ * @param {any[]} entries
+ * @returns {string}
+ */
+function summarizeBrowserEntries(entries) {
+  return entries.map((entry) => formatUnknown(entry?.text || entry?.message || entry)).join(', ')
+}
+
+/**
+ * @param {any} actual
+ */
+function assertNoBrowserJavascriptErrors(actual) {
+  assertBrowserPage(actual)
+  const state = getBrowserPageState(actual)
+  const errors = state?.javascriptErrors || []
+
+  if (errors.length > 0) {
+    failWithBrowserDiagnostics(
+      `Expected browser page to have no JavaScript errors, received ${summarizeBrowserEntries(errors)}.`,
+      actual
+    )
+  }
+}
+
+/**
+ * @param {any} actual
+ */
+function assertNoBrowserConsoleLogs(actual) {
+  assertBrowserPage(actual)
+  const state = getBrowserPageState(actual)
+  const messages = state?.consoleMessages || []
+
+  if (messages.length > 0) {
+    failWithBrowserDiagnostics(
+      `Expected browser page to have no console logs, received ${summarizeBrowserEntries(messages)}.`,
+      actual
+    )
+  }
+}
+
+/**
+ * @param {any} actual
+ */
+function assertNoBrowserConsoleErrors(actual) {
+  assertBrowserPage(actual)
+  const state = getBrowserPageState(actual)
+  const messages = state?.consoleErrors || []
+
+  if (messages.length > 0) {
+    failWithBrowserDiagnostics(
+      `Expected browser page to have no console errors, received ${summarizeBrowserEntries(messages)}.`,
+      actual
+    )
+  }
+}
+
+/**
  * @param {any} actual
  * @param {{ fallback?: (actual: any) => any }} [options]
  * @returns {SoundingExpectation | any}
@@ -1053,6 +1262,39 @@ function createExpect(actual, { fallback } = {}) {
       assertInertiaPartialReload(actual, expected)
     },
 
+    async toSee(expected) {
+      await assertBrowserText(actual, expected)
+    },
+
+    toHaveUrl(expected) {
+      assertBrowserUrl(actual, expected)
+    },
+
+    toHavePath(expected) {
+      assertBrowserPath(actual, expected)
+    },
+
+    async toHaveTitle(expected) {
+      await assertBrowserTitle(actual, expected)
+    },
+
+    toHaveNoJavascriptErrors() {
+      assertNoBrowserJavascriptErrors(actual)
+    },
+
+    toHaveNoConsoleLogs() {
+      assertNoBrowserConsoleLogs(actual)
+    },
+
+    toHaveNoConsoleErrors() {
+      assertNoBrowserConsoleErrors(actual)
+    },
+
+    toHaveNoSmoke() {
+      assertNoBrowserJavascriptErrors(actual)
+      assertNoBrowserConsoleErrors(actual)
+    },
+
     async toReceive(event, expected, options) {
       if (typeof actual?.receive !== 'function') {
         throw new TypeError('Sounding expect().toReceive() requires a Sounding socket client.')
@@ -1156,6 +1398,10 @@ function createExpect(actual, { fallback } = {}) {
           'Inertia validation error',
           actual
         )
+      },
+
+      async toSee(expected) {
+        await assertBrowserText(actual, expected, true)
       },
 
       async toReceive(event, expected, options = {}) {

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -1,4 +1,9 @@
 const nodeTest = require('node:test')
+const {
+  createBrowserVisit,
+  createMutableBrowserPage,
+  createSoundingBrowserPage,
+} = require('./create-browser-page')
 const { createAppManager } = require('./create-app-manager')
 const { createExpect } = require('./create-expect')
 const { createRuntime } = require('./create-runtime')
@@ -447,6 +452,7 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
         ...(worldOption ? { world: worldOption } : {}),
       }
       let browserSession = null
+      let currentBrowserPage = null
 
       try {
         if (worldOption) {
@@ -482,16 +488,59 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
               }
             : sounding.sockets
 
-        if (options.browser) {
-          browserSession = await sounding.browser.open(
-            normalizeBrowserOpenOptions(options.browser, title)
-          )
+        const browserOpenOptions = options.browser
+          ? normalizeBrowserOpenOptions(options.browser, title)
+          : null
+
+        async function openBrowserSession(openOptions = {}) {
+          const nextOpenOptions = {
+            ...(browserOpenOptions || {}),
+            ...openOptions,
+          }
+
+          if (
+            browserSession &&
+            nextOpenOptions.project &&
+            browserSession.project !== nextOpenOptions.project
+          ) {
+            await sounding.browser.close()
+            browserSession = null
+          }
+
+          if (!browserSession) {
+            browserSession = await sounding.browser.open(nextOpenOptions)
+          }
+
+          currentBrowserPage = createSoundingBrowserPage(browserSession.page, {
+            project: browserSession.project,
+            login: sounding.auth?.login,
+            getArtifacts: () => browserSession.latestArtifacts,
+          })
+
+          return currentBrowserPage
         }
 
+        if (browserOpenOptions) {
+          await openBrowserSession()
+        }
+
+        const activeBrowserSession = browserSession
         /** @type {SoundingExpect} */
-        const expect = browserSession?.expect
-          ? createExpect.withFallback(browserSession.expect)
+        const expect = activeBrowserSession?.expect
+          ? createExpect.withFallback(activeBrowserSession.expect)
           : /** @type {SoundingExpect} */ (createExpect)
+        const browserPage = activeBrowserSession
+          ? createMutableBrowserPage(() => currentBrowserPage)
+          : null
+        const trialVisit = browserPage
+          ? createBrowserVisit(browserPage, {
+              login: sounding.auth?.login,
+              transport: visit.transport,
+              async switchProject(project) {
+                await openBrowserSession({ project })
+              },
+            })
+          : visit
 
         /** @type {SoundingTrialContext} */
         const context = {
@@ -500,15 +549,13 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
           expect,
           sails,
           request,
-          visit,
+          visit: /** @type {any} */ (trialVisit),
           sockets,
           auth: sounding.auth,
           login: sounding.auth?.login,
           world: sounding.world,
           mailbox: sounding.mailbox,
-          browser: browserSession?.browser,
-          browserContext: browserSession?.context,
-          page: browserSession?.page,
+          page: browserPage,
           get: /** @type {any} */ (bindRequestMethod(request, 'get')),
           head: /** @type {any} */ (bindRequestMethod(request, 'head')),
           post: /** @type {any} */ (bindRequestMethod(request, 'post')),
@@ -516,6 +563,16 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
           patch: /** @type {any} */ (bindRequestMethod(request, 'patch')),
           del: /** @type {any} */ (bindRequestMethod(request, 'delete')),
         }
+        Object.defineProperties(context, {
+          browser: {
+            enumerable: true,
+            get: () => browserSession?.browser,
+          },
+          browserContext: {
+            enumerable: true,
+            get: () => browserSession?.context,
+          },
+        })
 
         return await handler(context)
       } catch (error) {

--- a/lib/init-project.js
+++ b/lib/init-project.js
@@ -318,10 +318,11 @@ test.skip('captured mail example', async ({ sails, mailbox, expect }) => {
   expect(mailbox).toHaveSentMail({ to: 'reader@example.com' })
 })
 
-test.skip('browser journey example', { browser: true }, async ({ page, expect }) => {
-  await page.goto('/')
+test.skip('browser journey example', { browser: true }, async ({ visit, expect }) => {
+  const page = await visit('/')
 
-  await expect(page).toBeDefined()
+  await expect(page).toSee('Welcome')
+  expect(page).toHaveNoSmoke()
 })
 `
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -151,6 +151,14 @@
  *   toHaveInertiaErrors(expected?: string | string[] | Record<string, any>): void,
  *   toHaveNoInertiaErrors(): void,
  *   toHaveInertiaPartialReload(expected?: { component?: string, only?: string[], except?: string[], reset?: string[], version?: string, errorBag?: string }): void,
+ *   toSee(expected: string | RegExp): Promise<void>,
+ *   toHaveUrl(expected: string | RegExp): void,
+ *   toHavePath(expected: string | RegExp): void,
+ *   toHaveTitle(expected: string | RegExp): Promise<void>,
+ *   toHaveNoJavascriptErrors(): void,
+ *   toHaveNoConsoleLogs(): void,
+ *   toHaveNoConsoleErrors(): void,
+ *   toHaveNoSmoke(): void,
  *   toReceive(event: string, expected?: any, options?: { timeout?: number }): Promise<void>,
  *   toHaveReceived(event: string, expected?: any): void,
  *   not: {
@@ -161,6 +169,7 @@
  *     toHaveInertiaProp(path: string, expected?: any): void,
  *     toHaveSharedInertiaProp(path: string, expected?: any): void,
  *     toHaveInertiaError(path: string, expected?: any): void,
+ *     toSee(expected: string | RegExp): Promise<void>,
  *     toReceive(event: string, expected?: any, options?: { timeout?: number }): Promise<void>,
  *   },
  *   [key: string]: any,
@@ -171,13 +180,101 @@
  *   withFallback(fallback: (actual: any) => any): (actual: any) => SoundingExpectation | any;
  * }} SoundingExpect
  *
+ * @typedef {PromiseLike<SoundingPage> & {
+ *   click(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   type(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   fill(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   typeSlowly(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   append(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   clear(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   press(target: string, keyOrOptions?: string | AnyRecord, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   select(target: string, value: any, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   check(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   uncheck(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   hover(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   attach(target: string, files: string | string[] | AnyRecord, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   drag(source: string, target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   scroll(target?: string | number, y?: number): SoundingBrowserPageActionChain,
+ *   wait(target?: string | number, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   resize(widthOrViewport: number | SoundingBrowserViewport, height?: number): SoundingBrowserPageActionChain,
+ *   key(key: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   keys(keys: string | string[], options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   navigate(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   goto(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   back(options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   forward(options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   reload(options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   debug(): SoundingBrowserPageActionChain,
+ *   withinFrame(target: string | AnyRecord, callback: (page: SoundingPage) => void | Promise<void>): SoundingBrowserPageActionChain,
+ *   as(actor: SoundingActor | string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   on(project: string): SoundingBrowserPageActionChain,
+ *   onMobile(): SoundingBrowserPageActionChain,
+ *   inDarkMode(): SoundingBrowserPageActionChain,
+ *   inLightMode(): SoundingBrowserPageActionChain,
+ *   withLocale(locale: string): SoundingBrowserPageActionChain,
+ *   withTimezone(timezone: string): SoundingBrowserPageActionChain,
+ *   withUserAgent(userAgent: string): SoundingBrowserPageActionChain,
+ *   withGeolocation(latitudeOrCoordinates: SoundingBrowserGeolocation | number, longitude?: number, accuracy?: number): SoundingBrowserPageActionChain,
+ *   withHost(host: string): SoundingBrowserPageActionChain,
+ * }} SoundingBrowserPageActionChain
+ *
  * @typedef {{
- *   goto(target: string): Promise<any> | any,
- *   fill(selector: string, value: string): Promise<any> | any,
- *   click(selector: string): Promise<any> | any,
- *   check?(selector: string): Promise<any> | any,
+ *   raw: AnyRecord,
+ *   playwrightPage: AnyRecord,
+ *   readonly javascriptErrors: any[],
+ *   readonly consoleMessages: any[],
+ *   readonly consoleErrors: any[],
+ *   click(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   type(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   fill(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   typeSlowly(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   append(target: string, value: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   clear(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   press(target: string, keyOrOptions?: string | AnyRecord, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   select(target: string, value: any, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   check(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   uncheck(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   hover(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   attach(target: string, files: string | string[] | AnyRecord, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   drag(source: string, target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   scroll(target?: string | number, y?: number): SoundingBrowserPageActionChain,
+ *   wait(target?: string | number, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   resize(widthOrViewport: number | SoundingBrowserViewport, height?: number): SoundingBrowserPageActionChain,
+ *   key(key: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   keys(keys: string | string[], options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   navigate(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   goto(target: string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   back(options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   forward(options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   reload(options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   debug(): SoundingBrowserPageActionChain,
+ *   withinFrame(target: string | AnyRecord, callback: (page: SoundingPage) => void | Promise<void>): SoundingBrowserPageActionChain,
+ *   as(actor: SoundingActor | string, options?: AnyRecord): SoundingBrowserPageActionChain,
+ *   on(project: string): SoundingBrowserPageActionChain,
+ *   onMobile(): SoundingBrowserPageActionChain,
+ *   inDarkMode(): SoundingBrowserPageActionChain,
+ *   inLightMode(): SoundingBrowserPageActionChain,
+ *   withLocale(locale: string): SoundingBrowserPageActionChain,
+ *   withTimezone(timezone: string): SoundingBrowserPageActionChain,
+ *   withUserAgent(userAgent: string): SoundingBrowserPageActionChain,
+ *   withGeolocation(latitudeOrCoordinates: SoundingBrowserGeolocation | number, longitude?: number, accuracy?: number): SoundingBrowserPageActionChain,
+ *   withHost(host: string): SoundingBrowserPageActionChain,
+ *   url(): string,
+ *   text(target?: string): Promise<string>,
+ *   content(): Promise<string>,
+ *   html(): Promise<string>,
+ *   script(pageFunction: Function | string, arg?: any): Promise<any>,
+ *   screenshot(pathOrOptions?: string | AnyRecord, options?: AnyRecord): Promise<any>,
+ *   screenshotElement(target: string, pathOrOptions?: string | AnyRecord, options?: AnyRecord): Promise<any>,
  *   [key: string]: any,
  * }} SoundingPage
+ *
+ * @typedef {((target: string, options?: AnyRecord) => SoundingBrowserPageActionChain) & {
+ *   readonly transport: string,
+ *   as(actor?: SoundingActor | string | null, options?: AnyRecord): (target: string, options?: AnyRecord) => SoundingBrowserPageActionChain,
+ * }} SoundingBrowserVisitClient
+ *
+ * @typedef {SoundingBrowserVisitClient & SoundingVisitClient} SoundingTrialVisitClient
  *
  * @typedef {'off' | 'on' | 'on-failure'} SoundingBrowserArtifactMode
  *
@@ -226,6 +323,12 @@
  * }} SoundingBrowserViewport
  *
  * @typedef {{
+ *   latitude: number,
+ *   longitude: number,
+ *   accuracy?: number,
+ * }} SoundingBrowserGeolocation
+ *
+ * @typedef {{
  *   name?: string,
  *   type?: 'chromium' | 'firefox' | 'webkit' | string,
  *   device?: string,
@@ -248,6 +351,7 @@
  *   browser: AnyRecord,
  *   context: AnyRecord,
  *   page: SoundingPage,
+ *   rawPage?: AnyRecord,
  *   expect?: (actual: any) => any,
  *   project: string,
  *   artifacts: SoundingBrowserResolvedArtifactsConfig,
@@ -411,8 +515,8 @@
  * }} SoundingPasswordRequestResult
  *
  * @typedef {{
- *   as(actorOrEmail: SoundingActor | string, page: SoundingPage, options?: AnyRecord): Promise<SoundingMagicLink>,
- *   withPassword(actorOrEmail: SoundingActor | string, page: SoundingPage, options: { password: string, rememberMe?: boolean, returnUrl?: string, [key: string]: any }): Promise<SoundingBrowserLoginResult>,
+ *   as(actorOrEmail: SoundingActor | string, page: SoundingPage | AnyRecord, options?: AnyRecord): Promise<SoundingMagicLink>,
+ *   withPassword(actorOrEmail: SoundingActor | string, page: SoundingPage | AnyRecord, options: { password: string, rememberMe?: boolean, returnUrl?: string, [key: string]: any }): Promise<SoundingBrowserLoginResult>,
  * }} SoundingLoginHelpers
  *
  * @typedef {{
@@ -633,7 +737,7 @@
  *   expect: SoundingExpect,
  *   sails: SoundingSailsApp,
  *   request: SoundingRequestClient,
- *   visit: SoundingVisitClient,
+ *   visit: SoundingTrialVisitClient,
  *   sockets: SoundingSocketManager,
  *   auth: SoundingAuthHelpers,
  *   login: SoundingLoginHelpers,

--- a/test/browser-auth.test.js
+++ b/test/browser-auth.test.js
@@ -7,6 +7,7 @@ const path = require('node:path')
 const { createBrowserManager } = require('../lib/create-browser-manager')
 const { createAuthHelpers } = require('../lib/create-auth-helpers')
 const { createExpect } = require('../lib/create-expect')
+const { createSoundingBrowserPage } = require('../lib/create-browser-page')
 
 test('createBrowserManager opens a browser session with the configured base URL', async () => {
   const calls = []
@@ -67,12 +68,337 @@ test('createBrowserManager opens a browser session with the configured base URL'
   })
 
   const session = await manager.open()
-  assert.equal(session.page, fakePage)
+  assert.equal(session.page.raw, fakePage)
+  assert.equal(session.page.playwrightPage, fakePage)
   assert.equal(session.context.contextOptions.baseURL, 'http://127.0.0.1:3333')
   await manager.close()
   assert.deepEqual(calls, [
     ['context:close'],
     ['browser:close'],
+  ])
+})
+
+test('createBrowserManager returns a Sounding page wrapper with raw Playwright escape hatches', async () => {
+  const calls = []
+  const handlers = {}
+  let currentUrl = 'http://127.0.0.1:3333/sign-in'
+  const fakePage = {
+    on(event, handler) {
+      handlers[event] = handler
+    },
+    url: () => currentUrl,
+    title: async () => 'Welcome back',
+    async goto(target) {
+      currentUrl = `http://127.0.0.1:3333${target}`
+      calls.push(['goto', target])
+    },
+    getByText(text) {
+      return {
+        first() {
+          return this
+        },
+        async click() {
+          calls.push(['text:click', text])
+        },
+      }
+    },
+    getByLabel(label) {
+      return {
+        first() {
+          return this
+        },
+        async fill(value) {
+          calls.push(['label:fill', label, value])
+        },
+      }
+    },
+    locator(selector) {
+      return {
+        async textContent() {
+          assert.equal(selector, 'body')
+          return 'Sign In Check your email'
+        },
+      }
+    },
+    async emulateMedia(options) {
+      calls.push(['emulateMedia', options])
+    },
+  }
+
+  const manager = createBrowserManager({
+    sails: {
+      config: {
+        appPath: '/tmp/app',
+        port: 3333,
+        sounding: {
+          browser: {
+            enabled: true,
+            projects: ['desktop'],
+            defaultProject: 'desktop',
+          },
+        },
+      },
+    },
+    getConfig: () => ({
+      browser: {
+        enabled: true,
+        projects: ['desktop'],
+        defaultProject: 'desktop',
+      },
+    }),
+    loadPlaywright: async () => ({
+      chromium: {
+        launch: async () => ({
+          newContext: async () => ({
+            newPage: async () => fakePage,
+            close: async () => {},
+          }),
+          close: async () => {},
+        }),
+      },
+      devices: {},
+    }),
+    loadPlaywrightTest: async () => null,
+  })
+
+  const session = await manager.open()
+  const page = session.page
+
+  await page.goto('/sign-in').inDarkMode()
+  await page.click('Email me a link').type('email', 'creator@example.com').press('Send link')
+  await createExpect(page).toSee('Check your email')
+  await createExpect(page).not.toSee('Forbidden')
+  createExpect(page).toHavePath('/sign-in')
+  await createExpect(page).toHaveTitle(/Welcome/)
+
+  handlers.console({ type: () => 'error', text: () => 'ReferenceError: boom' })
+  assert.throws(() => createExpect(page).toHaveNoSmoke(), /ReferenceError: boom/)
+  handlers.pageerror(new Error('hydration failed'))
+  assert.throws(() => createExpect(page).toHaveNoJavascriptErrors(), /hydration failed/)
+
+  assert.equal(page.raw, fakePage)
+  assert.deepEqual(calls, [
+    ['goto', '/sign-in'],
+    ['emulateMedia', { colorScheme: 'dark' }],
+    ['text:click', 'Email me a link'],
+    ['label:fill', 'email', 'creator@example.com'],
+    ['text:click', 'Send link'],
+  ])
+})
+
+test('createSoundingBrowserPage supports human browser affordances inspired by Pest', async () => {
+  const calls = []
+  const currentUrl = 'http://127.0.0.1:3333/dashboard'
+  const selectorFor = (selector) => ({
+    __selector: selector,
+    async textContent() {
+      calls.push(['locator:textContent', selector])
+      return selector === 'body' ? 'Dashboard Ready' : `Text for ${selector}`
+    },
+    async screenshot(options) {
+      calls.push(['locator:screenshot', selector, options])
+      return Buffer.from('fake-element-shot')
+    },
+    async scrollIntoViewIfNeeded() {
+      calls.push(['locator:scroll', selector])
+    },
+    async click(options) {
+      calls.push(['locator:click', selector, options])
+    },
+    async fill(value, options) {
+      calls.push(['locator:fill', selector, value, options])
+    },
+    async waitFor(options) {
+      calls.push(['locator:waitFor', selector, options])
+    },
+  })
+  const fakePage = {
+    on() {},
+    url: () => currentUrl,
+    locator: (selector) => selectorFor(selector),
+    getByText(text) {
+      return {
+        first() {
+          return this
+        },
+        async click(options) {
+          calls.push(['text:click', text, options])
+        },
+      }
+    },
+    getByLabel(label) {
+      return {
+        first() {
+          return this
+        },
+        async fill(value, options) {
+          calls.push(['label:fill', label, value, options])
+        },
+        async inputValue() {
+          calls.push(['label:inputValue', label])
+          return 'typed-'
+        },
+        async pressSequentially(value, options) {
+          calls.push(['label:pressSequentially', label, value, options])
+        },
+      }
+    },
+    async click(selector, options) {
+      calls.push(['click', selector, options])
+    },
+    async fill(selector, value, options) {
+      calls.push(['fill', selector, value, options])
+    },
+    async inputValue(selector) {
+      calls.push(['inputValue', selector])
+      return 'saved-'
+    },
+    async setInputFiles(selector, files, options) {
+      calls.push(['setInputFiles', selector, files, options])
+    },
+    async dragAndDrop(source, target, options) {
+      calls.push(['dragAndDrop', source, target, options])
+    },
+    async waitForSelector(selector, options) {
+      calls.push(['waitForSelector', selector, options])
+    },
+    async setViewportSize(viewport) {
+      calls.push(['setViewportSize', viewport])
+    },
+    keyboard: {
+      async press(key, options) {
+        calls.push(['keyboard:press', key, options])
+      },
+    },
+    async goBack(options) {
+      calls.push(['goBack', options])
+    },
+    async goForward(options) {
+      calls.push(['goForward', options])
+    },
+    async reload(options) {
+      calls.push(['reload', options])
+    },
+    async pause() {
+      calls.push(['pause'])
+    },
+    frameLocator(selector) {
+      calls.push(['frameLocator', selector])
+      return {
+        locator: (frameSelector) => selectorFor(`frame:${frameSelector}`),
+        getByText(text) {
+          return {
+            first() {
+              return this
+            },
+            async click() {
+              calls.push(['frame:text:click', text])
+            },
+          }
+        },
+      }
+    },
+    async content() {
+      calls.push(['content'])
+      return '<html>Dashboard</html>'
+    },
+    async evaluate(pageFunction, arg) {
+      calls.push(['evaluate', typeof pageFunction, arg])
+      return 'script-result'
+    },
+    async screenshot(options) {
+      calls.push(['screenshot', options])
+      return Buffer.from('fake-shot')
+    },
+    context() {
+      return {
+        async grantPermissions(permissions) {
+          calls.push(['grantPermissions', permissions])
+        },
+        async setGeolocation(geolocation) {
+          calls.push(['setGeolocation', geolocation])
+        },
+      }
+    },
+  }
+  const page = createSoundingBrowserPage(fakePage)
+
+  assert.equal(page.url(), currentUrl)
+  assert.equal(await page.text(), 'Dashboard Ready')
+  assert.equal(
+    await page.text('@status'),
+    'Text for [data-test="status"], [data-testid="status"]'
+  )
+  assert.equal(await page.content(), '<html>Dashboard</html>')
+  assert.equal(await page.html(), '<html>Dashboard</html>')
+  assert.equal(await page.script(() => 'ok', { from: 'test' }), 'script-result')
+  assert.equal((await page.screenshot('shot.png', { fullPage: true })).toString(), 'fake-shot')
+  assert.equal((await page.screenshotElement('@receipt', 'receipt.png')).toString(), 'fake-element-shot')
+
+  await page
+    .click('@login')
+    .typeSlowly('Search', 'billing', { delay: 5 })
+    .clear('@email')
+    .append('@email', 'owner@example.com')
+    .attach('@avatar', 'avatar.png')
+    .drag('@card', '@dropzone')
+    .wait('@ready', { state: 'visible' })
+    .scroll('@section')
+    .resize(390, 844)
+    .withGeolocation(6.5244, 3.3792, 20)
+    .key('Enter')
+    .keys(['Meta+K', 'Escape'])
+    .withinFrame('@billing-frame', async (frame) => {
+      await frame.click('Save')
+    })
+    .back({ waitUntil: 'domcontentloaded' })
+    .forward()
+    .reload()
+    .debug()
+
+  assert.deepEqual(calls, [
+    ['locator:textContent', 'body'],
+    ['locator:textContent', '[data-test="status"], [data-testid="status"]'],
+    ['content'],
+    ['content'],
+    ['evaluate', 'function', { from: 'test' }],
+    ['screenshot', { fullPage: true, path: 'shot.png' }],
+    [
+      'locator:screenshot',
+      '[data-test="receipt"], [data-testid="receipt"]',
+      { path: 'receipt.png' },
+    ],
+    ['click', '[data-test="login"], [data-testid="login"]', undefined],
+    ['label:pressSequentially', 'Search', 'billing', { delay: 5 }],
+    ['fill', '[data-test="email"], [data-testid="email"]', '', undefined],
+    ['inputValue', '[data-test="email"], [data-testid="email"]'],
+    [
+      'fill',
+      '[data-test="email"], [data-testid="email"]',
+      'saved-owner@example.com',
+      undefined,
+    ],
+    ['setInputFiles', '[data-test="avatar"], [data-testid="avatar"]', 'avatar.png', undefined],
+    [
+      'dragAndDrop',
+      '[data-test="card"], [data-testid="card"]',
+      '[data-test="dropzone"], [data-testid="dropzone"]',
+      undefined,
+    ],
+    ['waitForSelector', '[data-test="ready"], [data-testid="ready"]', { state: 'visible' }],
+    ['locator:scroll', '[data-test="section"], [data-testid="section"]'],
+    ['setViewportSize', { width: 390, height: 844 }],
+    ['grantPermissions', ['geolocation']],
+    ['setGeolocation', { latitude: 6.5244, longitude: 3.3792, accuracy: 20 }],
+    ['keyboard:press', 'Enter', undefined],
+    ['keyboard:press', 'Meta+K', undefined],
+    ['keyboard:press', 'Escape', undefined],
+    ['frameLocator', '[data-test="billing-frame"], [data-testid="billing-frame"]'],
+    ['frame:text:click', 'Save'],
+    ['goBack', { waitUntil: 'domcontentloaded' }],
+    ['goForward', undefined],
+    ['reload', undefined],
+    ['pause'],
   ])
 })
 
@@ -161,7 +487,7 @@ test('createBrowserManager resolves mobile and custom browser projects', async (
   const mobileManager = createManager()
   const mobileSession = await mobileManager.open({ project: 'mobile' })
   assert.equal(mobileSession.project, 'mobile')
-  assert.equal(mobileSession.page, fakePage)
+  assert.equal(mobileSession.page.raw, fakePage)
   await mobileManager.close()
 
   const safariManager = createManager()

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -701,7 +701,8 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
       assert.equal(sails.sounding, runtime)
       assert.equal(request.transport, 'http')
       assert.equal(visit.transport, 'http')
-      assert.deepEqual(page, { name: 'page' })
+      assert.equal(page.name, 'page')
+      assert.equal(page.raw.name, 'page')
     }
   )
 
@@ -719,6 +720,255 @@ test('test.only() runs focused trials through the Sounding wrapper', async () =>
     ['using', 'http'],
     ['visit:using', 'http'],
     ['browser:open', { project: 'desktop', trialName: 'focused http browser trial' }],
+    ['lower'],
+  ])
+})
+
+test('test() exposes an expect-first browser page wrapper and browser visit helper', async () => {
+  const calls = []
+  const registrations = []
+  let currentUrl = 'http://127.0.0.1:3333/'
+  const fakePage = {
+    on() {},
+    name: 'raw-page',
+    url: () => currentUrl,
+    title: async () => 'Dashboard',
+    async goto(target) {
+      currentUrl = String(target).startsWith('http')
+        ? target
+        : `http://127.0.0.1:3333${target}`
+      calls.push(['goto', target])
+    },
+    async emulateMedia(options) {
+      calls.push(['emulateMedia', options])
+    },
+    context() {
+      return {
+        async grantPermissions(permissions) {
+          calls.push(['grantPermissions', permissions])
+        },
+        async setGeolocation(geolocation) {
+          calls.push(['setGeolocation', geolocation])
+        },
+      }
+    },
+    getByText(text) {
+      return {
+        first() {
+          return this
+        },
+        async click() {
+          calls.push(['text:click', text])
+        },
+      }
+    },
+    getByLabel(label) {
+      return {
+        first() {
+          return this
+        },
+        async fill(value) {
+          calls.push(['label:fill', label, value])
+        },
+      }
+    },
+    locator(selector) {
+      return {
+        async textContent() {
+          assert.equal(selector, 'body')
+          return 'Dashboard Check your email'
+        },
+      }
+    },
+  }
+  const runtime = {
+    helpers: {},
+    world: {
+      reset() {},
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: {
+      transport: 'virtual',
+    },
+    sockets: {},
+    auth: {
+      login: {
+        async as(actor, page) {
+          calls.push(['login:as', actor, page.raw])
+        },
+      },
+    },
+    browser: {
+      async open(options) {
+        calls.push(['browser:open', options])
+        return {
+          browser: { name: 'browser' },
+          context: { name: 'context' },
+          page: fakePage,
+          project: 'mobile',
+          latestArtifacts: null,
+        }
+      },
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('owner can open the dashboard', { browser: 'mobile' }, async ({ visit, page, expect }) => {
+    const visitedPage = await visit
+      .as('owner')('/dashboard')
+      .withHost('app.test')
+      .inDarkMode()
+      .withGeolocation({ latitude: 6.5244, longitude: 3.3792 })
+
+    assert.equal(visitedPage, page)
+    assert.equal(page.raw, fakePage)
+    assert.equal(visit.transport, 'virtual')
+
+    await page.click('Email me a link').type('email', 'owner@example.com').press('Send link')
+    await expect(page).toSee('Dashboard')
+    await expect(page).not.toSee('Forbidden')
+    expect(page).toHavePath('/dashboard')
+    await expect(page).toHaveTitle('Dashboard')
+    expect(page).toHaveNoSmoke()
+  })
+
+  await registrations[0].handler({})
+
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['browser:open', { project: 'mobile', trialName: 'owner can open the dashboard' }],
+    ['login:as', 'owner', fakePage],
+    ['emulateMedia', { colorScheme: 'dark' }],
+    ['grantPermissions', ['geolocation']],
+    ['setGeolocation', { latitude: 6.5244, longitude: 3.3792 }],
+    ['goto', 'http://app.test/dashboard'],
+    ['text:click', 'Email me a link'],
+    ['label:fill', 'email', 'owner@example.com'],
+    ['text:click', 'Send link'],
+    ['lower'],
+  ])
+})
+
+test('test() lets visit select a browser project before navigation', async () => {
+  const calls = []
+  const registrations = []
+  const createFakePage = (name) => ({
+    on() {},
+    name,
+    url: () => `http://127.0.0.1:3333/${name}`,
+    async goto(target) {
+      calls.push(['goto', name, target])
+    },
+    async emulateMedia(options) {
+      calls.push(['emulateMedia', name, options])
+    },
+  })
+  const runtime = {
+    helpers: {},
+    world: {
+      reset() {},
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: {
+      transport: 'virtual',
+    },
+    sockets: {},
+    auth: {
+      login: {
+        async as(actor, page) {
+          calls.push(['login:as', actor, page.raw.name])
+        },
+      },
+    },
+    browser: {
+      async open(options) {
+        const project = options.project || 'desktop'
+        calls.push(['browser:open', options])
+        return {
+          browser: { name: `${project}-browser` },
+          context: { name: `${project}-context` },
+          page: createFakePage(`${project}-page`),
+          project,
+          latestArtifacts: null,
+        }
+      },
+      async close() {
+        calls.push(['browser:close'])
+      },
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('owner can open the mobile dashboard', { browser: true }, async ({ visit, page }) => {
+    const visitedPage = await visit
+      .as('owner')('/dashboard')
+      .onMobile()
+      .inDarkMode()
+
+    assert.equal(visitedPage, page)
+    assert.equal(page.raw.name, 'mobile-page')
+    assert.equal(page.playwrightPage.name, 'mobile-page')
+  })
+
+  await registrations[0].handler({})
+
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['browser:open', { trialName: 'owner can open the mobile dashboard' }],
+    ['browser:close'],
+    [
+      'browser:open',
+      { trialName: 'owner can open the mobile dashboard', project: 'mobile' },
+    ],
+    ['login:as', 'owner', 'mobile-page'],
+    ['emulateMedia', 'mobile-page', { colorScheme: 'dark' }],
+    ['goto', 'mobile-page', '/dashboard'],
     ['lower'],
   ])
 })

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -316,6 +316,63 @@ test('world string options are typed from JSDoc', { world: 'signed-in-user' }, a
 
 test.concurrent('concurrent trial options are typed from JSDoc', { concurrent: true }, async () => {})
 
+test('browser page wrapper context is typed from JSDoc', { browser: 'mobile' }, async ({ visit, page, expect }) => {
+  const visitedPage = await visit('/dashboard').inDarkMode()
+
+  await visitedPage
+    .click('@send-link')
+    .type('email', 'owner@example.com')
+    .typeSlowly('@search', 'billing')
+    .append('@email', '.test')
+    .clear('@search')
+    .attach('@avatar', 'avatar.png')
+    .drag('@card', '@dropzone')
+    .press('Send link')
+    .resize(390, 844)
+    .key('Enter')
+    .keys(['Meta+K', 'Escape'])
+    .withinFrame('@checkout-frame', async (frame) => {
+      await frame.click('Save')
+    })
+
+  await visit('/settings')
+    .on('safari')
+    .withHost('app.test')
+    .inLightMode()
+    .withLocale('en-GB')
+    .withTimezone('Africa/Lagos')
+    .withUserAgent('SoundingBot/1.0')
+    .withGeolocation(6.5244, 3.3792)
+    .click('@profile')
+
+  await visit('/nearby').withGeolocation({
+    latitude: 6.5244,
+    longitude: 3.3792,
+    accuracy: 20,
+  })
+
+  await visit('/mobile-dashboard').onMobile()
+
+  await expect(visitedPage).toSee('Dashboard')
+  await expect(visitedPage).not.toSee('Forbidden')
+  expect(visitedPage).toHavePath('/dashboard')
+  await expect(visitedPage).toHaveTitle(/Dashboard/)
+  expect(visitedPage).toHaveNoJavascriptErrors()
+  expect(visitedPage).toHaveNoConsoleLogs()
+  expect(visitedPage).toHaveNoConsoleErrors()
+  expect(visitedPage).toHaveNoSmoke()
+
+  visitedPage.url()
+  await visitedPage.text('@status')
+  await visitedPage.html()
+  await visitedPage.content()
+  await visitedPage.script(() => 'ok')
+  await visitedPage.screenshot('dashboard.png', { fullPage: true })
+  await visitedPage.screenshotElement('@receipt', 'receipt.png')
+
+  page?.raw
+})
+
 // @ts-expect-error Trial options only support virtual and http transports.
 test('invalid transport options are caught by public JSDoc', { transport: 'ftp' }, async () => {})
 


### PR DESCRIPTION
## Summary

- Adds a Sounding browser page wrapper around Playwright pages with raw escape hatches through `page.raw` and `page.playwrightPage`.
- Adds expect-first browser matchers: `toSee`, `not.toSee`, `toHaveUrl`, `toHavePath`, `toHaveTitle`, `toHaveNoJavascriptErrors`, `toHaveNoConsoleLogs`, `toHaveNoConsoleErrors`, and `toHaveNoSmoke`.
- Adds Pest-inspired browser affordances including `@name` test handles, fluent actions, setup helpers, read/capture helpers, frame scoping, geolocation, and real visit-level project switching with `visit().on()` / `visit().onMobile()`.
- Updates README, init examples, public JSDoc types, type smoke coverage, and browser/test API coverage.

## Docs

- Companion docs PR: sailscastshq/docs.sailscasts.com#94

## Validation

- `node --test test/browser-auth.test.js test/test-api.test.js`
- `npm run typecheck`
- `npm test`
- `git diff --check`

Closes #84.