### PR TITLE
feat: add browser smoke helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The canonical Sails-native surface is:
 - request assertions can check auth/session state with `expect(response).toHaveSession('userId', user.id)` and flash messages with `expect(response).toHaveFlash('info', /welcome/i)`
 - failed response assertions include concise request/response diagnostics; set `SOUNDING_DIAGNOSTICS=verbose` for full response excerpts
 - Inertia-style visits can use `visit('/pricing')` and partial reload options like `{ component, only }`
+- browser smoke helpers can check one route or a route list with `smoke(['/pricing', '/contact'])`
 - mail assertions can check captured emails with `expect(mailbox).toHaveSentMail({ to, subject })` and `expect(mailbox.latest()).toHaveCtaUrl(/magic-link/)`
 - a trial can opt into stricter parity with `test('...', { transport: 'http' }, ...)`
 - upload trials use `FormData` over the HTTP transport so Sails can exercise real Skipper streams
@@ -504,6 +505,43 @@ Supported browser expectations:
 | `expect(page).toHaveNoConsoleLogs()` | Fail on any console message, including `log`, `warn`, `info`, and `error`. |
 | `expect(page).toHaveNoConsoleErrors()` | Fail only on `console.error`. |
 | `expect(page).toHaveNoSmoke()` | Fail on JavaScript errors or console errors. |
+
+### Browser smoke helpers
+
+Use `smoke()` for public pages where the whole point is "open these routes and
+fail if the browser sees JavaScript errors or `console.error` output":
+
+```js
+test('public pages do not smoke', async ({ smoke }) => {
+  await smoke(['/', '/pricing', '/contact'])
+})
+```
+
+`smoke()` opens a browser lazily, so an otherwise request-level trial can stay
+light until it actually needs the browser. Pass a browser project when the smoke
+check should run through a named project:
+
+```js
+test('mobile pages do not smoke', async ({ smoke }) => {
+  await smoke(['/', '/pricing'], { project: 'mobile' })
+})
+```
+
+Use `visit.all()` when you want the inspected collection back:
+
+```js
+test('public pages do not smoke', async ({ visit, expect }) => {
+  const pages = await visit.all(['/', '/pricing', '/contact'])
+
+  expect(pages).toHaveNoSmoke()
+  expect(pages.entries[0].target).toBe('/')
+})
+```
+
+Each collection entry includes the original `target`, `project`, `currentUrl`,
+captured JavaScript errors, console messages, console errors, and the wrapped
+browser `page`. On failure, Sounding stops at the first smoky route so terminal
+diagnostics and browser artifacts point at the route that actually failed.
 
 Raw Playwright access remains available through `page.raw` or
 `page.playwrightPage` when a browser flow needs a lower-level escape hatch.

--- a/lib/create-browser-page.js
+++ b/lib/create-browser-page.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict')
 
 const SOUNDING_BROWSER_PAGE = Symbol.for('sounding.browserPage')
