### PR TITLE
feat: add stress testing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,10 +260,23 @@ discovers plugin packages installed in your app when their package names match
 `sounding-plugin-*` or `@sounding/plugin-*`, so official plugins work as soon as
 they are added as dev dependencies.
 
-For example, stress testing lives in `sounding-plugin-stress`:
+The setup is intentionally install-only:
 
 ```sh
 npm install -D sounding-plugin-stress
+```
+
+There is no `plugins` array and no `config/sounding.js` registration step. The
+dev dependency is the registration: Sounding reads your app's `package.json`,
+loads matching plugin packages, and lets each plugin register:
+
+- CLI commands, such as `sounding stress`
+- focused test methods, such as `test.stress(...)`
+- trial context helpers, such as `{ stress }`
+
+For example, stress testing lives in `sounding-plugin-stress`:
+
+```sh
 sounding stress /api/health --duration=10 --concurrency=25
 ```
 
@@ -271,6 +284,11 @@ Plugin commands, trial helpers, and focused test methods are registered through
 the plugin package. Core also provides a small event bus for lifecycle and
 streaming use cases such as `stress:start` and `stress:done`, while keeping
 capability registration explicit and predictable.
+
+Event emitters are the right tool for observability and lifecycle side effects,
+not for discovering the public API. A plugin should register commands, test
+methods, and trial helpers explicitly, then use events for things other tools may
+want to watch.
 
 If `sounding stress` is run before the plugin is installed, Sounding prints the
 plugin install command instead of making stress testing a required dependency for
@@ -280,6 +298,20 @@ every project.
 
 Install `sounding-plugin-stress` to run real HTTP load checks from the CLI or
 inside Sounding trials.
+
+```sh
+npm install -D sounding-plugin-stress
+```
+
+Sounding uses `autocannon` as the first stress engine. It is owned by the stress
+plugin, not by Sounding core, so apps that never run load checks do not install a
+load-testing engine. `autocannon` is a Node-native HTTP benchmarking tool, which
+fits Sounding's runtime and maps cleanly to Sails HTTP routes.
+
+The public API is still Sounding's API. The plugin translates fluent Sounding
+calls into engine options, then normalizes engine output into assertion-friendly
+metrics. That gives us room to add another engine later without changing trial
+code.
 
 External targets run directly:
 
@@ -294,6 +326,12 @@ HTTP route:
 sounding stress /api/health --duration=10 --concurrency=25
 ```
 
+Relative paths can also target a deployed host without lifting a local app:
+
+```sh
+sounding stress /api/health --base-url=https://staging.example.com
+```
+
 Worlds and actor aliases work for local Sails app stress runs:
 
 ```sh
@@ -302,6 +340,33 @@ sounding stress /api/billing/summary \
   --as=owner \
   --duration=10 \
   --concurrency=20
+```
+
+Remote and `--base-url` targets should use normal HTTP auth, such as headers or
+tokens:
+
+```sh
+sounding stress https://staging.example.com/api/me \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+Useful CLI options:
+
+```sh
+sounding stress <target> \
+  --duration=10 \
+  --concurrency=25 \
+  --method=POST \
+  --header "x-test-lane: stress" \
+  --json '{"plan":"pro"}'
+```
+
+Method shorthands are available too:
+
+```sh
+sounding stress /api/invoices --post='{"plan":"pro"}'
+sounding stress /api/health --get
+sounding stress /api/session --delete
 ```
 
 Inside a trial, use `test.stress()` when the behavior needs real HTTP load:
@@ -326,9 +391,37 @@ test.stress(
 )
 ```
 
+You can also use the `stress` helper in any HTTP-capable trial:
+
+```js
+test(
+  'health endpoint has no failed requests',
+  { transport: 'http' },
+  async ({ stress, expect }) => {
+    const result = await stress.get('/api/health').concurrently(25).for(10).seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+  }
+)
+```
+
+The fluent request API covers the common HTTP shapes:
+
+```js
+await stress.get('/api/health')
+await stress.head('/api/health')
+await stress.options('/api/health')
+await stress.post('/api/invoices').json({ plan: 'pro' })
+await stress.put('/api/invoices/1').body('raw body')
+await stress.patch('/api/invoices/1', { memo: 'updated' })
+await stress.delete('/api/session')
+await stress.request('POST', '/api/events').headers({ authorization: 'Bearer token' })
+```
+
 The result exposes stable metrics like `requests.count()`,
 `requests.rate()`, `requests.failed().count()`, `requests.duration().p95()`,
-and `testRun.concurrency()`.
+and `testRun.concurrency()`. It also keeps the raw engine result at `result.raw`
+when you need to inspect autocannon-specific fields.
 
 ## App lifecycle
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,83 @@ There is also a small passing fixture for successful-output screenshots:
 node ./bin/sounding.js test --app examples/pretty-output-success
 ```
 
+## Plugins
+
+Sounding keeps heavy or specialized features in installable plugins. Core
+discovers plugin packages installed in your app when their package names match
+`sounding-plugin-*` or `@sounding/plugin-*`, so official plugins work as soon as
+they are added as dev dependencies.
+
+For example, stress testing lives in `sounding-plugin-stress`:
+
+```sh
+npm install -D sounding-plugin-stress
+sounding stress /api/health --duration=10 --concurrency=25
+```
+
+Plugin commands, trial helpers, and focused test methods are registered through
+the plugin package. Core also provides a small event bus for lifecycle and
+streaming use cases such as `stress:start` and `stress:done`, while keeping
+capability registration explicit and predictable.
+
+If `sounding stress` is run before the plugin is installed, Sounding prints the
+plugin install command instead of making stress testing a required dependency for
+every project.
+
+## Stress Testing
+
+Install `sounding-plugin-stress` to run real HTTP load checks from the CLI or
+inside Sounding trials.
+
+External targets run directly:
+
+```sh
+sounding stress https://staging.example.com/api/health --duration=10 --concurrency=25
+```
+
+Relative targets are Sails-native. Sounding lifts the app, then stresses the real
+HTTP route:
+
+```sh
+sounding stress /api/health --duration=10 --concurrency=25
+```
+
+Worlds and actor aliases work for local Sails app stress runs:
+
+```sh
+sounding stress /api/billing/summary \
+  --world=subscribed-creator \
+  --as=owner \
+  --duration=10 \
+  --concurrency=20
+```
+
+Inside a trial, use `test.stress()` when the behavior needs real HTTP load:
+
+```js
+const { test } = require('sounding')
+
+test.stress(
+  'billing summary stays fast under creator load',
+  { world: 'subscribed-creator' },
+  async ({ stress, expect }) => {
+    const result = await stress
+      .get('/api/billing/summary')
+      .as('owner')
+      .concurrently(20)
+      .for(10)
+      .seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+    expect(result.requests.duration().p95()).toBeLessThan(250)
+  }
+)
+```
+
+The result exposes stable metrics like `requests.count()`,
+`requests.rate()`, `requests.failed().count()`, `requests.duration().p95()`,
+and `testRun.concurrency()`.
+
 ## App lifecycle
 
 Sounding keeps a warm Sails app by default. Virtual request trials load the app without opening an HTTP listener, while HTTP, socket, and browser-capable trials lift the app so the network stack exists.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The canonical Sails-native surface is:
 - `get('/api/issues')` or `sails.sounding.request.get('/api/issues')` inside endpoint-style trials
 - `await auth.login.withPassword('creator@example.com', page, { password: 'secret123' })` inside browser trials
 - `await auth.request.withPassword('creator@example.com', { password: 'secret123' })` inside request trials
+- `test.it('...', async ({ expect }) => {})` when you want the behavior-reading alias
 - `test('...', { world: 'signed-in-user' }, async ({ request }) => {})` can auto-load named worlds before the handler runs
 - `request.as('owner')` and `visit.as('owner')` can resolve actor aliases from the current world
 - `test('...', { browser: 'mobile' }, async ({ page }) => {})` can select a named browser project without extra ceremony
@@ -461,6 +462,12 @@ Sounding runs trials serially by default. That keeps shared Sails app state bori
 Independent trials can opt into Node test concurrency:
 
 ```js
+test.it('health check is readable', async ({ get, expect }) => {
+  const response = await get('/health')
+
+  expect(response).toHaveStatus(200)
+})
+
 test.concurrent('health check is isolated', async ({ get, expect }) => {
   const response = await get('/health')
 

--- a/bin/sounding.js
+++ b/bin/sounding.js
@@ -2,6 +2,10 @@
 
 const { initProject } = require('../lib/init-project')
 const { formatTestCommand, runTests } = require('../lib/test-runner')
+const {
+  createMissingStressPluginError,
+  createPluginManager,
+} = require('../lib/create-plugin-manager')
 
 function printHelp() {
   process.stdout.write(`Sounding
@@ -9,10 +13,13 @@ function printHelp() {
 Usage:
   sounding init [--app <path>] [--config]
   sounding test [options] [files or folders]
+  sounding <plugin-command> [options]
 
 Commands:
   init      Scaffold Sounding tests, worlds, and package scripts in a Sails app.
   test      Run Sounding trials through the Node.js test runner.
+
+Plugin commands are discovered from installed packages like sounding-plugin-stress.
 
 Options:
   --app     Target app directory. Defaults to the current working directory.
@@ -76,6 +83,13 @@ function parseArgs(argv) {
     }
   }
 
+  if (command && command !== 'init') {
+    return {
+      command,
+      options: parsePluginCommandArgs(args),
+    }
+  }
+
   while (args.length > 0) {
     const arg = args.shift()
 
@@ -106,6 +120,35 @@ function parseArgs(argv) {
   }
 }
 
