### PR TITLE
feat: add visual screenshot assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The canonical Sails-native surface is:
 - `request.as('owner')` and `visit.as('owner')` can resolve actor aliases from the current world
 - `test('...', { browser: 'mobile' }, async ({ page }) => {})` can select a named browser project without extra ceremony
 - failed browser trials capture the current URL and a full-page screenshot under `.tmp/sounding/artifacts`
+- opt-in visual snapshots can compare browser pages with `expect(page).toMatchScreenshot('pricing')`
 - request helpers default to Sails virtual requests powered by `sails.request()`
 - virtual request responses expose the final `req.session` snapshot as `response.session`; HTTP responses leave it undefined
 - request assertions can check auth/session state with `expect(response).toHaveSession('userId', user.id)` and flash messages with `expect(response).toHaveFlash('info', /welcome/i)`
@@ -230,6 +231,12 @@ Use `--raw-error` or `SOUNDING_RAW=1` when the formatted view hides something im
 
 ```sh
 npx sounding test --raw-error
+```
+
+Use `--update-snapshots` to create or update visual screenshot baselines:
+
+```sh
+npx sounding test --update-snapshots
 ```
 
 Use `--dry-run` to inspect the exact `node --test` command before running it.
@@ -505,6 +512,34 @@ Supported browser expectations:
 | `expect(page).toHaveNoConsoleLogs()` | Fail on any console message, including `log`, `warn`, `info`, and `error`. |
 | `expect(page).toHaveNoConsoleErrors()` | Fail only on `console.error`. |
 | `expect(page).toHaveNoSmoke()` | Fail on JavaScript errors or console errors. |
+| `expect(page).toMatchScreenshot(name)` | Compare a full-page screenshot against an approved visual baseline. |
+
+### Visual regression snapshots
+
+Use visual snapshots only when the rendered page shape matters more than a DOM
+contract:
+
+```js
+test('pricing page matches approved desktop screenshot', { browser: 'desktop' }, async ({ visit, expect }) => {
+  const page = await visit('/pricing')
+
+  await expect(page).toMatchScreenshot('pricing')
+})
+```
+
+Baselines live under `tests/screenshots/<browser-project>/<name>.png`, so
+desktop and mobile screenshots do not collide. Create or update baselines with:
+
+```sh
+SOUNDING_UPDATE_SNAPSHOTS=1 npx sounding test
+# or
+npx sounding test --update-snapshots
+```
+
+When a baseline is missing, Sounding tells you how to create it. When a
+screenshot differs, Sounding writes `actual.png`, `expected.png`, and
+`diff.html` under `.tmp/sounding/artifacts/visual/<browser-project>/<name>/`
+and includes those paths in the failure output.
 
 ### Browser smoke helpers
 

--- a/bin/sounding.js
+++ b/bin/sounding.js
@@ -43,6 +43,7 @@ Options:
   --slow <count>                 Control how many profiled trials are shown. Implies --profile.
   --verbose                      Show full stacks and verbose Sounding diagnostics.
   --raw-error                    Show raw Node/Sounding error details after formatted failures.
+  --update-snapshots             Create or overwrite visual screenshot baselines.
   --junit [path]                 Use the junit reporter.
   --json                         Use the json reporter.
   --coverage                     Enable Node test coverage.

--- a/lib/create-expect.js
+++ b/lib/create-expect.js
@@ -11,6 +11,7 @@ const {
   isSoundingBrowserPageCollection,
 } = require('./create-browser-page')
 const { createSoundingError } = require('./create-error')
+const { matchVisualSnapshot } = require('./visual-snapshots')
 
 /** @typedef {import('./types').SoundingExpect} SoundingExpect */
 /** @typedef {import('./types').SoundingExpectation} SoundingExpectation */
