### PR TITLE
fix: polish reporter summary labels

### DIFF
--- a/lib/sounding-reporter.js
+++ b/lib/sounding-reporter.js
@@ -855,14 +855,11 @@ function formatSummary(summary, theme) {
   ].filter(Boolean)
   const duration = formatDuration(summary?.duration_ms)
   const label = failed || cancelled ? theme.failBadge('FAIL') : theme.passBadge('PASS')
-  const summaryIndent = ' '.repeat(visibleLength(label) + 2)
+  const testsLabel = theme.dim('Tests:')
+  const durationLabel = theme.dim('Duration:')
+  const summaryLine = `${label}  ${testsLabel} ${parts.join(', ')}  ${durationLabel} ${theme.bold(duration || 'unknown')}`
 
-  return [
-    `${label}  Tests: ${parts.join(', ')}`,
-    '',
-    `${summaryIndent}${theme.dim('Duration:')} ${theme.bold(duration || 'unknown')}`,
-    '',
-  ].join('\n')
+  return [summaryLine, ''].join('\n')
 }
 
 function formatPassLine(trial, width, theme) {

--- a/test/sounding-reporter.test.js
+++ b/test/sounding-reporter.test.js
@@ -133,6 +133,50 @@ test('formatPassedGroups accepts raw Node pass events', () => {
   assert.match(rendered, /✓ JSON paths read like product facts\s+2ms/)
 })
 
+test('formatSummary keeps final counts and duration on one quiet-label row', () => {
+  const theme = {
+    red: (value) => `[red:${value}]`,
+    green: (value) => `[green:${value}]`,
+    bold: (value) => `[bold:${value}]`,
+    dim: (value) => `[dim:${value}]`,
+    passBadge: (value) => `[pass:${value}]`,
+    failBadge: (value) => `[fail:${value}]`,
+  }
+
+  const passed = reporter.formatSummary(
+    {
+      counts: {
+        tests: 2,
+        passed: 2,
+      },
+      duration_ms: 62,
+    },
+    theme
+  )
+
+  assert.equal(
+    passed,
+    '[pass:PASS]  [dim:Tests:] [green:2 passed], 2 total  [dim:Duration:] [bold:62ms]\n'
+  )
+  assert.doesNotMatch(passed, /total\n+\s*\[dim:Duration:/)
+
+  const failed = reporter.formatSummary(
+    {
+      counts: {
+        tests: 1,
+        failed: 1,
+      },
+      duration_ms: 61,
+    },
+    theme
+  )
+
+  assert.equal(
+    failed,
+    '[fail:FAIL]  [dim:Tests:] [red:1 failed], 1 total  [dim:Duration:] [bold:61ms]\n'
+  )
+})
+
 test('formatProfileTrials renders the slowest trials in duration order', () => {
   const rendered = reporter.formatProfileTrials(
     [

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -295,10 +295,9 @@ test('bin/sounding.js shows a readable PASS block for small successful runs', ()
   assert.equal(result.status, 0, result.stderr.toString())
   assert.match(stdout, /PASS\s+tests\/account\.test\.js/)
   assert.match(stdout, /✓ account/)
-  assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total/)
+  assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total\s+Duration:\s+\d+ms/)
   assert.doesNotMatch(stdout, /Tests:\s{2,}\d/)
-  assert.match(stdout, /\n\n {6}Duration: \d+ms/)
-  assert.doesNotMatch(stdout, /\n\n {0,5}Duration:/)
+  assert.doesNotMatch(stdout, /1 total\n+\s*Duration:/)
 })
 
 test('bin/sounding.js can print the slowest trial profile', () => {
@@ -319,7 +318,7 @@ test('bin/sounding.js can print the slowest trial profile', () => {
   assert.match(stdout, /PROFILE\s+Slowest trials/)
   assert.match(stdout, /\bpassed\s+tests\/account\.test\.js/)
   assert.match(stdout, /account/)
-  assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total/)
+  assert.match(stdout, /PASS\s+Tests:\s+1 passed, 1 total\s+Duration:\s+\d+ms/)
 })
 
 test('bin/sounding.js uses the Sounding reporter for failures by default', () => {


### PR DESCRIPTION
Dims the final reporter summary labels consistently and keeps Tests/Duration on the same row so terminal wrapping is natural instead of forced. Closes #92. Validation: node --test test/sounding-reporter.test.js test/test-runner.test.js; npm run typecheck; npm test.