+function parsePluginCommandArgs(argv) {
+  const args = [...argv]
+  const forwarded = []
+  const options = {
+    argv: forwarded,
+  }
+
+  while (args.length > 0) {
+    const arg = args.shift()
+
+    if (arg === '--app') {
+      options.appPath = args.shift()
+      if (!options.appPath) {
+        throw new Error('Sounding option `--app` requires a path.')
+      }
+      continue
+    }
+
+    if (arg.startsWith('--app=')) {
+      options.appPath = arg.slice('--app='.length)
+      continue
+    }
+
+    forwarded.push(arg)
+  }
+
+  return options
+}
+
 function printInitResult(result) {
   process.stdout.write(`Sounding initialized ${result.appPath}\n`)
   process.stdout.write(
@@ -123,12 +166,17 @@ function printInitResult(result) {
 async function main() {
   const { command, options } = parseArgs(process.argv.slice(2))
 
-  if (!command || options.help) {
+  if (!command) {
     printHelp()
     return
   }
 
   if (command === 'init') {
+    if (options.help) {
+      printHelp()
+      return
+    }
+
     const result = initProject(options)
     printInitResult(result)
     return
@@ -153,9 +201,30 @@ async function main() {
     return
   }
 
-  {
-    throw new Error(`Unknown Sounding command: ${command}`)
+  const plugins = createPluginManager({
+    appPath: options.appPath || process.cwd(),
+  })
+  const pluginCommand = plugins.command(command)
+
+  if (pluginCommand) {
+    const result = await pluginCommand.command(options.argv || [], {
+      appPath: plugins.appPath,
+      command,
+      plugin: pluginCommand.plugin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    })
+
+    process.exitCode =
+      typeof result === 'number' ? result : result?.status === undefined ? 0 : result.status
+    return
   }
+
+  if (command === 'stress') {
+    throw createMissingStressPluginError()
+  }
+
+  throw new Error(`Unknown Sounding command: ${command}`)
 }
 
 main().catch((error) => {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const { createSocketManager } = require('./lib/create-socket-manager')
 const { createAuthHelpers } = require('./lib/create-auth-helpers')
 const { createExpect } = require('./lib/create-expect')
 const { createTestApi } = require('./lib/create-test-api')
+const { createPluginManager } = require('./lib/create-plugin-manager')
 const { getDefaultConfig } = require('./lib/default-config')
 
 /** @typedef {import('./lib/types').SoundingSailsApp} SoundingSailsApp */
@@ -105,5 +106,6 @@ module.exports.createSocketManager = createSocketManager
 module.exports.createAuthHelpers = createAuthHelpers
 module.exports.createExpect = createExpect
 module.exports.createTestApi = createTestApi
+module.exports.createPluginManager = createPluginManager
 module.exports.getDefaultConfig = getDefaultConfig
 module.exports.createMailCapture = createMailCapture

--- a/lib/create-plugin-manager.js
+++ b/lib/create-plugin-manager.js
@@ -1,0 +1,349 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const EventEmitter = require('node:events')
+
+const { createAppManager } = require('./create-app-manager')
+const { createSoundingError } = require('./create-error')
+const { createSessionCookie } = require('./create-session-cookie')
+const {
+  createRequestActorUnresolvedError,
+  resolveActorHeaders,
+  resolveActorSession,
+  resolveBaseUrl,
+  resolveUrl,
+  resolveWorldActor,
+} = require('./create-request-client')
+const { loadDependencyFromApp } = require('./resolve-dependency')
+const { resolveAuthConfig } = require('./resolve-auth-config')
+
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+
+const PLUGIN_PACKAGE_PATTERNS = [/^sounding-plugin-[a-z0-9][a-z0-9-]*$/i, /^@sounding\/plugin-[a-z0-9][a-z0-9-]*$/i]
+
+/**
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isSoundingPluginPackageName(name) {
+  return PLUGIN_PACKAGE_PATTERNS.some((pattern) => pattern.test(name))
+}
+
+/**
+ * @param {string} appPath
+ * @returns {AnyRecord | null}
+ */
+function readPackageJson(appPath) {
+  const packagePath = path.join(appPath, 'package.json')
+
+  if (!fs.existsSync(packagePath)) {
+    return null
+  }
+
+  return JSON.parse(fs.readFileSync(packagePath, 'utf8'))
+}
+
+/**
+ * @param {AnyRecord | null} packageJson
+ * @returns {string[]}
+ */
+function discoverDependencyPluginNames(packageJson) {
+  if (!packageJson) {
+    return []
+  }
+
+  const dependencies = {
+    ...(packageJson.dependencies || {}),
+    ...(packageJson.devDependencies || {}),
+    ...(packageJson.optionalDependencies || {}),
+    ...(packageJson.peerDependencies || {}),
+  }
+
+  return Object.keys(dependencies).filter(isSoundingPluginPackageName).sort()
+}
+
+/**
+ * @param {string} appPath
+ * @returns {Array<{ name: string, localPath: string }>}
+ */
+function discoverLocalPluginPackages(appPath) {
+  const pluginsPath = path.join(appPath, 'plugins')
+
+  if (!fs.existsSync(pluginsPath)) {
+    return []
+  }
+
+  const specs = []
+
+  for (const entry of fs.readdirSync(pluginsPath, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const pluginPath = path.join(pluginsPath, entry.name)
+    const packageJson = readPackageJson(pluginPath)
+    const name = packageJson?.name
+
+    if (!name || !isSoundingPluginPackageName(name)) {
+      continue
+    }
+
+    specs.push({
+      name,
+      localPath: path.join(pluginPath, packageJson.main || 'index.js'),
+    })
+  }
+
+  return specs.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+/**
+ * @param {string} appPath
+ * @returns {Array<{ name: string, moduleId?: string, localPath?: string }>}
+ */
+function discoverPluginSpecs(appPath = process.cwd()) {
+  const resolvedAppPath = path.resolve(appPath)
+  const specs = new Map()
+
+  for (const name of discoverDependencyPluginNames(readPackageJson(resolvedAppPath))) {
+    specs.set(name, {
+      name,
+      moduleId: name,
+    })
+  }
+
+  for (const localSpec of discoverLocalPluginPackages(resolvedAppPath)) {
+    specs.set(localSpec.name, localSpec)
+  }
+
+  return Array.from(specs.values())
+}
+
+/**
+ * @param {string[]} appPaths
+ * @returns {Array<{ name: string, moduleId?: string, localPath?: string }>}
+ */
+function discoverPluginSpecsFrom(appPaths) {
+  const specs = new Map()
+
+  for (const appPath of appPaths) {
+    for (const spec of discoverPluginSpecs(appPath)) {
+      if (!specs.has(spec.name)) {
+        specs.set(spec.name, spec)
+      }
+    }
+  }
+
+  return Array.from(specs.values())
+}
+
+/**
+ * @param {any} loaded
+ * @returns {Function}
+ */
+function normalizePluginFactory(loaded) {
+  const candidate = loaded?.default || loaded
+
+  if (typeof candidate !== 'function') {
+    throw createSoundingError({
+      code: 'E_SOUNDING_PLUGIN_INVALID',
+      name: 'SoundingPluginError',
+      message: 'Sounding plugins must export a function.',
+    })
+  }
+
+  return candidate
+}
+
+/**
+ * @param {{
+ *   spec: { name: string, moduleId?: string, localPath?: string },
+ *   appPath: string,
+ *   api: AnyRecord,
+ *   requireImplementation?: NodeJS.Require,
+ * }} input
+ * @returns {AnyRecord}
+ */
+function loadPlugin({ spec, appPath, api, requireImplementation = require }) {
+  const loaded = spec.localPath
+    ? requireImplementation(spec.localPath)
+    : loadDependencyFromApp({
+        appPath,
+        moduleId: spec.moduleId || spec.name,
+        dependency: spec.name,
+        purpose: 'load a Sounding plugin',
+        install: `npm install -D ${spec.name}`,
+      })
+  const factory = normalizePluginFactory(loaded)
+  const plugin = factory(api)
+
+  if (!plugin || typeof plugin !== 'object') {
+    throw createSoundingError({
+      code: 'E_SOUNDING_PLUGIN_INVALID',
+      name: 'SoundingPluginError',
+      message: `Sounding plugin \`${spec.name}\` must return a plugin object.`,
+      details: {
+        plugin: spec.name,
+      },
+    })
+  }
+
+  return {
+    ...plugin,
+    packageName: spec.name,
+    name: plugin.name || spec.name,
+  }
+}
+
+/**
+ * @param {{ appPath?: string, events?: EventEmitter }} [options]
+ * @returns {AnyRecord}
+ */
+function createPluginApi({ appPath = process.cwd(), events } = {}) {
+  return {
+    appPath: path.resolve(appPath),
+    events,
+    createAppManager,
+    createSessionCookie,
+    createSoundingError,
+    resolveActorHeaders,
+    resolveActorSession,
+    resolveAuthConfig,
+    resolveBaseUrl,
+    resolveUrl,
+    resolveWorldActor,
+    createRequestActorUnresolvedError,
+    loadDependencyFromApp,
+  }
+}
+
+/**
+ * @param {{
+ *   appPath?: string,
+ *   specs?: Array<{ name: string, moduleId?: string, localPath?: string }>,
+ *   plugins?: AnyRecord[],
+ *   requireImplementation?: NodeJS.Require,
+ * }} [options]
+ */
+function createPluginManager({
+  appPath = process.cwd(),
+  specs,
+  plugins,
+  requireImplementation = require,
+} = {}) {
+  const resolvedAppPath = path.resolve(appPath)
+  const events = new EventEmitter()
+  const api = createPluginApi({ appPath: resolvedAppPath, events })
+  const loadedPlugins =
+    plugins ||
+    (specs || discoverPluginSpecsFrom([resolvedAppPath, process.cwd()])).map((spec) =>
+      loadPlugin({
+        spec,
+        appPath: resolvedAppPath,
+        api,
+        requireImplementation,
+      })
+    )
+
+  for (const plugin of loadedPlugins) {
+    events.emit('plugin:loaded', plugin)
+  }
+
+  return {
+    appPath: resolvedAppPath,
+    events,
+
+    get plugins() {
+      return [...loadedPlugins]
+    },
+
+    command(name) {
+      for (const plugin of loadedPlugins) {
+        const command = plugin.commands?.[name]
+
+        if (typeof command === 'function') {
+          return {
+            plugin,
+            command,
+          }
+        }
+      }
+
+      return null
+    },
+
+    testMethods() {
+      const methods = []
+
+      for (const plugin of loadedPlugins) {
+        for (const [name, definition] of Object.entries(plugin.testMethods || {})) {
+          methods.push({
+            plugin,
+            name,
+            definition: definition || {},
+          })
+        }
+      }
+
+      return methods
+    },
+
+    async trialContext(input) {
+      const context = {}
+
+      for (const plugin of loadedPlugins) {
+        if (typeof plugin.trial !== 'function') {
+          continue
+        }
+
+        events.emit('trial:plugin:before', {
+          plugin,
+          title: input.title,
+        })
+
+        const extension = await plugin.trial({
+          ...input,
+          appPath: resolvedAppPath,
+          plugin,
+          events,
+        })
+
+        if (extension && typeof extension === 'object') {
+          Object.assign(context, extension)
+        }
+
+        events.emit('trial:plugin:after', {
+          plugin,
+          title: input.title,
+          keys: Object.keys(extension || {}),
+        })
+      }
+
+      return context
+    },
+  }
+}
+
+function createMissingStressPluginError() {
+  return createSoundingError({
+    code: 'E_SOUNDING_PLUGIN_COMMAND_MISSING',
+    name: 'SoundingPluginError',
+    message:
+      'Sounding stress testing lives in `sounding-plugin-stress`. Install it with: `npm install -D sounding-plugin-stress`.',
+    details: {
+      command: 'stress',
+      install: 'npm install -D sounding-plugin-stress',
+      plugin: 'sounding-plugin-stress',
+    },
+  })
+}
+
+module.exports = {
+  createMissingStressPluginError,
+  createPluginApi,
+  createPluginManager,
+  discoverDependencyPluginNames,
+  discoverLocalPluginPackages,
+  discoverPluginSpecs,
+  discoverPluginSpecsFrom,
+  isSoundingPluginPackageName,
+}

--- a/lib/create-request-client.js
+++ b/lib/create-request-client.js
@@ -1120,11 +1120,16 @@ function createRequestClient({
 }
 
 module.exports = {
+  availableWorldActors,
   createRequestClient,
+  createRequestActorUnresolvedError,
   createVirtualTransport,
   createHttpTransport,
   normalizeResponse,
+  resolveActorHeaders,
+  resolveActorSession,
   resolveBaseUrl,
   resolveTransport,
   resolveUrl,
+  resolveWorldActor,
 }

--- a/lib/create-session-cookie.js
+++ b/lib/create-session-cookie.js
@@ -1,0 +1,57 @@
+const { createSoundingError } = require('./create-error')
+
+/** @typedef {import('./types').AnyRecord} AnyRecord */
+/** @typedef {import('./types').SoundingSailsApp} SoundingSailsApp */
+
+/**
+ * @param {SoundingSailsApp} sails
+ * @param {AnyRecord} session
+ * @returns {Promise<string | null>}
+ */
+async function createSessionCookie(sails, session) {
+  if (
+    !sails?.session ||
+    typeof sails.session.generateNewSidCookie !== 'function' ||
+    typeof sails.session.parseSessionIdFromCookie !== 'function' ||
+    typeof sails.session.set !== 'function'
+  ) {
+    return null
+  }
+
+  const cookie = sails.session.generateNewSidCookie()
+  const sid = sails.session.parseSessionIdFromCookie(cookie)
+
+  await new Promise((resolve, reject) => {
+    sails.session.set(
+      sid,
+      {
+        cookie: {
+          httpOnly: true,
+          path: '/',
+        },
+        ...session,
+      },
+      (error) => {
+        if (error) {
+          reject(
+            createSoundingError({
+              code: 'E_SOUNDING_SESSION_COOKIE_FAILED',
+              name: 'SoundingSessionError',
+              message: 'Sounding could not create a Sails session cookie.',
+              cause: error,
+            })
+          )
+          return
+        }
+
+        resolve()
+      }
+    )
+  })
+
+  return cookie
+}
+
+module.exports = {
+  createSessionCookie,
+}

--- a/lib/create-socket-manager.js
+++ b/lib/create-socket-manager.js
@@ -2,6 +2,7 @@ const { normalizeResponse, resolveBaseUrl } = require('./create-request-client')
 const { createSoundingError } = require('./create-error')
 const { loadDependencyFromApp } = require('./resolve-dependency')
 const { resolveAuthConfig } = require('./resolve-auth-config')
+const { createSessionCookie } = require('./create-session-cookie')
 
 /** @typedef {import('./types').AnyRecord} AnyRecord */
 /** @typedef {import('./types').SoundingActor} SoundingActor */
@@ -181,48 +182,6 @@ function normalizeJwrResponse(jwr, method, target, body) {
       url: target,
     },
   })
-}
-
-/**
- * @param {SoundingSailsApp} sails
- * @param {AnyRecord} session
- * @returns {Promise<string | null>}
- */
-async function createSessionCookie(sails, session) {
-  if (
-    !sails?.session ||
-    typeof sails.session.generateNewSidCookie !== 'function' ||
-    typeof sails.session.parseSessionIdFromCookie !== 'function' ||
-    typeof sails.session.set !== 'function'
-  ) {
-    return null
-  }
-
-  const cookie = sails.session.generateNewSidCookie()
-  const sid = sails.session.parseSessionIdFromCookie(cookie)
-
-  await new Promise((resolve, reject) => {
-    sails.session.set(
-      sid,
-      {
-        cookie: {
-          httpOnly: true,
-          path: '/',
-        },
-        ...session,
-      },
-      (error) => {
-        if (error) {
-          reject(error)
-          return
-        }
-
-        resolve()
-      }
-    )
-  })
-
-  return cookie
 }
 
 /**

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -6,6 +6,7 @@ const {
 } = require('./create-browser-page')
 const { createAppManager } = require('./create-app-manager')
 const { createExpect } = require('./create-expect')
+const { createPluginManager } = require('./create-plugin-manager')
 const { createRuntime } = require('./create-runtime')
 const { createSoundingError } = require('./create-error')
 const { runWithTrialContext } = require('./trial-context')
@@ -465,10 +466,19 @@ function createVisitWithBrowserSmokeAll(visit, browserVisit) {
  *   nodeContext: Record<string, any>,
  *   handler: SoundingTrialHandler,
  *   options?: SoundingTestOptions,
+ *   pluginManager?: ReturnType<typeof createPluginManager>,
  * }} args
  * @returns {Promise<any>}
  */
-async function runTrial({ runtime, mode, title, nodeContext, handler, options = {} }) {
+async function runTrial({
+  runtime,
+  mode,
+  title,
+  nodeContext,
+  handler,
+  options = {},
+  pluginManager,
+}) {
   const resolved = await resolveTrialRuntime(runtime, options)
   const sounding = resolved.sounding
 
@@ -592,9 +602,28 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
           return pages
         }
 
+        const pluginContext = pluginManager
+          ? await pluginManager.trialContext({
+              runtime: sounding,
+              sails,
+              config: sounding.config,
+              world: sounding.world,
+              request,
+              visit: trialVisit,
+              sockets,
+              auth: sounding.auth,
+              login: sounding.auth?.login,
+              mailbox: sounding.mailbox,
+              expect,
+              title,
+              options,
+            })
+          : {}
+
         /** @type {SoundingTrialContext} */
         const context = {
           ...nodeContext,
+          ...pluginContext,
           t: nodeContext,
           expect,
           sails,
@@ -645,9 +674,18 @@ async function runTrial({ runtime, mode, title, nodeContext, handler, options = 
  * @param {SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>) | undefined} runtime
  * @param {string} mode
  * @param {boolean} [forceConcurrent]
+ * @param {SoundingTestOptions} [defaultTrialOptions]
  * @returns {SoundingTrialRegistrar}
  */
-function createTrialMethod(baseTest, runtime, mode, apiName = 'test', forceConcurrent = false) {
+function createTrialMethod(
+  baseTest,
+  runtime,
+  mode,
+  apiName = 'test',
+  forceConcurrent = false,
+  defaultTrialOptions = {},
+  pluginManager = null
+) {
   const registerTrial = function registerTrial(title, optionsOrHandler, maybeHandler) {
     const { options, handler } = normalizeTestArgs(
       title,
@@ -655,7 +693,9 @@ function createTrialMethod(baseTest, runtime, mode, apiName = 'test', forceConcu
       maybeHandler,
       apiName
     )
-    const nextOptions = forceConcurrent ? { ...options, concurrent: true } : options
+    const nextOptions = forceConcurrent
+      ? { ...defaultTrialOptions, ...options, concurrent: true }
+      : { ...defaultTrialOptions, ...options }
     const { nodeOptions, trialOptions } = splitTestOptions(nextOptions, apiName)
 
     return baseTest(title, nodeOptions, async (nodeContext) => {
@@ -669,6 +709,7 @@ function createTrialMethod(baseTest, runtime, mode, apiName = 'test', forceConcu
           nodeContext,
           handler,
           options: trialOptions,
+          pluginManager,
         })
       })
     })
@@ -680,10 +721,15 @@ function createTrialMethod(baseTest, runtime, mode, apiName = 'test', forceConcu
 /**
  * Create Sounding's `test()` API.
  *
- * @param {{ baseTest?: NodeTestLike, runtime?: SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>) }} [options]
+ * @param {{ baseTest?: NodeTestLike, runtime?: SoundingRuntime | (() => SoundingRuntime | Promise<SoundingRuntime>), plugins?: Record<string, any>[] }} [options]
  * @returns {SoundingTest}
  */
-function createTestApi({ baseTest = nodeTest, runtime } = {}) {
+function createTestApi({ baseTest = nodeTest, runtime, plugins } = {}) {
+  const pluginManager = createPluginManager({
+    appPath: process.cwd(),
+    ...(plugins ? { plugins } : {}),
+  })
+
   function soundingTest(title, optionsOrHandler, maybeHandler) {
     const { options, handler } = normalizeTestArgs(title, optionsOrHandler, maybeHandler, 'test')
     const { nodeOptions, trialOptions } = splitTestOptions(options, 'test')
@@ -699,6 +745,7 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
           nodeContext,
           handler,
           options: trialOptions,
+          pluginManager,
         })
       })
     })
@@ -707,9 +754,42 @@ function createTestApi({ baseTest = nodeTest, runtime } = {}) {
   soundingTest.skip = (...args) => baseTest.skip?.(...args)
   soundingTest.todo = (...args) => baseTest.todo?.(...args)
   if (typeof baseTest.only === 'function') {
-    soundingTest.only = createTrialMethod(baseTest.only.bind(baseTest), runtime, 'trial', 'test.only')
+    soundingTest.only = createTrialMethod(
+      baseTest.only.bind(baseTest),
+      runtime,
+      'trial',
+      'test.only',
+      false,
+      {},
+      pluginManager
+    )
   }
-  soundingTest.concurrent = createTrialMethod(baseTest, runtime, 'trial', 'test.concurrent', true)
+  soundingTest.concurrent = createTrialMethod(
+    baseTest,
+    runtime,
+    'trial',
+    'test.concurrent',
+    true,
+    {},
+    pluginManager
+  )
+
+  for (const method of pluginManager.testMethods()) {
+    if (Object.prototype.hasOwnProperty.call(soundingTest, method.name)) {
+      continue
+    }
+
+    const definition = method.definition || {}
+    soundingTest[method.name] = createTrialMethod(
+      baseTest,
+      runtime,
+      definition.mode || method.name,
+      `test.${method.name}`,
+      false,
+      definition.options || {},
+      pluginManager
+    )
+  }
 
   return soundingTest
 }

--- a/lib/create-test-api.js
+++ b/lib/create-test-api.js
@@ -16,6 +16,7 @@ const { normalizeTestArgs, splitTestOptions } = require('./validate-test-args')
 /** @typedef {import('./types').SoundingExpect} SoundingExpect */
 /** @typedef {import('./types').SoundingBrowserArtifacts} SoundingBrowserArtifacts */
 /** @typedef {import('./types').SoundingBrowserSession} SoundingBrowserSession */
+/** @typedef {import('./types').SoundingItRegistrar} SoundingItRegistrar */
 /** @typedef {import('./types').SoundingTest} SoundingTest */
 /** @typedef {import('./types').SoundingTestOptions} SoundingTestOptions */
 /** @typedef {import('./types').SoundingTrialContext} SoundingTrialContext */
@@ -773,6 +774,33 @@ function createTestApi({ baseTest = nodeTest, runtime, plugins } = {}) {
     {},
     pluginManager
   )
+
+  const it = /** @type {SoundingItRegistrar} */ (
+    createTrialMethod(baseTest, runtime, 'trial', 'test.it', false, {}, pluginManager)
+  )
+  it.skip = (...args) => baseTest.skip?.(...args)
+  it.todo = (...args) => baseTest.todo?.(...args)
+  if (typeof baseTest.only === 'function') {
+    it.only = createTrialMethod(
+      baseTest.only.bind(baseTest),
+      runtime,
+      'trial',
+      'test.it.only',
+      false,
+      {},
+      pluginManager
+    )
+  }
+  it.concurrent = createTrialMethod(
+    baseTest,
+    runtime,
+    'trial',
+    'test.it.concurrent',
+    true,
+    {},
+    pluginManager
+  )
+  soundingTest.it = it
 
   for (const method of pluginManager.testMethods()) {
     if (Object.prototype.hasOwnProperty.call(soundingTest, method.name)) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -792,6 +792,14 @@
  *   todo(...args: any[]): unknown,
  *   only?: SoundingTrialRegistrar,
  *   concurrent: SoundingTrialRegistrar,
+ * }} SoundingItRegistrar
+ *
+ * @typedef {SoundingTrialRegistrar & {
+ *   skip(...args: any[]): unknown,
+ *   todo(...args: any[]): unknown,
+ *   only?: SoundingTrialRegistrar,
+ *   concurrent: SoundingTrialRegistrar,
+ *   it: SoundingItRegistrar,
  * }} SoundingTest
  *
  * @typedef {{

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "sounding",
       "version": "0.1.0",
       "license": "MIT",
+      "workspaces": [
+        "plugins/*"
+      ],
       "bin": {
         "sounding": "bin/sounding.js"
       },
@@ -19,6 +22,31 @@
         "sails-sqlite": "^0.2.6",
         "socket.io-client": "^4.8.3",
         "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",
+      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@minimistjs/subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@minimistjs/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.1.0"
       }
     },
     "node_modules/@sailshq/binary-search-tree": {
@@ -188,6 +216,15 @@
         "validator": "13.15.23"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -224,6 +261,116 @@
         "lodash": "^4.17.14"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/autocannon": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/autocannon/-/autocannon-8.0.0.tgz",
+      "integrity": "sha512-fMMcWc2JPFcUaqHeR6+PbmEpTxCrPZyBUM95oG4w3ngJ8NfBNas/ZXA+pTHXLqJ0UlFVTcy05GC25WxKx/M20A==",
+      "license": "MIT",
+      "dependencies": {
+        "@minimistjs/subarg": "^1.0.0",
+        "chalk": "^4.1.0",
+        "char-spinner": "^1.0.1",
+        "cli-table3": "^0.6.0",
+        "color-support": "^1.1.1",
+        "cross-argv": "^2.0.0",
+        "form-data": "^4.0.0",
+        "has-async-hooks": "^1.0.0",
+        "hdr-histogram-js": "^3.0.0",
+        "hdr-histogram-percentiles-obj": "^3.0.0",
+        "http-parser-js": "^0.5.2",
+        "hyperid": "^3.0.0",
+        "lodash.chunk": "^4.2.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "manage-path": "^2.0.0",
+        "on-net-listen": "^1.1.1",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "reinterval": "^1.1.0",
+        "retimer": "^3.0.0",
+        "semver": "^7.3.2",
+        "timestring": "^6.0.0"
+      },
+      "bin": {
+        "autocannon": "autocannon.js"
+      }
+    },
+    "node_modules/autocannon/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/autocannon/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/autocannon/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/autocannon/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/autocannon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/autocannon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -235,7 +382,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -377,7 +523,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -412,7 +557,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -477,12 +621,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/char-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+      "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
+      "license": "ISC"
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -501,6 +666,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -509,6 +683,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -662,6 +848,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cross-argv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cross-argv/-/cross-argv-2.0.0.tgz",
+      "integrity": "sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==",
+      "license": "MIT"
+    },
     "node_modules/csrf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
@@ -732,6 +924,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/denque": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
@@ -777,7 +978,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -810,6 +1010,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -944,7 +1150,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -954,7 +1159,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -964,10 +1168,24 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1286,6 +1504,22 @@
         "@sailshq/lodash": "^3.10.2"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1338,7 +1572,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1348,7 +1581,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1373,7 +1605,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -1413,7 +1644,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1436,6 +1666,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/has-async-hooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-async-hooks/-/has-async-hooks-1.0.0.tgz",
+      "integrity": "sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -1450,8 +1686,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1463,7 +1713,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1471,6 +1720,26 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hdr-histogram-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-3.0.1.tgz",
+      "integrity": "sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@assemblyscript/loader": "^0.19.21",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "1.8.0",
@@ -1507,6 +1776,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/hyperid": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.3.0.tgz",
+      "integrity": "sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "uuid": "^8.3.2",
+        "uuid-parse": "^1.1.0"
       }
     },
     "node_modules/i18n-2": {
@@ -1557,7 +1843,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1629,6 +1914,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-wsl": {
@@ -1717,6 +2011,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
     "node_modules/lodash.issafeinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.issafeinteger/-/lodash.issafeinteger-4.0.4.tgz",
@@ -1728,7 +2040,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -1830,11 +2141,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/manage-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/manage-path/-/manage-path-2.0.0.tgz",
+      "integrity": "sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1917,7 +2233,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -1930,7 +2245,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1966,7 +2280,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mkdirp": {
@@ -2131,6 +2444,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-net-listen": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/on-net-listen/-/on-net-listen-1.1.2.tgz",
+      "integrity": "sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=9.4.0 || ^8.9.4"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2153,6 +2475,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parasails": {
       "version": "0.9.3",
@@ -2243,6 +2571,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/promise": {
@@ -2491,6 +2840,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "license": "MIT"
+    },
     "node_modules/reportback": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/reportback/-/reportback-2.0.2.tgz",
@@ -2501,6 +2856,12 @@
         "captains-log": "^2.0.2",
         "switchback": "^2.0.1"
       }
+    },
+    "node_modules/retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
+      "license": "MIT"
     },
     "node_modules/revalidator": {
       "version": "0.1.8",
@@ -2794,7 +3155,6 @@
       "version": "7.5.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
       "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3350,6 +3710,20 @@
         "@sailshq/lodash": "^3.10.2"
       }
     },
+    "node_modules/sounding": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sounding/-/sounding-0.1.0.tgz",
+      "integrity": "sha512-f6wjnIrGvPN6YmRN4WiQjiBPycjmFYlDiLkki3ZAQ0GdYMqw/ag3S2UPYAaUA0NpLebd2Ux5xDx/rLsABYPzZQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "sounding": "bin/sounding.js"
+      }
+    },
+    "node_modules/sounding-plugin-stress": {
+      "resolved": "plugins/stress",
+      "link": true
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -3393,6 +3767,32 @@
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
@@ -3455,6 +3855,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/timestring": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
+      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tmpl": {
@@ -3584,6 +3993,22 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
+      "license": "MIT"
     },
     "node_modules/validator": {
       "version": "13.15.23",
@@ -3781,7 +4206,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
@@ -3795,6 +4219,17 @@
         "decamelize": "^1.0.0",
         "window-size": "0.1.0",
         "wordwrap": "0.0.2"
+      }
+    },
+    "plugins/stress": {
+      "name": "sounding-plugin-stress",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "autocannon": "^8.0.0"
+      },
+      "peerDependencies": {
+        "sounding": "^0.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "sounding": "bin/sounding.js"
   },