+const SOUNDING_BROWSER_PAGE_COLLECTION = Symbol.for('sounding.browserPageCollection')
 
 /**
  * @param {unknown} value
@@ -213,6 +214,82 @@ function getBrowserPageState(page) {
 function getBrowserPageUrl(page) {
   const rawPage = getRawPage(page)
   return typeof rawPage?.url === 'function' ? rawPage.url() : ''
+}
+
+/**
+ * @param {any} page
+ * @returns {{ javascriptErrors: number, consoleMessages: number, consoleErrors: number }}
+ */
+function getBrowserPageSmokeCheckpoint(page) {
+  const state = getBrowserPageState(page)
+
+  return {
+    javascriptErrors: state?.javascriptErrors?.length || 0,
+    consoleMessages: state?.consoleMessages?.length || 0,
+    consoleErrors: state?.consoleErrors?.length || 0,
+  }
+}
+
+/**
+ * @param {any} page
+ * @param {any} target
+ * @param {{ javascriptErrors: number, consoleMessages: number, consoleErrors: number }} checkpoint
+ * @returns {any}
+ */
+function createBrowserPageCollectionEntry(page, target, checkpoint) {
+  const state = getBrowserPageState(page)
+
+  return {
+    target,
+    page,
+    project: state?.project,
+    currentUrl: getBrowserPageUrl(page),
+    javascriptErrors: (state?.javascriptErrors || []).slice(checkpoint.javascriptErrors),
+    consoleMessages: (state?.consoleMessages || []).slice(checkpoint.consoleMessages),
+    consoleErrors: (state?.consoleErrors || []).slice(checkpoint.consoleErrors),
+  }
+}
+
+/**
+ * @param {any} entry
+ * @returns {boolean}
+ */
+function browserPageCollectionEntryHasSmoke(entry) {
+  return Boolean(entry?.javascriptErrors?.length || entry?.consoleErrors?.length)
+}
+
+/**
+ * @param {any[]} entries
+ * @returns {any}
+ */
+function createBrowserPageCollection(entries) {
+  return {
+    [SOUNDING_BROWSER_PAGE_COLLECTION]: true,
+    entries,
+    pages: entries.map((entry) => entry.page),
+    get length() {
+      return entries.length
+    },
+    [Symbol.iterator]() {
+      return entries[Symbol.iterator]()
+    },
+  }
+}
+
+/**
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isSoundingBrowserPageCollection(value) {
+  return Boolean(value?.[SOUNDING_BROWSER_PAGE_COLLECTION])
+}
+
+/**
+ * @param {any} value
+ * @returns {any[]}
+ */
+function getBrowserPageCollectionEntries(value) {
+  return isSoundingBrowserPageCollection(value) ? value.entries : []
 }
 
 /**
@@ -1030,15 +1107,15 @@ function createMutableBrowserPage(getPage) {
 
 /**
  * @param {any} page
- * @param {{ login?: { as?: Function }, transport?: string, switchProject?: (project: string) => Promise<any> }} [options]
- * @returns {Function & { as(actor: any, options?: any): Function }}
+ * @param {{
+ *   login?: { as?: Function },
+ *   transport?: string,
+ *   ensureOpen?: () => Promise<any>,
+ *   switchProject?: (project: string) => Promise<any>,
+ * }} [options]
+ * @returns {Function & { as(actor: any, options?: any): Function, all(targets: any, options?: any): Promise<any> }}
  */
 function createBrowserVisit(page, options = {}) {
-  const state = getBrowserPageState(page)
-  if (state && options.login) {
-    state.login = options.login
-  }
-
   function createVisitChain(target, navigationOptions) {
     const before = []
     const after = []
@@ -1061,6 +1138,8 @@ function createBrowserVisit(page, options = {}) {
         } else {
           await page.on(project)
         }
+      } else if (typeof options.ensureOpen === 'function') {
+        await options.ensureOpen()
       }
 
       for (const action of before) {
@@ -1194,6 +1273,38 @@ function createBrowserVisit(page, options = {}) {
     return chain
   }
 
+  async function visitAll(targets, visitAllOptions = {}) {
+    const routeTargets = Array.isArray(targets) ? targets : [targets]
+    const {
+      project,
+      ...navigationOptions
+    } = visitAllOptions || {}
+    const entries = []
+
+    for (const target of routeTargets) {
+      if (project) {
+        if (typeof options.switchProject === 'function') {
+          await options.switchProject(project)
+        } else {
+          await page.on(project)
+        }
+      } else if (typeof options.ensureOpen === 'function') {
+        await options.ensureOpen()
+      }
+
+      const checkpoint = getBrowserPageSmokeCheckpoint(page)
+      await page.navigate(target, navigationOptions)
+      const entry = createBrowserPageCollectionEntry(page, target, checkpoint)
+      entries.push(entry)
+
+      if (browserPageCollectionEntryHasSmoke(entry)) {
+        break
+      }
+    }
+
+    return createBrowserPageCollection(entries)
+  }
+
   const visit = function visit(target, navigationOptions) {
     return createVisitChain(target, navigationOptions)
   }
@@ -1208,6 +1319,8 @@ function createBrowserVisit(page, options = {}) {
       return createVisitChain(target, navigationOptions).as(actor, loginOptions)
     }
   }
+
+  visit.all = visitAll
 
   return visit
 }