@@ -1064,6 +1065,31 @@ function assertNoBrowserSmoke(actual) {
 
 /**
  * @param {any} actual
+ * @param {string} name
+ * @param {Record<string, any>} [options]
+ */
+async function assertBrowserScreenshotMatch(actual, name, options = {}) {
+  assertBrowserPage(actual)
+
+  const state = getBrowserPageState(actual)
+
+  try {
+    await matchVisualSnapshot(actual, name, {
+      project: state?.project,
+      screenshotOptions: options,
+    })
+  } catch (error) {
+    if (String(error?.code || '').startsWith('E_SOUNDING_VISUAL_SNAPSHOT_')) {
+      failWithBrowserDiagnostics(error.message, actual)
+      return
+    }
+
+    throw error
+  }
+}
+
+/**
+ * @param {any} actual
  * @param {{ fallback?: (actual: any) => any }} [options]
  * @returns {SoundingExpectation | any}
  */
@@ -1346,6 +1372,10 @@ function createExpect(actual, { fallback } = {}) {
 
     toHaveNoSmoke() {
       assertNoBrowserSmoke(actual)
+    },
+
+    async toMatchScreenshot(name, options) {
+      await assertBrowserScreenshotMatch(actual, name, options)
     },
 
     async toReceive(event, expected, options) {

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -333,6 +333,11 @@ function parseTestArgs(argv = [], appPath = process.cwd()) {
       continue
     }
 
+    if (arg === '--update-snapshots') {
+      env.SOUNDING_UPDATE_SNAPSHOTS = '1'
+      continue
+    }
+
     if (arg === '--app') {
       resolvedAppPath = path.resolve(readValue(arg))
       continue

--- a/lib/types.js
+++ b/lib/types.js
@@ -159,6 +159,7 @@
  *   toHaveNoConsoleLogs(): void,
  *   toHaveNoConsoleErrors(): void,
  *   toHaveNoSmoke(): void,
+ *   toMatchScreenshot(name: string, options?: AnyRecord): Promise<void>,
  *   toReceive(event: string, expected?: any, options?: { timeout?: number }): Promise<void>,
  *   toHaveReceived(event: string, expected?: any): void,
  *   not: {

--- a/lib/visual-snapshots.js
+++ b/lib/visual-snapshots.js
@@ -1,0 +1,236 @@
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const DEFAULT_SNAPSHOT_DIR = 'tests/screenshots'
+const DEFAULT_VISUAL_ARTIFACT_DIR = '.tmp/sounding/artifacts/visual'
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function sanitizePathSegment(value) {
+  return String(value || '')
+    .trim()
+    .replace(/\.png$/i, '')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120)
+}
+
+/**
+ * @param {string} filePath
+ * @returns {string}
+ */
+function escapeHtml(filePath) {
+  return String(filePath)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/**
+ * @param {Buffer} value
+ * @returns {string}
+ */
+function hashBuffer(value) {
+  return crypto.createHash('sha256').update(value).digest('hex')
+}
+
+/**
+ * @param {string} value
+ * @param {string} fallback
+ * @returns {string}
+ */
+function resolveConfiguredPath(value, fallback) {
+  const configured = value || fallback
+  return path.resolve(process.cwd(), configured)
+}
+
+/**
+ * @returns {boolean}
+ */
+function shouldUpdateSnapshots() {
+  return (
+    process.env.SOUNDING_UPDATE_SNAPSHOTS === '1' ||
+    process.env.SOUNDING_UPDATE_SNAPSHOTS === 'true'
+  )
+}
+
+/**
+ * @param {string} snapshotName
+ * @param {string} project
+ * @returns {{
+ *   name: string,
+ *   project: string,
+ *   baselinePath: string,
+ *   artifactDirectory: string,
+ *   actualPath: string,
+ *   expectedPath: string,
+ *   diffPath: string,
+ * }}
+ */
+function resolveVisualSnapshotPaths(snapshotName, project = 'desktop') {
+  const safeName = sanitizePathSegment(snapshotName)
+  const safeProject = sanitizePathSegment(project) || 'desktop'
+
+  if (!safeName) {
+    throw new TypeError('Sounding visual snapshots require a non-empty screenshot name.')
+  }
+
+  const baselineDirectory = path.join(
+    resolveConfiguredPath(process.env.SOUNDING_SNAPSHOT_DIR, DEFAULT_SNAPSHOT_DIR),
+    safeProject
+  )
+  const artifactDirectory = path.join(
+    resolveConfiguredPath(process.env.SOUNDING_VISUAL_ARTIFACT_DIR, DEFAULT_VISUAL_ARTIFACT_DIR),
+    safeProject,
+    safeName
+  )
+
+  return {
+    name: safeName,
+    project: safeProject,
+    baselinePath: path.join(baselineDirectory, `${safeName}.png`),
+    artifactDirectory,
+    actualPath: path.join(artifactDirectory, 'actual.png'),
+    expectedPath: path.join(artifactDirectory, 'expected.png'),
+    diffPath: path.join(artifactDirectory, 'diff.html'),
+  }
+}
+
+/**
+ * @param {string} expectedPath
+ * @param {string} actualPath
+ * @returns {string}
+ */
+function createVisualDiffHtml(expectedPath, actualPath) {
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '<meta charset="utf-8">',
+    '<title>Sounding visual diff</title>',
+    '<style>',
+    'body{font-family:ui-sans-serif,system-ui,sans-serif;margin:24px;background:#111;color:#f7f7f2;}',
+    'main{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:20px;}',
+    'figure{margin:0;border:1px solid #333;background:#181818;padding:12px;}',
+    'img{display:block;width:100%;height:auto;background:white;}',
+    'figcaption{margin-bottom:10px;color:#aaa;font-size:14px;}',
+    '</style>',
+    '</head>',
+    '<body>',
+    '<h1>Sounding visual diff</h1>',
+    '<main>',
+    `<figure><figcaption>Expected</figcaption><img src="${escapeHtml(path.basename(expectedPath))}" alt="Expected screenshot"></figure>`,
+    `<figure><figcaption>Actual</figcaption><img src="${escapeHtml(path.basename(actualPath))}" alt="Actual screenshot"></figure>`,
+    '</main>',
+    '</body>',
+    '</html>',
+    '',
+  ].join('\n')
+}
+
+/**
+ * @param {Buffer} expected
+ * @param {Buffer} actual
+ * @param {ReturnType<typeof resolveVisualSnapshotPaths>} paths
+ * @returns {Promise<void>}
+ */
+async function writeVisualDiffArtifacts(expected, actual, paths) {
+  await fs.promises.mkdir(paths.artifactDirectory, { recursive: true })
+  await fs.promises.writeFile(paths.expectedPath, expected)
+  await fs.promises.writeFile(paths.actualPath, actual)
+  await fs.promises.writeFile(paths.diffPath, createVisualDiffHtml(paths.expectedPath, paths.actualPath))
+}
+
+/**
+ * @param {any} page
+ * @param {string} snapshotName
+ * @param {{ project?: string, screenshotOptions?: Record<string, any> }} options
+ * @returns {Promise<{ status: 'matched' | 'updated', paths: ReturnType<typeof resolveVisualSnapshotPaths> }>}
+ */
+async function matchVisualSnapshot(page, snapshotName, options = {}) {
+  if (typeof page?.screenshot !== 'function') {
+    throw new TypeError('Sounding visual snapshots require a browser page with screenshot().')
+  }
+
+  const paths = resolveVisualSnapshotPaths(snapshotName, options.project)
+  const { path: _path, ...screenshotOptions } = options.screenshotOptions || {}
+  const actual = await page.screenshot({
+    fullPage: true,
+    ...screenshotOptions,
+  })
+
+  if (!Buffer.isBuffer(actual)) {
+    throw new TypeError('Sounding visual snapshots require page.screenshot() to return a Buffer.')
+  }
+
+  if (shouldUpdateSnapshots()) {
+    await fs.promises.mkdir(path.dirname(paths.baselinePath), { recursive: true })
+    await fs.promises.writeFile(paths.baselinePath, actual)
+    return {
+      status: 'updated',
+      paths,
+    }
+  }
+
+  let expected
+  try {
+    expected = await fs.promises.readFile(paths.baselinePath)
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      const missing = /** @type {Error & { code?: string, paths?: any }} */ (
+        new Error(
+          [
+            `Missing visual baseline for ${JSON.stringify(snapshotName)}.`,
+            '',
+            'Run with `SOUNDING_UPDATE_SNAPSHOTS=1 npx sounding test` or `npx sounding test --update-snapshots` to create it.',
+            `Baseline: ${paths.baselinePath}`,
+          ].join('\n')
+        )
+      )
+      missing.code = 'E_SOUNDING_VISUAL_SNAPSHOT_MISSING'
+      missing.paths = paths
+      throw missing
+    }
+
+    throw error
+  }
+
+  if (!expected.equals(actual)) {
+    await writeVisualDiffArtifacts(expected, actual, paths)
+
+    const mismatch = /** @type {Error & { code?: string, paths?: any }} */ (
+      new Error(
+        [
+          `Visual snapshot ${JSON.stringify(snapshotName)} did not match.`,
+          '',
+          `Baseline: ${paths.baselinePath}`,
+          `Expected: ${paths.expectedPath}`,
+          `Actual: ${paths.actualPath}`,
+          `Diff: ${paths.diffPath}`,
+          `Expected SHA-256: ${hashBuffer(expected)}`,
+          `Actual SHA-256: ${hashBuffer(actual)}`,
+        ].join('\n')
+      )
+    )
+    mismatch.code = 'E_SOUNDING_VISUAL_SNAPSHOT_MISMATCH'
+    mismatch.paths = paths
+    throw mismatch
+  }
+
+  return {
+    status: 'matched',
+    paths,
+  }
+}
+
+module.exports = {
+  DEFAULT_SNAPSHOT_DIR,
+  DEFAULT_VISUAL_ARTIFACT_DIR,
+  matchVisualSnapshot,
+  resolveVisualSnapshotPaths,
+  shouldUpdateSnapshots,
+}

--- a/test/test-runner.test.js
+++ b/test/test-runner.test.js
@@ -127,12 +127,12 @@ test('buildTestCommand uses the Sounding reporter by default', () => {
   ])
 })
 
-test('buildTestCommand maps Sounding reporter mode flags to environment', () => {
+test('buildTestCommand maps Sounding runner mode flags to environment', () => {
   const appPath = createTempApp()
   const command = buildTestCommand({
     appPath,
     nodeExecutable: 'node',
-    argv: ['--compact', '--verbose', '--raw-error', 'tests/account.test.js'],
+    argv: ['--compact', '--verbose', '--raw-error', '--update-snapshots', 'tests/account.test.js'],
   })
 
   assert.deepEqual(command.env, {
@@ -140,6 +140,7 @@ test('buildTestCommand maps Sounding reporter mode flags to environment', () => 
     SOUNDING_REPORTER_VERBOSE: '1',
     SOUNDING_DIAGNOSTICS: 'verbose',
     SOUNDING_RAW: '1',
+    SOUNDING_UPDATE_SNAPSHOTS: '1',
   })
   assert.deepEqual(command.args, [
     '--test',

--- a/test/visual-snapshots.test.js
+++ b/test/visual-snapshots.test.js
@@ -1,0 +1,142 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { createSoundingBrowserPage } = require('../lib/create-browser-page')
+const { createExpect } = require('../lib/create-expect')
+const { resolveVisualSnapshotPaths } = require('../lib/visual-snapshots')
+
+function createTempVisualEnv() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-visual-'))
+  const previous = {
+    SOUNDING_SNAPSHOT_DIR: process.env.SOUNDING_SNAPSHOT_DIR,
+    SOUNDING_VISUAL_ARTIFACT_DIR: process.env.SOUNDING_VISUAL_ARTIFACT_DIR,
+    SOUNDING_UPDATE_SNAPSHOTS: process.env.SOUNDING_UPDATE_SNAPSHOTS,
+  }
+
+  process.env.SOUNDING_SNAPSHOT_DIR = path.join(root, 'snapshots')
+  process.env.SOUNDING_VISUAL_ARTIFACT_DIR = path.join(root, 'artifacts')
+  delete process.env.SOUNDING_UPDATE_SNAPSHOTS
+
+  return {
+    root,
+    restore() {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+
+      fs.rmSync(root, { recursive: true, force: true })
+    },
+  }
+}
+
+function createPage(buffer, options = {}) {
+  const calls = []
+  const rawPage = {
+    async screenshot(screenshotOptions) {
+      calls.push(['screenshot', screenshotOptions])
+      return Buffer.from(buffer)
+    },
+    url: () => 'http://127.0.0.1:3333/pricing',
+  }
+
+  return {
+    calls,
+    page: createSoundingBrowserPage(rawPage, {
+      project: options.project || 'desktop',
+    }),
+  }
+}
+
+test('toMatchScreenshot creates baselines in update mode', async () => {
+  const env = createTempVisualEnv()
+
+  try {
+    process.env.SOUNDING_UPDATE_SNAPSHOTS = '1'
+    const { page, calls } = createPage('approved screenshot', { project: 'mobile' })
+
+    await createExpect(page).toMatchScreenshot('pricing page')
+
+    const paths = resolveVisualSnapshotPaths('pricing page', 'mobile')
+    assert.equal(fs.readFileSync(paths.baselinePath).toString(), 'approved screenshot')
+    assert.deepEqual(calls, [['screenshot', { fullPage: true }]])
+  } finally {
+    env.restore()
+  }
+})
+
+test('toMatchScreenshot passes when the baseline matches', async () => {
+  const env = createTempVisualEnv()
+
+  try {
+    const paths = resolveVisualSnapshotPaths('pricing', 'desktop')
+    fs.mkdirSync(path.dirname(paths.baselinePath), { recursive: true })
+    fs.writeFileSync(paths.baselinePath, 'same screenshot')
+
+    const { page } = createPage('same screenshot')
+
+    await createExpect(page).toMatchScreenshot('pricing')
+  } finally {
+    env.restore()
+  }
+})
+
+test('toMatchScreenshot explains missing baselines', async () => {
+  const env = createTempVisualEnv()
+
+  try {
+    const { page } = createPage('new screenshot')
+
+    await assert.rejects(
+      async () => {
+        await createExpect(page).toMatchScreenshot('pricing')
+      },
+      (error) => {
+        assert.match(error.message, /Missing visual baseline/)
+        assert.match(error.message, /SOUNDING_UPDATE_SNAPSHOTS=1 npx sounding test/)
+        assert.match(error.message, /--update-snapshots/)
+        assert.match(error.message, /tests\/screenshots|snapshots/)
+        return true
+      }
+    )
+  } finally {
+    env.restore()
+  }
+})
+
+test('toMatchScreenshot writes mismatch artifacts', async () => {
+  const env = createTempVisualEnv()
+
+  try {
+    const paths = resolveVisualSnapshotPaths('pricing', 'desktop')
+    fs.mkdirSync(path.dirname(paths.baselinePath), { recursive: true })
+    fs.writeFileSync(paths.baselinePath, 'expected screenshot')
+
+    const { page } = createPage('actual screenshot')
+
+    await assert.rejects(
+      async () => {
+        await createExpect(page).toMatchScreenshot('pricing', { animations: 'disabled' })
+      },
+      (error) => {
+        assert.match(error.message, /Visual snapshot "pricing" did not match/)
+        assert.match(error.message, /actual\.png/)
+        assert.match(error.message, /expected\.png/)
+        assert.match(error.message, /diff\.html/)
+        return true
+      }
+    )
+
+    assert.equal(fs.readFileSync(paths.actualPath).toString(), 'actual screenshot')
+    assert.equal(fs.readFileSync(paths.expectedPath).toString(), 'expected screenshot')
+    assert.match(fs.readFileSync(paths.diffPath, 'utf8'), /Sounding visual diff/)
+  } finally {
+    env.restore()
+  }
+})

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -371,6 +371,8 @@ test('browser page wrapper context is typed from JSDoc', { browser: 'mobile' }, 
   expect(visitedPage).toHaveNoConsoleLogs()
   expect(visitedPage).toHaveNoConsoleErrors()
   expect(visitedPage).toHaveNoSmoke()
+  await expect(visitedPage).toMatchScreenshot('dashboard-mobile')
+  await expect(visitedPage).toMatchScreenshot('dashboard-mobile-dark', { fullPage: true })
 
   visitedPage.url()
   await visitedPage.text('@status')


### PR DESCRIPTION
Adds opt-in visual screenshot assertions for browser trials via expect(page).toMatchScreenshot(name), project-scoped baselines, update mode, mismatch artifacts, README coverage, CLI flag support, public JSDoc typing, and tests. Closes #86. Validation: node --test test/visual-snapshots.test.js test/browser-auth.test.js test/test-runner.test.js; npm run typecheck; npm test.