+  "workspaces": [
+    "plugins/*"
+  ],
   "license": "MIT",
   "keywords": [
     "sails",

--- a/plugins/stress/README.md
+++ b/plugins/stress/README.md
@@ -1,0 +1,110 @@
+# sounding-plugin-stress
+
+Stress testing for Sounding.
+
+Install it in a Sails app that already uses Sounding:
+
+```sh
+npm install -D sounding-plugin-stress
+```
+
+Once installed, Sounding discovers the plugin automatically.
+
+## CLI
+
+Stress a local Sails route by passing a relative target:
+
+```sh
+sounding stress /api/health --duration=10 --concurrency=25
+```
+
+Stress an external or deployed URL directly:
+
+```sh
+sounding stress https://staging.example.com/api/health --duration=10 --concurrency=25
+```
+
+Stress a Sails-shaped path against a specific host:
+
+```sh
+sounding stress /api/health --base-url=https://staging.example.com
+```
+
+Use worlds and actor aliases for local Sails app stress runs:
+
+```sh
+sounding stress /api/billing/summary \
+  --world=subscribed-creator \
+  --as=owner \
+  --duration=10 \
+  --concurrency=20
+```
+
+Remote and `--base-url` targets should use headers or tokens for auth:
+
+```sh
+sounding stress https://staging.example.com/api/me \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+## Trial API
+
+Use `test.stress()` when the trial is specifically about real HTTP load:
+
+```js
+const { test } = require('sounding')
+
+test.stress(
+  'billing summary stays fast under creator load',
+  { world: 'subscribed-creator' },
+  async ({ stress, expect }) => {
+    const result = await stress
+      .get('/api/billing/summary')
+      .as('owner')
+      .concurrently(20)
+      .for(10)
+      .seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+    expect(result.requests.duration().p95()).toBeLessThan(250)
+  }
+)
+```
+
+POST JSON payloads and headers:
+
+```js
+const result = await stress
+  .post('/api/invoices')
+  .json({ plan: 'pro' })
+  .headers({ 'x-test-lane': 'stress' })
+  .concurrently(10)
+  .for(5)
+  .seconds()
+```
+
+## Metrics
+
+The result is assertion-friendly:
+
+```js
+result.requests.count()
+result.requests.rate()
+result.requests.failed().count()
+result.requests.failed().rate()
+result.requests.duration().min()
+result.requests.duration().med()
+result.requests.duration().p90()
+result.requests.duration().p95()
+result.requests.duration().max()
+result.requests.download().data().count()
+result.requests.download().data().rate()
+result.testRun.concurrency()
+result.testRun.duration()
+```
+
+## Engine
+
+The first engine is `autocannon`, owned by this plugin so core Sounding stays light.
+Sounding owns the public API and result model, so future engines can be added without
+forcing test code to change.

--- a/plugins/stress/README.md
+++ b/plugins/stress/README.md
@@ -2,13 +2,42 @@
 
 Stress testing for Sounding.
 
+The plugin keeps Sounding core light while still giving Sails apps a native
+stress-testing surface. It owns the load engine dependency, while Sounding owns
+the public API and result shape.
+
 Install it in a Sails app that already uses Sounding:
 
 ```sh
 npm install -D sounding-plugin-stress
 ```
 
-Once installed, Sounding discovers the plugin automatically.
+Once installed, Sounding discovers the plugin automatically from `package.json`.
+There is no `plugins` array and no `config/sounding.js` registration step.
+
+The plugin adds:
+
+- the `sounding stress` CLI command
+- `test.stress(...)`
+- a `{ stress }` trial context helper
+- `stress:start` and `stress:done` lifecycle events on Sounding's plugin event bus
+
+## Engine choice
+
+The first engine is `autocannon`.
+
+That choice is deliberate:
+
+- it is a Node-native HTTP benchmarking tool
+- it can be installed as a normal dev dependency through this plugin
+- it has a programmatic API, so Sounding can wrap it instead of shelling out
+- its core options map cleanly to Sounding concepts like duration, concurrency,
+  method, headers, and body
+- its result data includes request rate, latency, failures, and throughput, which
+  Sounding normalizes into assertion-friendly metrics
+
+Sounding does not expose `autocannon` directly. The public API is the Sounding
+stress API, and `autocannon` is the current engine behind that API.
 
 ## CLI
 
@@ -47,6 +76,49 @@ sounding stress https://staging.example.com/api/me \
   --header "Authorization: Bearer $TOKEN"
 ```
 
+Send methods, JSON, raw bodies, and headers:
+
+```sh
+sounding stress /api/invoices \
+  --post='{"plan":"pro"}' \
+  --header "x-test-lane: stress" \
+  --duration=5 \
+  --concurrency=10
+
+sounding stress /api/events \
+  --method=POST \
+  --json '{"name":"invoice.created"}'
+
+sounding stress /api/upload-token \
+  --put \
+  --body raw-payload
+```
+
+CLI reference:
+
+```txt
+sounding stress <target> [options]
+
+Targets:
+  /api/health                         Lift the local Sails app and stress a route.
+  https://example.com/api/health      Stress an external URL directly.
+  /api/health --base-url=<url>        Stress a path on a chosen host.
+
+Options:
+  --duration <seconds>                Duration in seconds. Defaults to 10.
+  --concurrency <requests>            Concurrent requests. Defaults to 1.
+  --connections <requests>            Alias for --concurrency.
+  --method <method>                   HTTP method.
+  --get, --head, --options            Method shorthands.
+  --post, --put, --patch, --delete    Method shorthands. Body-capable flags accept JSON.
+  --header "Name: value"              Add a request header. May be repeated.
+  --json '<payload>'                  Send a JSON body.
+  --body <payload>                    Send a raw body.
+  --base-url <url>                    Resolve a relative target against this host.
+  --world <scenario>                  Load a Sounding world before stressing a local app.
+  --as <actor>                        Use a world actor alias for local Sails auth/session.
+```
+
 ## Trial API
 
 Use `test.stress()` when the trial is specifically about real HTTP load:
@@ -71,6 +143,35 @@ test.stress(
 )
 ```
 
+`test.stress()` behaves like `test()` with `{ transport: 'http' }` as the
+default, then adds the `stress` helper to the trial context.
+
+You can also use the `stress` helper from any trial that opts into HTTP:
+
+```js
+test(
+  'health endpoint has no failed requests',
+  { transport: 'http' },
+  async ({ stress, expect }) => {
+    const result = await stress.get('/api/health').concurrently(25).for(10).seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+  }
+)
+```
+
+The request API is chainable and promise-like. Awaiting a chain runs it:
+
+```js
+const result = await stress.get('/api/health')
+```
+
+Use `.run()` when you want the execution point to be explicit:
+
+```js
+const result = await stress.get('/api/health').concurrently(10).run()
+```
+
 POST JSON payloads and headers:
 
 ```js
@@ -82,6 +183,45 @@ const result = await stress
   .for(5)
   .seconds()
 ```
+
+Supported methods:
+
+```js
+stress.request(method, target, payload)
+stress.get(target)
+stress.head(target)
+stress.options(target, payload)
+stress.post(target, payload)
+stress.put(target, payload)
+stress.patch(target, payload)
+stress.delete(target, payload)
+```
+
+Chain helpers:
+
+```js
+stress.get('/api/health')
+  .baseUrl('https://staging.example.com')
+  .as('owner')
+  .header('x-test-lane', 'stress')
+  .headers({ accept: 'application/json' })
+  .json({ plan: 'pro' })
+  .body('raw body')
+  .concurrently(25)
+  .for(10)
+  .seconds()
+```
+
+`as(actor)` accepts:
+
+- an actor object
+- a world actor alias, such as `owner`
+- an actor object with `headers` or `sounding.headers`
+- an actor object whose identity can be converted into the configured auth session
+
+For local Sails runs, actor aliases can create a real Sails session cookie before
+the load run starts. Remote targets should use `.headers()` or CLI `--header`
+instead.
 
 ## Metrics
 
@@ -97,10 +237,15 @@ result.requests.duration().med()
 result.requests.duration().p90()
 result.requests.duration().p95()
 result.requests.duration().max()
+result.requests.ttfb().duration().p95()
 result.requests.download().data().count()
 result.requests.download().data().rate()
+result.requests.upload().data().count()
+result.requests.upload().data().rate()
 result.testRun.concurrency()
 result.testRun.duration()
+result.toJSON()
+result.raw
 ```
 
 ## Engine
@@ -108,3 +253,14 @@ result.testRun.duration()
 The first engine is `autocannon`, owned by this plugin so core Sounding stays light.
 Sounding owns the public API and result model, so future engines can be added without
 forcing test code to change.
+
+## Events
+
+Sounding's plugin host exposes an event bus for lifecycle and observability.
+The stress plugin emits:
+
+- `stress:start` with the normalized run options
+- `stress:done` with the normalized result
+
+Those events are useful for logs, dashboards, custom reporters, or future
+streaming output. They are not required for normal usage.

--- a/plugins/stress/index.js
+++ b/plugins/stress/index.js
@@ -1,0 +1,44 @@
+const { createStressClient } = require('./lib/create-stress-client')
+const { runStressCommand } = require('./lib/command')
+const { createStressResult, formatStressResult } = require('./lib/result')
+
+module.exports = function stressPlugin(api) {
+  return {
+    name: 'stress',
+
+    commands: {
+      stress(argv, context) {
+        return runStressCommand(argv, {
+          ...context,
+          api,
+        })
+      },
+    },
+
+    testMethods: {
+      stress: {
+        mode: 'stress',
+        options: {
+          transport: 'http',
+        },
+      },
+    },
+
+    trial({ sails, config, world, appPath, events }) {
+      return {
+        stress: createStressClient({
+          api,
+          sails,
+          getConfig: () => config,
+          world,
+          appPath,
+          events,
+        }),
+      }
+    },
+  }
+}
+
+module.exports.createStressClient = createStressClient
+module.exports.createStressResult = createStressResult
+module.exports.formatStressResult = formatStressResult

--- a/plugins/stress/lib/command.js
+++ b/plugins/stress/lib/command.js
@@ -1,0 +1,381 @@
+const { createStressClient } = require('./create-stress-client')
+const { formatStressResult } = require('./result')
+
+const METHOD_FLAGS = {
+  '--get': 'GET',
+  '--head': 'HEAD',
+  '--options': 'OPTIONS',
+  '--post': 'POST',
+  '--put': 'PUT',
+  '--patch': 'PATCH',
+  '--delete': 'DELETE',
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isAbsoluteUrl(value) {
+  return /^https?:\/\//i.test(value)
+}
+
+/**
+ * @param {string} value
+ * @returns {any}
+ */
+function parseJson(value) {
+  return JSON.parse(value)
+}
+
+/**
+ * @param {string} value
+ * @returns {[string, string]}
+ */
+function parseHeader(value) {
+  const colon = value.indexOf(':')
+
+  if (colon !== -1) {
+    return [value.slice(0, colon).trim(), value.slice(colon + 1).trim()]
+  }
+
+  const equals = value.indexOf('=')
+  if (equals !== -1) {
+    return [value.slice(0, equals).trim(), value.slice(equals + 1).trim()]
+  }
+
+  return [value.trim(), '']
+}
+
+/**
+ * @param {string[]} argv
+ */
+function parseStressArgs(argv) {
+  const args = [...argv]
+  const options = {
+    method: 'GET',
+    headers: {},
+  }
+
+  function readValue(flag) {
+    const value = args.shift()
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Sounding stress option \`${flag}\` requires a value.`)
+    }
+
+    return value
+  }
+
+  while (args.length > 0) {
+    const arg = args.shift()
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true
+      continue
+    }
+
+    if (arg === '--duration') {
+      options.duration = Number(readValue(arg))
+      continue
+    }
+
+    if (arg.startsWith('--duration=')) {
+      options.duration = Number(arg.slice('--duration='.length))
+      continue
+    }
+
+    if (arg === '--concurrency' || arg === '--connections') {
+      options.concurrency = Number(readValue(arg))
+      continue
+    }
+
+    if (arg.startsWith('--concurrency=')) {
+      options.concurrency = Number(arg.slice('--concurrency='.length))
+      continue
+    }
+
+    if (arg.startsWith('--connections=')) {
+      options.concurrency = Number(arg.slice('--connections='.length))
+      continue
+    }
+
+    if (arg === '--method') {
+      options.method = readValue(arg).toUpperCase()
+      continue
+    }
+
+    if (arg.startsWith('--method=')) {
+      options.method = arg.slice('--method='.length).toUpperCase()
+      continue
+    }
+
+    if (arg === '--header') {
+      const [name, value] = parseHeader(readValue(arg))
+      options.headers[name] = value
+      continue
+    }
+
+    if (arg.startsWith('--header=')) {
+      const [name, value] = parseHeader(arg.slice('--header='.length))
+      options.headers[name] = value
+      continue
+    }
+
+    if (arg === '--json') {
+      options.payload = parseJson(readValue(arg))
+      options.headers['content-type'] = 'application/json'
+      continue
+    }
+
+    if (arg.startsWith('--json=')) {
+      options.payload = parseJson(arg.slice('--json='.length))
+      options.headers['content-type'] = 'application/json'
+      continue
+    }
+
+    if (arg === '--body') {
+      options.payload = readValue(arg)
+      continue
+    }
+
+    if (arg.startsWith('--body=')) {
+      options.payload = arg.slice('--body='.length)
+      continue
+    }
+
+    if (arg === '--base-url') {
+      options.baseUrl = readValue(arg)
+      continue
+    }
+
+    if (arg.startsWith('--base-url=')) {
+      options.baseUrl = arg.slice('--base-url='.length)
+      continue
+    }
+
+    if (arg === '--world') {
+      options.world = readValue(arg)
+      continue
+    }
+
+    if (arg.startsWith('--world=')) {
+      options.world = arg.slice('--world='.length)
+      continue
+    }
+
+    if (arg === '--as') {
+      options.actor = readValue(arg)
+      continue
+    }
+
+    if (arg.startsWith('--as=')) {
+      options.actor = arg.slice('--as='.length)
+      continue
+    }
+
+    const methodFlag = Object.keys(METHOD_FLAGS).find(
+      (flag) => arg === flag || arg.startsWith(`${flag}=`)
+    )
+
+    if (methodFlag) {
+      options.method = METHOD_FLAGS[methodFlag]
+
+      if (arg.startsWith(`${methodFlag}=`)) {
+        options.payload = parseJson(arg.slice(methodFlag.length + 1))
+        options.headers['content-type'] = 'application/json'
+      }
+
+      continue
+    }
+
+    if (arg.startsWith('--')) {
+      throw new Error(`Unknown Sounding stress option: ${arg}`)
+    }
+
+    if (!options.target) {
+      options.target = arg
+      continue
+    }
+
+    throw new Error(`Unexpected Sounding stress argument: ${arg}`)
+  }
+
+  return options
+}
+
+function printStressHelp(stdout) {
+  stdout.write(`Sounding stress
+
+Usage:
+  sounding stress <target> [options]
+
+Targets:
+  /api/health                         Stress a local Sails app route.
+  https://example.com/api/health      Stress an external URL directly.
+  /api/health --base-url=<url>        Stress a Sails-shaped path on a chosen host.
+
+Options:
+  --duration <seconds>                Duration in seconds. Defaults to 10.
+  --concurrency <requests>            Concurrent requests. Defaults to 1.
+  --method <method>                   HTTP method.
+  --get, --post, --put, --patch       Method shorthands. Body-capable flags accept JSON.
+  --delete, --head, --options         More method shorthands.
+  --header "Name: value"              Add a request header. May be repeated.
+  --json '<payload>'                  Send a JSON body.
+  --body <payload>                    Send a raw body.
+  --world <scenario>                  Load a Sounding world before stressing a local app.
+  --as <actor>                        Use a world actor alias for local Sails auth/session.
+`)
+}
+
+/**
+ * @param {any} value
+ * @param {string} name
+ * @param {any} api
+ */
+function assertPositiveInteger(value, name, api) {
+  if (value === undefined) {
+    return undefined
+  }
+
+  const number = Number(value)
+
+  if (!Number.isInteger(number) || number < 1) {
+    throw api.createSoundingError({
+      code: 'E_SOUNDING_STRESS_OPTION_INVALID',
+      name: 'SoundingStressError',
+      message: `Sounding stress option \`${name}\` must be a positive integer.`,
+      details: {
+        option: name,
+        value,
+      },
+    })
+  }
+
+  return number
+}
+
+/**
+ * @param {any} options
+ * @returns {boolean}
+ */
+function needsLocalSailsApp(options) {
+  if (!options.target) {
+    return false
+  }
+
+  if (options.world || options.actor) {
+    return true
+  }
+
+  return !isAbsoluteUrl(options.target) && !options.baseUrl
+}
+
+/**
+ * @param {ReturnType<typeof createStressClient>} stress
+ * @param {any} options
+ */
+function createStressRun(stress, options) {
+  let chain = stress.request(options.method, options.target, options.payload)
+
+  if (options.baseUrl) {
+    chain = chain.baseUrl(options.baseUrl)
+  }
+
+  if (Object.keys(options.headers || {}).length > 0) {
+    chain = chain.headers(options.headers)
+  }
+
+  if (options.actor) {
+    chain = chain.as(options.actor)
+  }
+
+  if (options.concurrency) {
+    chain = chain.concurrently(options.concurrency)
+  }
+
+  if (options.duration) {
+    return chain.for(options.duration).seconds()
+  }
+
+  return chain.run()
+}
+
+/**
+ * @param {string[]} argv
+ * @param {{ api: any, appPath: string, stdout: NodeJS.WriteStream }} context
+ */
+async function runStressCommand(argv, context) {
+  const options = parseStressArgs(argv)
+  const api = context.api
+
+  if (options.help) {
+    printStressHelp(context.stdout)
+    return {
+      status: 0,
+    }
+  }
+
+  if (!options.target) {
+    throw new Error('Sounding stress requires a target URL or path.')
+  }
+
+  options.duration = assertPositiveInteger(options.duration, 'duration', api)
+  options.concurrency = assertPositiveInteger(options.concurrency, 'concurrency', api)
+
+  if (options.baseUrl && (options.world || options.actor)) {
+    throw api.createSoundingError({
+      code: 'E_SOUNDING_STRESS_REMOTE_ACTOR_UNSUPPORTED',
+      name: 'SoundingStressError',
+      message:
+        'Sounding stress `--world` and `--as` need a local lifted Sails app. Use headers for remote or --base-url targets.',
+    })
+  }
+
+  if (!needsLocalSailsApp(options)) {
+    const stress = createStressClient({
+      api,
+      events: api.events,
+    })
+    const result = await createStressRun(stress, options)
+    context.stdout.write(`${formatStressResult(result)}\n`)
+    return {
+      status: result.requests.failed().count() > 0 ? 1 : 0,
+    }
+  }
+
+  const appManager = api.createAppManager({
+    appPath: context.appPath,
+  })
+
+  try {
+    const runtime = await appManager.runtime({ app: 'lift' })
+    const booted = await runtime.boot({ mode: 'stress' })
+
+    if (options.world) {
+      await runtime.world.use(options.world)
+    }
+
+    const stress = createStressClient({
+      api,
+      sails: booted.sails,
+      getConfig: () => runtime.config,
+      world: runtime.world,
+      appPath: context.appPath,
+      events: api.events,
+    })
+    const result = await createStressRun(stress, options)
+    context.stdout.write(`${formatStressResult(result)}\n`)
+
+    return {
+      status: result.requests.failed().count() > 0 ? 1 : 0,
+    }
+  } finally {
+    await appManager.lower()
+  }
+}
+
+module.exports = {
+  parseStressArgs,
+  runStressCommand,
+}