@@ -1235,14 +1348,19 @@ async function getBrowserPageText(page) {
 
 module.exports = {
   SOUNDING_BROWSER_PAGE,
+  SOUNDING_BROWSER_PAGE_COLLECTION,
+  browserPageCollectionEntryHasSmoke,
+  createBrowserPageCollection,
   createBrowserVisit,
   createMutableBrowserPage,
   createSoundingBrowserPage,
   failWithBrowserDiagnostics,
   formatBrowserPageDiagnostics,
+  getBrowserPageCollectionEntries,
   getBrowserPageState,
   getBrowserPageText,
   getBrowserPageUrl,
   getRawPage,
   isSoundingBrowserPage,
+  isSoundingBrowserPageCollection,
 }

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -1,11 +1,14 @@
 const assert = require('node:assert/strict')
 
 const {
+  browserPageCollectionEntryHasSmoke,
   failWithBrowserDiagnostics,
+  getBrowserPageCollectionEntries,
   getBrowserPageState,
   getBrowserPageText,
   getBrowserPageUrl,
   isSoundingBrowserPage,
+  isSoundingBrowserPageCollection,
 } = require('./create-browser-page')
 const { createSoundingError } = require('./create-error')
 
@@ -129,7 +132,7 @@ function resolveStructuredValue(actual) {
  * @returns {boolean}
  */
 function shouldUseFallback(actual) {
-  if (isSoundingBrowserPage(actual)) {
+  if (isSoundingBrowserPage(actual) || isSoundingBrowserPageCollection(actual)) {
     return false
   }
 
@@ -1009,6 +1012,57 @@ function assertNoBrowserConsoleErrors(actual) {
 }
 
 /**
+ * @param {any} entry
+ * @returns {string}
+ */
+function formatBrowserSmokeFailure(entry) {
+  const lines = [
+    'Sounding smoke diagnostics:',
+    `- route: ${entry.target}`,
+  ]
+
+  if (entry.project) {
+    lines.push(`- project: ${entry.project}`)
+  }
+
+  if (entry.currentUrl) {
+    lines.push(`- current URL: ${entry.currentUrl}`)
+  }
+
+  if (entry.javascriptErrors?.length) {
+    lines.push(`- JavaScript errors: ${summarizeBrowserEntries(entry.javascriptErrors)}`)
+  }
+
+  if (entry.consoleErrors?.length) {
+    lines.push(`- console errors: ${summarizeBrowserEntries(entry.consoleErrors)}`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * @param {any} actual
+ */
+function assertNoBrowserSmoke(actual) {
+  if (isSoundingBrowserPageCollection(actual)) {
+    const entries = getBrowserPageCollectionEntries(actual)
+    const failure = entries.find(browserPageCollectionEntryHasSmoke)
+
+    if (failure) {
+      failWithBrowserDiagnostics(
+        `Expected browser smoke check to pass for ${describeExpected(String(failure.target))}.\n\n${formatBrowserSmokeFailure(failure)}`,
+        failure.page
+      )
+    }
+
+    return
+  }
+
+  assertNoBrowserJavascriptErrors(actual)
+  assertNoBrowserConsoleErrors(actual)
+}
+
+/**
  * @param {any} actual
  * @param {{ fallback?: (actual: any) => any }} [options]
  * @returns {SoundingExpectation | any}
@@ -1291,8 +1345,7 @@ function createExpect(actual, { fallback } = {}) {
     },
 
     toHaveNoSmoke() {
-      assertNoBrowserJavascriptErrors(actual)
-      assertNoBrowserConsoleErrors(actual)
+      assertNoBrowserSmoke(actual)
     },
 
     async toReceive(event, expected, options) {

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -422,6 +422,42 @@ async function runInTrialQueue(handler) {
 }
 
 /**
+ * @param {any} visit
+ * @param {Function & { all: Function }} browserVisit
+ * @returns {Function & { all: Function }}
+ */
+function createVisitWithBrowserSmokeAll(visit, browserVisit) {
+  function smokeAwareVisit(target, options) {
+    if (typeof visit === 'function') {
+      return visit(target, options)
+    }
+
+    if (typeof visit?.get === 'function') {
+      return visit.get(target, options)
+    }
+
+    throw new TypeError('Sounding visit client is not available for this runtime.')
+  }
+
+  if (visit && (typeof visit === 'function' || typeof visit === 'object')) {
+    for (const property of Reflect.ownKeys(visit)) {
+      if (property === 'length' || property === 'name' || property === 'prototype') {
+        continue
+      }
+
+      const descriptor = Object.getOwnPropertyDescriptor(visit, property)
+      if (descriptor) {
+        Object.defineProperty(smokeAwareVisit, property, descriptor)
+      }
+    }
+  }
+
+  return Object.assign(smokeAwareVisit, {
+    all: (...args) => browserVisit.all(...args),
+  })
+}
+
+/**
  * @param {{
  *   runtime?: SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>),
  *   mode: string,
@@ -460,7 +496,10 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
         }
 
         const request = options.transport ? sounding.request.using(options.transport) : sounding.request
-        const visit = options.transport ? sounding.visit.using(options.transport) : sounding.visit
+        const visit =
+          options.transport && typeof sounding.visit?.using === 'function'
+            ? sounding.visit.using(options.transport)
+            : sounding.visit
         const socketOptions =
           options.socket && typeof options.socket === 'object' ? options.socket : {}
         const sockets =
@@ -505,17 +544,20 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
           ) {
             await sounding.browser.close()
             browserSession = null
+            currentBrowserPage = null
           }
 
           if (!browserSession) {
             browserSession = await sounding.browser.open(nextOpenOptions)
           }
 
-          currentBrowserPage = createSoundingBrowserPage(browserSession.page, {
-            project: browserSession.project,
-            login: sounding.auth?.login,
-            getArtifacts: () => browserSession.latestArtifacts,
-          })
+          if (!currentBrowserPage) {
+            currentBrowserPage = createSoundingBrowserPage(browserSession.page, {
+              project: browserSession.project,
+              login: sounding.auth?.login,
+              getArtifacts: () => browserSession.latestArtifacts,
+            })
+          }
 
           return currentBrowserPage
         }
@@ -529,18 +571,26 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
         const expect = activeBrowserSession?.expect
           ? createExpect.withFallback(activeBrowserSession.expect)
           : /** @type {SoundingExpect} */ (createExpect)
-        const browserPage = activeBrowserSession
-          ? createMutableBrowserPage(() => currentBrowserPage)
-          : null
+        const lazyBrowserPage = createMutableBrowserPage(() => currentBrowserPage)
+        const browserPage = activeBrowserSession ? lazyBrowserPage : null
+        const browserVisit = createBrowserVisit(lazyBrowserPage, {
+          login: sounding.auth?.login,
+          transport: visit?.transport || request?.transport,
+          async ensureOpen() {
+            await openBrowserSession()
+          },
+          async switchProject(project) {
+            await openBrowserSession({ project })
+          },
+        })
         const trialVisit = browserPage
-          ? createBrowserVisit(browserPage, {
-              login: sounding.auth?.login,
-              transport: visit.transport,
-              async switchProject(project) {
-                await openBrowserSession({ project })
-              },
-            })
-          : visit
+          ? browserVisit
+          : createVisitWithBrowserSmokeAll(/** @type {any} */ (visit), browserVisit)
+        async function smoke(targets, smokeOptions) {
+          const pages = await browserVisit.all(targets, smokeOptions)
+          createExpect(pages).toHaveNoSmoke()
+          return pages
+        }
 
         /** @type {SoundingTrialContext} */
         const context = {
@@ -555,6 +605,7 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
           login: sounding.auth?.login,
           world: sounding.world,
           mailbox: sounding.mailbox,
+          smoke,
           page: browserPage,
           get: /** @type {any} */ (bindRequestMethod(request, 'get')),
           head: /** @type {any} */ (bindRequestMethod(request, 'head')),

--- a/lib/types.js
+++ b/lib/types.js
@@ -269,12 +269,36 @@
  *   [key: string]: any,
  * }} SoundingPage
  *
+ * @typedef {{
+ *   target: string,
+ *   page: SoundingPage,
+ *   project?: string,
+ *   currentUrl?: string,
+ *   javascriptErrors: any[],
+ *   consoleMessages: any[],
+ *   consoleErrors: any[],
+ * }} SoundingBrowserSmokeEntry
+ *
+ * @typedef {{
+ *   readonly entries: SoundingBrowserSmokeEntry[],
+ *   readonly pages: SoundingPage[],
+ *   readonly length: number,
+ *   [Symbol.iterator](): IterableIterator<SoundingBrowserSmokeEntry>,
+ * }} SoundingBrowserSmokeCollection
+ *
+ * @typedef {AnyRecord & {
+ *   project?: string,
+ * }} SoundingBrowserVisitAllOptions
+ *
  * @typedef {((target: string, options?: AnyRecord) => SoundingBrowserPageActionChain) & {
  *   readonly transport: string,
  *   as(actor?: SoundingActor | string | null, options?: AnyRecord): (target: string, options?: AnyRecord) => SoundingBrowserPageActionChain,
+ *   all(targets: string | string[], options?: SoundingBrowserVisitAllOptions): Promise<SoundingBrowserSmokeCollection>,
  * }} SoundingBrowserVisitClient
  *
  * @typedef {SoundingBrowserVisitClient & SoundingVisitClient} SoundingTrialVisitClient
+ *
+ * @typedef {(targets: string | string[], options?: SoundingBrowserVisitAllOptions) => Promise<SoundingBrowserSmokeCollection>} SoundingSmokeClient
  *
  * @typedef {'off' | 'on' | 'on-failure'} SoundingBrowserArtifactMode
  *
@@ -743,6 +767,7 @@
  *   login: SoundingLoginHelpers,
  *   world: SoundingWorldEngine,
  *   mailbox: SoundingMailbox,
+ *   smoke: SoundingSmokeClient,
  *   browser?: AnyRecord,
  *   browserContext?: AnyRecord,
  *   page?: SoundingPage,

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -814,6 +814,9 @@ test('test() exposes an expect-first browser page wrapper and browser visit help
           latestArtifacts: null,
         }
       },
+      async close() {
+        calls.push(['browser:close'])
+      },
     },
     async boot(options) {
       calls.push(['boot', options.mode])
@@ -969,6 +972,213 @@ test('test() lets visit select a browser project before navigation', async () =>
     ['login:as', 'owner', 'mobile-page'],
     ['emulateMedia', 'mobile-page', { colorScheme: 'dark' }],
     ['goto', 'mobile-page', '/dashboard'],
+    ['lower'],
+  ])
+})
+
+test('test() exposes browser smoke helpers for clean route collections', async () => {
+  const calls = []
+  const registrations = []
+  let currentUrl = 'http://127.0.0.1:3333/'
+  const fakePage = {
+    on() {},
+    url: () => currentUrl,
+    async goto(target) {
+      currentUrl = `http://127.0.0.1:3333${target}`
+      calls.push(['goto', target])
+    },
+  }
+  const runtime = {
+    helpers: {},
+    world: {
+      reset() {},
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: {
+      transport: 'virtual',
+      async get(target) {
+        calls.push(['inertia:visit', target])
+        return { status: 200, data: { target } }
+      },
+    },
+    sockets: {},
+    browser: {
+      async open(options) {
+        calls.push(['browser:open', options])
+        return {
+          browser: { name: 'browser' },
+          context: { name: 'context' },
+          page: fakePage,
+          project: options.project || 'desktop',
+          latestArtifacts: null,
+        }
+      },
+      async close() {
+        calls.push(['browser:close'])
+      },
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('public pages do not smoke', async ({ visit, smoke, expect }) => {
+    const response = await visit('/inertia-dashboard')
+    assert.equal(response.status, 200)
+
+    const smokePages = await smoke(['/', '/pricing'])
+    assert.equal(smokePages.length, 2)
+    assert.deepEqual(smokePages.entries.map((entry) => entry.target), ['/', '/pricing'])
+
+    const visitedPages = await visit.all(['/contact'], { project: 'mobile' })
+    expect(visitedPages).toHaveNoSmoke()
+    assert.equal(visitedPages.entries[0].project, 'mobile')
+  })
+
+  await registrations[0].handler({})
+
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['inertia:visit', '/inertia-dashboard'],
+    ['browser:open', {}],
+    ['goto', '/'],
+    ['goto', '/pricing'],
+    ['browser:close'],
+    ['browser:open', { project: 'mobile' }],
+    ['goto', '/contact'],
+    ['lower'],
+  ])
+})
+
+test('test() reports browser smoke failures with route project and artifacts', async () => {
+  const calls = []
+  const registrations = []
+  const handlers = {}
+  const artifacts = {
+    outputDir: '/tmp/sounding-artifacts',
+    directory: '/tmp/sounding-artifacts/smoke/mobile',
+    project: 'mobile',
+    trialName: 'public pages do not smoke',
+    currentUrl: 'http://127.0.0.1:3333/pricing',
+    currentUrlPath: '/tmp/sounding-artifacts/smoke/mobile/current-url.txt',
+    screenshot: '/tmp/sounding-artifacts/smoke/mobile/screenshot.png',
+    errors: [],
+  }
+  let currentUrl = 'http://127.0.0.1:3333/'
+  const fakePage = {
+    on(event, handler) {
+      handlers[event] = handler
+    },
+    url: () => currentUrl,
+    async goto(target) {
+      currentUrl = `http://127.0.0.1:3333${target}`
+      calls.push(['goto', target])
+
+      if (target === '/pricing') {
+        handlers.console({ type: () => 'error', text: () => 'Hydration failed' })
+        handlers.pageerror(new Error('window is not defined'))
+      }
+    },
+  }
+  const runtime = {
+    helpers: {},
+    world: {
+      reset() {},
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+    },
+    visit: {
+      transport: 'virtual',
+    },
+    sockets: {},
+    browser: {
+      async open(options) {
+        calls.push(['browser:open', options])
+        return {
+          browser: { name: 'browser' },
+          context: { name: 'context' },
+          page: fakePage,
+          project: options.project || 'desktop',
+          latestArtifacts: null,
+          async captureFailureArtifacts() {
+            calls.push(['browser:captureFailureArtifacts'])
+            return artifacts
+          },
+        }
+      },
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+  const baseTest = (title, options, handler) => {
+    registrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({ baseTest, runtime })
+
+  soundingTest('public pages do not smoke', async ({ smoke }) => {
+    await smoke(['/', '/pricing', '/contact'], { project: 'mobile' })
+  })
+
+  await assert.rejects(
+    async () => {
+      await registrations[0].handler({})
+    },
+    (error) => {
+      assert.match(error.message, /Expected browser smoke check to pass/)
+      assert.match(error.message, /route: \/pricing/)
+      assert.match(error.message, /project: mobile/)
+      assert.match(error.message, /Hydration failed/)
+      assert.match(error.message, /window is not defined/)
+      assert.match(error.message, /Sounding browser artifacts:/)
+      assert.match(error.message, /screenshot\.png/)
+      return true
+    }
+  )
+
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['browser:open', { project: 'mobile' }],
+    ['goto', '/'],
+    ['goto', '/pricing'],
+    ['browser:captureFailureArtifacts'],
     ['lower'],
   ])
 })

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -316,7 +316,7 @@ test('world string options are typed from JSDoc', { world: 'signed-in-user' }, a
 
 test.concurrent('concurrent trial options are typed from JSDoc', { concurrent: true }, async () => {})
 
-test('browser page wrapper context is typed from JSDoc', { browser: 'mobile' }, async ({ visit, page, expect }) => {
+test('browser page wrapper context is typed from JSDoc', { browser: 'mobile' }, async ({ visit, page, expect, smoke }) => {
   const visitedPage = await visit('/dashboard').inDarkMode()
 
   await visitedPage
@@ -352,6 +352,16 @@ test('browser page wrapper context is typed from JSDoc', { browser: 'mobile' }, 
   })
 
   await visit('/mobile-dashboard').onMobile()
+
+  const smokePages = await smoke(['/', '/pricing'], { project: 'mobile' })
+  expect(smokePages).toHaveNoSmoke()
+  smokePages.entries[0].target
+  smokePages.entries[0].currentUrl
+  smokePages.entries[0].project
+  smokePages.pages[0].raw
+
+  const visitedPages = await visit.all(['/contact', '/about'])
+  expect(visitedPages).toHaveNoSmoke()
 
   await expect(visitedPage).toSee('Dashboard')
   await expect(visitedPage).not.toSee('Forbidden')


### PR DESCRIPTION
Adds smoke() and visit.all() browser smoke helpers, route-level smoke diagnostics, collection support for toHaveNoSmoke(), README coverage, public JSDoc types, and regression tests. Closes #85. Validation: npm run typecheck; npm test.