--- a/plugins/stress/lib/create-stress-client.js
+++ b/plugins/stress/lib/create-stress-client.js
@@ -1,0 +1,444 @@
+const { createStressResult } = require('./result')
+
+const DEFAULT_DURATION = 10
+const DEFAULT_CONCURRENCY = 1
+const BODY_METHODS = ['POST', 'PUT', 'PATCH', 'OPTIONS']
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isAbsoluteUrl(value) {
+  return /^https?:\/\//i.test(value)
+}
+
+/**
+ * @param {any} value
+ * @returns {boolean}
+ */
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @param {any} value
+ * @returns {Record<string, any>}
+ */
+function toHeaderObject(value) {
+  if (!value) {
+    return {}
+  }
+
+  if (typeof Headers !== 'undefined' && value instanceof Headers) {
+    return Object.fromEntries(value.entries())
+  }
+
+  if (Array.isArray(value)) {
+    return Object.fromEntries(value)
+  }
+
+  return { ...value }
+}
+
+/**
+ * @param {any} value
+ * @param {string} name
+ * @param {any} api
+ * @returns {number}
+ */
+function assertPositiveInteger(value, name, api) {
+  const number = Number(value)
+
+  if (!Number.isInteger(number) || number < 1) {
+    throw api.createSoundingError({
+      code: 'E_SOUNDING_STRESS_OPTION_INVALID',
+      name: 'SoundingStressError',
+      message: `Sounding stress option \`${name}\` must be a positive integer.`,
+      details: {
+        option: name,
+        value,
+      },
+    })
+  }
+
+  return number
+}
+
+/**
+ * @param {any} api
+ * @returns {(options: Record<string, any>) => Promise<any>}
+ */
+function createDefaultEngineRunner(api) {
+  return async function runAutocannon(options) {
+    let autocannon
+
+    try {
+      autocannon = require('autocannon')
+    } catch (error) {
+      throw api.createSoundingError({
+        code: 'E_SOUNDING_STRESS_ENGINE_MISSING',
+        name: 'SoundingStressError',
+        message:
+          'Sounding stress testing needs `autocannon`. Install `sounding-plugin-stress`, which provides the stress engine.',
+        details: {
+          dependency: 'autocannon',
+          plugin: 'sounding-plugin-stress',
+          install: 'npm install -D sounding-plugin-stress',
+        },
+        cause: error,
+      })
+    }
+
+    return autocannon(options)
+  }
+}
+
+/**
+ * @param {{
+ *   payload: any,
+ *   headers: Record<string, any>,
+ *   method: string,
+ * }} input
+ */
+function normalizeBody({ payload, headers, method }) {
+  if (payload === undefined || !BODY_METHODS.includes(method)) {
+    return {
+      body: undefined,
+      headers,
+      bodyBytes: 0,
+    }
+  }
+
+  if (typeof payload === 'string' || Buffer.isBuffer(payload)) {
+    return {
+      body: payload,
+      headers,
+      bodyBytes: Buffer.byteLength(payload),
+    }
+  }
+
+  if (isPlainObject(payload) || Array.isArray(payload)) {
+    const nextHeaders = { ...headers }
+    const hasContentType = Object.keys(nextHeaders).some(
+      (header) => header.toLowerCase() === 'content-type'
+    )
+
+    if (!hasContentType) {
+      nextHeaders['content-type'] = 'application/json'
+    }
+
+    const body = JSON.stringify(payload)
+    return {
+      body,
+      headers: nextHeaders,
+      bodyBytes: Buffer.byteLength(body),
+    }
+  }
+
+  return {
+    body: payload,
+    headers,
+    bodyBytes: 0,
+  }
+}
+
+/**
+ * @param {{
+ *   api: any,
+ *   actor: any,
+ *   world?: any,
+ *   sails?: any,
+ *   getConfig?: () => any,
+ * }} input
+ */
+function resolveActor({ api, actor, world, sails, getConfig }) {
+  if (!actor) {
+    return null
+  }
+
+  if (typeof actor === 'object') {
+    return actor
+  }
+
+  const resolved = api.resolveWorldActor({
+    actor,
+    world,
+    sails,
+    getConfig,
+  })
+
+  if (!resolved) {
+    throw api.createRequestActorUnresolvedError({
+      actor,
+      world,
+      sails,
+      getConfig,
+    })
+  }
+
+  return resolved
+}
+
+/**
+ * @param {{
+ *   api: any,
+ *   actor: any,
+ *   headers: Record<string, any>,
+ *   sails?: any,
+ *   getConfig?: () => any,
+ * }} input
+ */
+async function resolveActorRequestHeaders({ api, actor, headers, sails, getConfig }) {
+  if (!actor) {
+    return headers
+  }
+
+  const auth = api.resolveAuthConfig({ sails, getConfig })
+  const actorHeaders = toHeaderObject(api.resolveActorHeaders(actor))
+  const actorSession = api.resolveActorSession(actor, auth)
+  const nextHeaders = {
+    ...actorHeaders,
+    ...headers,
+  }
+  const hasCookie = Object.keys(nextHeaders).some((header) => header.toLowerCase() === 'cookie')
+
+  if (!hasCookie && Object.keys(actorSession || {}).length > 0) {
+    const cookie = await api.createSessionCookie(sails, actorSession)
+
+    if (cookie) {
+      nextHeaders.cookie = cookie
+    }
+  }
+
+  return nextHeaders
+}
+
+/**
+ * @param {{
+ *   api: any,
+ *   state: Record<string, any>,
+ *   sails?: any,
+ *   getConfig?: () => any,
+ *   world?: any,
+ * }} input
+ */
+async function buildEngineOptions({ api, state, sails, getConfig, world }) {
+  const target = state.target
+  const url = isAbsoluteUrl(target)
+    ? target
+    : api.resolveUrl({
+        sails,
+        getConfig,
+        target,
+        baseUrl: state.baseUrl,
+      })
+  const actor = resolveActor({
+    api,
+    actor: state.actor,
+    world,
+    sails,
+    getConfig,
+  })
+  const actorHeaders = await resolveActorRequestHeaders({
+    api,
+    actor,
+    headers: state.headers,
+    sails,
+    getConfig,
+  })
+  const body = normalizeBody({
+    payload: state.payload,
+    headers: actorHeaders,
+    method: state.method,
+  })
+
+  return {
+    url,
+    target,
+    method: state.method,
+    concurrency: state.concurrency,
+    duration: state.duration,
+    bodyBytes: body.bodyBytes,
+    engine: {
+      url,
+      method: state.method,
+      connections: state.concurrency,
+      duration: state.duration,
+      headers: body.headers,
+      ...(body.body !== undefined ? { body: body.body } : {}),
+    },
+  }
+}
+
+/**
+ * @param {{
+ *   api: any,
+ *   state: Record<string, any>,
+ *   runEngine: (options: Record<string, any>) => Promise<any>,
+ *   sails?: any,
+ *   getConfig?: () => any,
+ *   world?: any,
+ *   events?: any,
+ * }} input
+ */
+function createStressChain({ api, state, runEngine, sails, getConfig, world, events }) {
+  const clone = (patch) =>
+    createStressChain({
+      api,
+      state: {
+        ...state,
+        ...patch,
+      },
+      runEngine,
+      sails,
+      getConfig,
+      world,
+      events,
+    })
+
+  async function run() {
+    const options = await buildEngineOptions({
+      api,
+      state,
+      sails,
+      getConfig,
+      world,
+    })
+
+    events?.emit?.('stress:start', options)
+    const raw = (await runEngine(options.engine)) || {}
+    raw.bodyBytes = options.bodyBytes * (raw?.requests?.total || 0)
+    const result = createStressResult({
+      raw,
+      options,
+    })
+    events?.emit?.('stress:done', result)
+    return result
+  }
+
+  return {
+    as(actor) {
+      return clone({ actor })
+    },
+    baseUrl(baseUrl) {
+      return clone({ baseUrl })
+    },
+    headers(headers = {}) {
+      return clone({
+        headers: {
+          ...state.headers,
+          ...toHeaderObject(headers),
+        },
+      })
+    },
+    header(name, value) {
+      return this.headers({ [name]: value })
+    },
+    json(payload) {
+      return clone({
+        payload,
+        headers: {
+          ...state.headers,
+          'content-type': 'application/json',
+        },
+      })
+    },
+    body(payload) {
+      return clone({ payload })
+    },
+    concurrently(concurrency) {
+      return clone({
+        concurrency: assertPositiveInteger(concurrency, 'concurrency', api),
+      })
+    },
+    for(duration) {
+      const seconds = assertPositiveInteger(duration, 'duration', api)
+
+      return {
+        seconds: () => clone({ duration: seconds }).run(),
+        second: () => clone({ duration: seconds }).run(),
+      }
+    },
+    run,
+    then(onFulfilled, onRejected) {
+      return run().then(onFulfilled, onRejected)
+    },
+    catch(onRejected) {
+      return run().catch(onRejected)
+    },
+    finally(onFinally) {
+      return run().finally(onFinally)
+    },
+  }
+}
+
+/**
+ * @param {{
+ *   api: any,
+ *   sails?: any,
+ *   getConfig?: () => any,
+ *   world?: any,
+ *   appPath?: string,
+ *   events?: any,
+ *   runEngine?: (options: Record<string, any>) => Promise<any>,
+ * }} input
+ */
+function createStressClient({
+  api,
+  sails,
+  getConfig,
+  world,
+  events,
+  runEngine = createDefaultEngineRunner(api),
+}) {
+  function request(method, target, payload) {
+    return createStressChain({
+      api,
+      sails,
+      getConfig,
+      world,
+      events,
+      runEngine,
+      state: {
+        method,
+        target,
+        payload,
+        headers: {},
+        concurrency: DEFAULT_CONCURRENCY,
+        duration: DEFAULT_DURATION,
+      },
+    })
+  }
+
+  return {
+    request(method, target, payload) {
+      return request(String(method || 'GET').toUpperCase(), target, payload)
+    },
+    get(target) {
+      return request('GET', target)
+    },
+    head(target) {
+      return request('HEAD', target)
+    },
+    options(target, payload) {
+      return request('OPTIONS', target, payload)
+    },
+    post(target, payload) {
+      return request('POST', target, payload)
+    },
+    put(target, payload) {
+      return request('PUT', target, payload)
+    },
+    patch(target, payload) {
+      return request('PATCH', target, payload)
+    },
+    delete(target, payload) {
+      return request('DELETE', target, payload)
+    },
+  }
+}
+
+module.exports = {
+  createStressClient,
+  createDefaultEngineRunner,
+}

--- a/plugins/stress/lib/result.js
+++ b/plugins/stress/lib/result.js
@@ -1,0 +1,193 @@
+/**
+ * @param {any} value
+ * @returns {number}
+ */
+function toNumber(value) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : 0
+}
+
+/**
+ * @param {any} source
+ * @param {string[]} keys
+ * @returns {number}
+ */
+function pickNumber(source, keys) {
+  for (const key of keys) {
+    if (source && source[key] !== undefined) {
+      return toNumber(source[key])
+    }
+  }
+
+  return 0
+}
+
+/**
+ * @param {Record<string, any>} source
+ * @returns {{
+ *   min(): number,
+ *   med(): number,
+ *   median(): number,
+ *   mean(): number,
+ *   average(): number,
+ *   max(): number,
+ *   p90(): number,
+ *   p95(): number,
+ *   p99(): number,
+ * }}
+ */
+function createDurationMetric(source = {}) {
+  return {
+    min: () => pickNumber(source, ['min', 'minimum']),
+    med: () => pickNumber(source, ['p50', 'median', 'med']),
+    median: () => pickNumber(source, ['p50', 'median', 'med']),
+    mean: () => pickNumber(source, ['average', 'mean']),
+    average: () => pickNumber(source, ['average', 'mean']),
+    max: () => pickNumber(source, ['max', 'maximum']),
+    p90: () => pickNumber(source, ['p90']),
+    p95: () => pickNumber(source, ['p95', 'p97_5', 'p97.5']),
+    p99: () => pickNumber(source, ['p99']),
+  }
+}
+
+/**
+ * @param {{ count?: number, rate?: number }} input
+ */
+function createDataMetric(input = {}) {
+  return {
+    count: () => toNumber(input.count),
+    rate: () => toNumber(input.rate),
+  }
+}
+
+/**
+ * @param {{
+ *   raw: any,
+ *   options: {
+ *     concurrency: number,
+ *     duration: number,
+ *     method: string,
+ *     target: string,
+ *     url: string,
+ *   },
+ * }} input
+ */
+function createStressResult({ raw, options }) {
+  const duration = toNumber(raw?.duration || options.duration)
+  const requestCount = pickNumber(raw?.requests, ['total', 'sent', 'count'])
+  const requestRate =
+    pickNumber(raw?.requests, ['average', 'mean', 'rate']) ||
+    (duration > 0 ? requestCount / duration : 0)
+  const failedCount =
+    toNumber(raw?.errors) + toNumber(raw?.timeouts) + toNumber(raw?.non2xx) + toNumber(raw?.mismatches)
+  const failedRate = duration > 0 ? failedCount / duration : 0
+  const downloadBytes = pickNumber(raw?.throughput, ['total', 'count'])
+  const downloadRate = pickNumber(raw?.throughput, ['average', 'mean', 'rate'])
+  const uploadBytes = toNumber(raw?.bodyBytes || raw?.uploadBytes)
+  const uploadRate = duration > 0 ? uploadBytes / duration : 0
+
+  return {
+    raw,
+    target: options.target,
+    url: options.url,
+    method: options.method,
+    requests: {
+      count: () => requestCount,
+      rate: () => requestRate,
+      duration: () => createDurationMetric(raw?.latency || {}),
+      ttfb: () => ({
+        duration: () => createDurationMetric(raw?.ttfb || {}),
+      }),
+      failed: () => ({
+        count: () => failedCount,
+        rate: () => failedRate,
+      }),
+      download: () => ({
+        duration: () => createDurationMetric(raw?.download || {}),
+        data: () =>
+          createDataMetric({
+            count: downloadBytes,
+            rate: downloadRate,
+          }),
+      }),
+      upload: () => ({
+        duration: () => createDurationMetric(raw?.upload || {}),
+        data: () =>
+          createDataMetric({
+            count: uploadBytes,
+            rate: uploadRate,
+          }),
+      }),
+    },
+    testRun: {
+      concurrency: () => toNumber(raw?.connections || options.concurrency),
+      duration: () => duration,
+    },
+    toJSON() {
+      return {
+        target: options.target,
+        url: options.url,
+        method: options.method,
+        requests: {
+          count: requestCount,
+          rate: requestRate,
+          failed: {
+            count: failedCount,
+            rate: failedRate,
+          },
+          duration: {
+            min: this.requests.duration().min(),
+            med: this.requests.duration().med(),
+            max: this.requests.duration().max(),
+            p90: this.requests.duration().p90(),
+            p95: this.requests.duration().p95(),
+          },
+          download: {
+            bytes: downloadBytes,
+            rate: downloadRate,
+          },
+          upload: {
+            bytes: uploadBytes,
+            rate: uploadRate,
+          },
+        },
+        testRun: {
+          concurrency: this.testRun.concurrency(),
+          duration: this.testRun.duration(),
+        },
+      }
+    },
+  }
+}
+
+/**
+ * @param {number} value
+ * @param {string} unit
+ * @returns {string}
+ */
+function formatNumber(value, unit = '') {
+  const normalized = Number.isInteger(value) ? String(value) : value.toFixed(2)
+  return `${normalized}${unit}`
+}
+
+/**
+ * @param {ReturnType<typeof createStressResult>} result
+ * @returns {string}
+ */
+function formatStressResult(result) {
+  const requests = result.requests
+  const duration = requests.duration()
+  const failed = requests.failed()
+
+  return [
+    `STRESS ${result.method} ${result.url}`,
+    `Requests: ${formatNumber(requests.count())} total, ${formatNumber(requests.rate())}/s, ${formatNumber(failed.count())} failed`,
+    `Latency: med ${formatNumber(duration.med(), 'ms')}, p95 ${formatNumber(duration.p95(), 'ms')}, max ${formatNumber(duration.max(), 'ms')}`,
+    `Run: ${formatNumber(result.testRun.duration(), 's')}, concurrency ${formatNumber(result.testRun.concurrency())}`,
+  ].join('\n')
+}
+
+module.exports = {
+  createStressResult,
+  formatStressResult,
+}

--- a/plugins/stress/package.json
+++ b/plugins/stress/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sounding-plugin-stress",
+  "version": "0.1.0",
+  "description": "Stress testing plugin for Sounding.",
+  "main": "index.js",
+  "license": "MIT",
+  "peerDependencies": {
+    "sounding": "^0.1.0"
+  },
+  "dependencies": {
+    "autocannon": "^8.0.0"
+  }
+}

--- a/test/plugin-manager.test.js
+++ b/test/plugin-manager.test.js
@@ -1,0 +1,113 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const {
+  createPluginManager,
+  discoverDependencyPluginNames,
+  discoverPluginSpecs,
+} = require('../lib/create-plugin-manager')
+
+function createTempApp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'sounding-plugins-'))
+}
+
+function createChildEnv() {
+  const env = { ...process.env }
+  delete env.NODE_TEST_CONTEXT
+  return env
+}
+
+test('discoverDependencyPluginNames finds Sounding plugins in package dependencies', () => {
+  assert.deepEqual(
+    discoverDependencyPluginNames({
+      dependencies: {
+        'sounding-plugin-stress': '^0.1.0',
+        express: '^5.0.0',
+      },
+      devDependencies: {
+        '@sounding/plugin-mutation': '^0.1.0',
+        '@types/node': '^25.0.0',
+      },
+    }),
+    ['@sounding/plugin-mutation', 'sounding-plugin-stress']
+  )
+})
+
+test('discoverPluginSpecs finds local monorepo plugin packages', () => {
+  const appPath = createTempApp()
+  const pluginPath = path.join(appPath, 'plugins', 'stress')
+
+  fs.mkdirSync(pluginPath, { recursive: true })
+  fs.writeFileSync(
+    path.join(pluginPath, 'package.json'),
+    JSON.stringify({
+      name: 'sounding-plugin-stress',
+      main: 'index.js',
+    })
+  )
+
+  assert.deepEqual(discoverPluginSpecs(appPath), [
+    {
+      name: 'sounding-plugin-stress',
+      localPath: path.join(pluginPath, 'index.js'),
+    },
+  ])
+})
+
+test('createPluginManager exposes plugin commands, test methods, events, and trial context', async () => {
+  const events = []
+  const plugin = {
+    name: 'fixture',
+    commands: {
+      fixture: () => ({ status: 0 }),
+    },
+    testMethods: {
+      fixture: {
+        mode: 'fixture',
+      },
+    },
+    trial({ title, events: eventBus }) {
+      eventBus.emit('fixture:trial', title)
+      return {
+        fixtureHelper: title,
+      }
+    },
+  }
+  const manager = createPluginManager({
+    plugins: [plugin],
+  })
+
+  manager.events.on('trial:plugin:before', (entry) => events.push(['before', entry.plugin.name]))
+  manager.events.on('trial:plugin:after', (entry) => events.push(['after', entry.keys]))
+  manager.events.on('fixture:trial', (title) => events.push(['fixture', title]))
+
+  assert.equal(manager.command('fixture').plugin, plugin)
+  assert.deepEqual(manager.testMethods()[0].name, 'fixture')
+  assert.deepEqual(await manager.trialContext({ title: 'runs fixture plugin' }), {
+    fixtureHelper: 'runs fixture plugin',
+  })
+  assert.deepEqual(events, [
+    ['before', 'fixture'],
+    ['fixture', 'runs fixture plugin'],
+    ['after', ['fixtureHelper']],
+  ])
+})
+
+test('bin/sounding.js gives a setup hint when the stress plugin is missing', () => {
+  const appPath = createTempApp()
+  fs.writeFileSync(path.join(appPath, 'package.json'), JSON.stringify({ name: 'empty-app' }))
+
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, '..', 'bin', 'sounding.js'), 'stress', '--app', appPath, '--help'],
+    { cwd: appPath, env: createChildEnv() }
+  )
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr.toString(), /sounding-plugin-stress/)
+  assert.match(result.stderr.toString(), /npm install -D sounding-plugin-stress/)
+})

--- a/test/stress-plugin.test.js
+++ b/test/stress-plugin.test.js
@@ -1,0 +1,180 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { createPluginApi } = require('../lib/create-plugin-manager')
+const { createStressClient } = require('../plugins/stress')
+const { parseStressArgs } = require('../plugins/stress/lib/command')
+
+test('stress client maps Sounding stress options to the load engine and normalizes results', async () => {
+  const calls = []
+  const api = createPluginApi()
+  const stress = createStressClient({
+    api,
+    runEngine: async (options) => {
+      calls.push(options)
+      return {
+        duration: 5,
+        connections: 2,
+        requests: {
+          total: 20,
+          average: 4,
+        },
+        latency: {
+          min: 2,
+          p50: 8,
+          p95: 16,
+          max: 30,
+        },
+        throughput: {
+          total: 400,
+          average: 80,
+        },
+        errors: 0,
+        timeouts: 0,
+        non2xx: 0,
+      }
+    },
+  })
+
+  const result = await stress
+    .post('https://example.com/api/invoices', { plan: 'pro' })
+    .headers({ authorization: 'Bearer test-token' })
+    .concurrently(2)
+    .for(5)
+    .seconds()
+
+  assert.deepEqual(calls, [
+    {
+      url: 'https://example.com/api/invoices',
+      method: 'POST',
+      connections: 2,
+      duration: 5,
+      headers: {
+        authorization: 'Bearer test-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ plan: 'pro' }),
+    },
+  ])
+  assert.equal(result.requests.count(), 20)
+  assert.equal(result.requests.rate(), 4)
+  assert.equal(result.requests.failed().count(), 0)
+  assert.equal(result.requests.duration().med(), 8)
+  assert.equal(result.requests.duration().p95(), 16)
+  assert.equal(result.requests.download().data().count(), 400)
+  assert.equal(result.testRun.concurrency(), 2)
+  assert.equal(result.testRun.duration(), 5)
+})
+
+test('stress client can create a real Sails session cookie for world actors', async () => {
+  const calls = []
+  const sessionWrites = []
+  const api = createPluginApi()
+  const sails = {
+    config: {
+      port: 1337,
+      sounding: {},
+    },
+    session: {
+      generateNewSidCookie() {
+        return 'sails.sid=signed-session'
+      },
+      parseSessionIdFromCookie(cookie) {
+        assert.equal(cookie, 'sails.sid=signed-session')
+        return 'session-id'
+      },
+      set(sid, value, done) {
+        sessionWrites.push([sid, value])
+        done()
+      },
+    },
+  }
+  const world = {
+    current: {
+      users: {
+        owner: {
+          id: 7,
+          teamId: 3,
+          headers: {
+            'x-actor': 'owner',
+          },
+        },
+      },
+    },
+  }
+  const stress = createStressClient({
+    api,
+    sails,
+    getConfig: () => ({}),
+    world,
+    runEngine: async (options) => {
+      calls.push(options)
+      return {
+        duration: 1,
+        connections: 1,
+        requests: {
+          total: 1,
+          average: 1,
+        },
+        latency: {
+          p50: 1,
+          p95: 1,
+          max: 1,
+        },
+      }
+    },
+  })
+
+  await stress.get('/dashboard').as('owner').run()
+
+  assert.equal(calls[0].url, 'http://127.0.0.1:1337/dashboard')
+  assert.deepEqual(calls[0].headers, {
+    'x-actor': 'owner',
+    cookie: 'sails.sid=signed-session',
+  })
+  assert.deepEqual(sessionWrites, [
+    [
+      'session-id',
+      {
+        cookie: {
+          httpOnly: true,
+          path: '/',
+        },
+        userId: 7,
+        teamId: 3,
+      },
+    ],
+  ])
+})
+
+test('parseStressArgs supports external URLs, local worlds, method flags, and headers', () => {
+  assert.deepEqual(
+    parseStressArgs([
+      '/api/billing/summary',
+      '--world=subscribed-creator',
+      '--as',
+      'owner',
+      '--duration=10',
+      '--concurrency',
+      '20',
+      '--post={"plan":"pro"}',
+      '--header',
+      'x-test-lane: stress',
+    ]),
+    {
+      target: '/api/billing/summary',
+      world: 'subscribed-creator',
+      actor: 'owner',
+      duration: 10,
+      concurrency: 20,
+      method: 'POST',
+      payload: {
+        plan: 'pro',
+      },
+      headers: {
+        'content-type': 'application/json',
+        'x-test-lane': 'stress',
+      },
+    }
+  )
+})

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -70,6 +70,79 @@ test('test() boots the runtime and passes a Sails-native helper context', async 
   ])
 })
 
+test('test.it() mirrors the Sounding trial family', async () => {
+  const calls = []
+  const baseRegistrations = []
+  const onlyRegistrations = []
+  const skipped = []
+  const todos = []
+  const runtime = {
+    helpers: {},
+    world: {
+      use: async () => ({}),
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      get: async () => ({ status: 200 }),
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.only = (title, options, handler) => {
+    onlyRegistrations.push({ title, options, handler })
+    return { title, only: true }
+  }
+  baseTest.skip = (...args) => skipped.push(args)
+  baseTest.todo = (...args) => todos.push(args)
+
+  const soundingTest = createTestApi({
+    baseTest,
+    runtime,
+  })
+
+  soundingTest.it('health endpoint is available', async ({ expect }) => {
+    expect(true).toBe(true)
+  })
+  soundingTest.it.only('focused health endpoint is available', async ({ expect }) => {
+    expect(true).toBe(true)
+  })
+  soundingTest.it.concurrent('isolated health endpoint is available', async () => {})
+  soundingTest.it.skip('skipped behavior')
+  soundingTest.it.todo('future behavior')
+
+  assert.equal(baseRegistrations.length, 2)
+  assert.equal(onlyRegistrations.length, 1)
+  assert.deepEqual(skipped, [['skipped behavior']])
+  assert.deepEqual(todos, [['future behavior']])
+  assert.equal(typeof soundingTest.it.concurrent, 'function')
+
+  await baseRegistrations[0].handler({})
+  await onlyRegistrations[0].handler({})
+
+  assert.deepEqual(calls, [
+    ['boot', 'trial'],
+    ['lower'],
+    ['boot', 'trial'],
+    ['lower'],
+  ])
+})
+
 test('test() exposes request verb aliases for endpoint-style trials', async () => {
   const calls = []
   const baseRegistrations = []

--- a/test/test-api.test.js
+++ b/test/test-api.test.js
@@ -215,6 +215,103 @@ test('test() can override transport for the whole trial', async () => {
   ])
 })
 
+test('plugins can add focused test methods and trial context helpers', async () => {
+  const calls = []
+  const baseRegistrations = []
+  const plugin = {
+    name: 'fixture',
+    testMethods: {
+      stress: {
+        mode: 'stress',
+        options: {
+          transport: 'http',
+        },
+      },
+    },
+    trial({ request, options }) {
+      calls.push(['plugin:trial', request.transport, options.transport])
+      return {
+        stress: {
+          transport: request.transport,
+        },
+      }
+    },
+  }
+  const runtime = {
+    helpers: {},
+    world: {
+      use: async () => ({}),
+    },
+    mailbox: {
+      latest: () => null,
+    },
+    request: {
+      transport: 'virtual',
+      using(transport) {
+        calls.push(['request:using', transport])
+        return {
+          transport,
+          get: async () => ({
+            status: 200,
+            data: { ok: true },
+            header: () => null,
+          }),
+        }
+      },
+    },
+    visit: {
+      transport: 'virtual',
+      using(transport) {
+        calls.push(['visit:using', transport])
+        return {
+          transport,
+        }
+      },
+    },
+    async boot(options) {
+      calls.push(['boot', options.mode])
+      return {
+        sails: {
+          config: {},
+        },
+      }
+    },
+    async lower() {
+      calls.push(['lower'])
+    },
+  }
+
+  const baseTest = (title, options, handler) => {
+    baseRegistrations.push({ title, options, handler })
+    return { title }
+  }
+  baseTest.skip = () => {}
+  baseTest.todo = () => {}
+
+  const soundingTest = createTestApi({
+    baseTest,
+    runtime,
+    plugins: [plugin],
+  })
+
+  assert.equal(typeof soundingTest.stress, 'function')
+
+  soundingTest.stress('billing is steady', async ({ stress, request, expect }) => {
+    assert.equal(stress.transport, 'http')
+    assert.equal(request.transport, 'http')
+    expect(await request.get('/health')).toHaveStatus(200)
+  })
+
+  await baseRegistrations[0].handler({})
+  assert.deepEqual(calls, [
+    ['boot', 'stress'],
+    ['request:using', 'http'],
+    ['visit:using', 'http'],
+    ['plugin:trial', 'http', 'http'],
+    ['lower'],
+  ])
+})
+
 test('test() can auto-load a world before the trial handler', async () => {
   const calls = []
   const baseRegistrations = []

--- a/typecheck/public-api-smoke.js
+++ b/typecheck/public-api-smoke.js
@@ -314,6 +314,17 @@ test(
 
 test('world string options are typed from JSDoc', { world: 'signed-in-user' }, async () => {})
 
+test.it('it alias is typed from JSDoc', async ({ get, expect }) => {
+  const response = await get('/health')
+
+  expect(response).toHaveStatus(200)
+})
+
+test.it.only?.('focused it alias is typed from JSDoc', async () => {})
+test.it.skip('skipped it alias is typed from JSDoc')
+test.it.todo('todo it alias is typed from JSDoc')
+test.it.concurrent('concurrent it alias is typed from JSDoc', { concurrent: true }, async () => {})
+
 test.concurrent('concurrent trial options are typed from JSDoc', { concurrent: true }, async () => {})
 
 test('browser page wrapper context is typed from JSDoc', { browser: 'mobile' }, async ({ visit, page, expect, smoke }) => {


### PR DESCRIPTION
## Summary

- add Sounding plugin discovery for installed `sounding-plugin-*` and `@sounding/plugin-*` packages, plus local monorepo plugins
- add `sounding-plugin-stress` with `sounding stress <target>`, `test.stress()`, Sails world/actor support, and assertion-friendly stress metrics
- add a plugin event bus for lifecycle/progress signals while keeping command/test/context registration explicit
- document plugin behavior and stress testing API in the repo README and plugin README

## Verification

- `npm test`
- `npm run typecheck`
- `git diff --check`
- `node bin/sounding.js stress --app test/fixtures/sails-app /api/health --duration=1 --concurrency=1`

Closes #82
