### PR TITLE
docs: update Sounding skill

### DIFF
--- a/skills/sounding/SKILL.md
+++ b/skills/sounding/SKILL.md
@@ -5,7 +5,8 @@ description: >
   skill when writing or reviewing Sounding-powered trials, configuring `config/sounding.js`,
   working with worlds, request or visit helpers, mailbox assertions, browser-capable flows, or
   auth helpers like `login.as()`, `login.withPassword()`, and
-  `auth.request.withPassword()`.
+  `auth.request.withPassword()`, or working with Sounding plugins such as
+  `sounding-plugin-stress`.
 ---
 
 # Sounding
@@ -17,6 +18,7 @@ Typical triggers:
 - writing or reviewing tests that import `test` from `sounding`
 - configuring `config/sounding.js` or `config/env/test.js` for Sounding
 - using `world`, `request`, `visit`, `mailbox`, `auth`, or `login`
+- using Sounding plugin APIs such as `test.stress()` or `sounding stress`
 - migrating app-specific test glue to Sounding
 - working with auth flows in Sounding-powered trials, including `User` / `userId` and `Creator` / `creatorId` apps
 
@@ -25,12 +27,14 @@ Typical triggers:
 - Prefer Sounding's public surface:
   - `const { test } = require('sounding')`
   - `test('...', async ({ sails, get, visit, auth, login, page, expect }) => {})`
+  - `test.it('...', async ({ get, expect }) => {})` when the suite wants behavior-reading declarations
   - `test('...', { world: 'signed-in-user' }, async ({ request, world }) => {})`
   - `request.as(actor)`
   - `request.as('owner')` or `visit.as('owner')` after a world has loaded actor aliases
   - `auth.request.withPassword(...)`
   - `login.withPassword(...)`
   - `login.as(...)`
+- Keep the `test.*` family coherent. `test.it()` mirrors `test()`, and supports `test.it.only()`, `test.it.skip()`, `test.it.todo()`, and `test.it.concurrent()`. Plugin methods such as `test.stress()` should feel like focused trial lanes, not a second testing grammar.
 - Prefer fluent world builders when setup is record-shaped:
   - inside scenarios: `await create('user').trait('admin').with({ email })`
   - top-level persisted records: `await world.create('user').trait('admin').with({ email })`
@@ -38,6 +42,8 @@ Typical triggers:
 - Treat hook activation as explicit and test-first. By default, Sounding only enables its Sails hook in the environments listed under `sounding.environments`, which starts as `['test']`.
 - Use the app's real auth flow when auth behavior matters. If `/login` or `/magic-link` is the behavior, do not replace it with fake session plumbing.
 - Use `request` for JSON and endpoint behavior, `visit()` for Inertia contracts, and browser trials only when the DOM or navigation is the behavior under test.
+- Prefer named browser projects for mobile/cross-browser coverage: `browser: true` uses the default `desktop` project, `browser: 'mobile'` selects a project by name, and `browser: { project: 'safari' }` leaves room for artifacts or overrides.
+- Browser trials capture failure artifacts by default: current URL plus `screenshot.png` under `.tmp/sounding/artifacts/<trial-name>/<browser-project>/`. Keep trace/video opt-in with `browser: { artifacts: { trace: true, video: true } }`, usually scoped to one flaky or timing-sensitive trial.
 - Prefer Inertia-specific matchers for page contracts:
   - `expect(page).toBeInertiaPage('dashboard/index')`
   - `expect(page).toHaveInertiaProp('auth.user.email', email)`
@@ -50,6 +56,42 @@ Typical triggers:
 - Use `sequence()` in factories for deterministic unique emails, slugs, tokens, invoice numbers, and similar values. Do not keep reintroducing `Date.now()` plus random helpers in test bodies.
 - Use traits for meaningful variants such as `admin`, `subscriber`, `unverified`, or `published`. Use scenarios when the setup is a business situation, not just a record shape.
 - Follow the current factory-builder shape: `world.create('user').trait('admin')` is fluent and persisted; `world.build('user', {}, { traits: ['admin'] })` returns an immediate preview object.
+
+## Plugins and Stress Testing
+
+- Sounding plugins are auto-detected from the app's `package.json`. Do not tell users to register plugins in `config/sounding.js`; that file is for core runtime overrides such as datastore, auth, browser projects, and diagnostics.
+- Plugin package names should match `sounding-plugin-*` or `@sounding/plugin-*`. Local monorepo plugins can live under `plugins/*` when the package name matches.
+- `sounding-plugin-stress` is the stress testing plugin. It owns `autocannon` so Sounding core stays light, while Sounding owns the public API and normalized result model.
+- Use the CLI for quick checks:
+
+```sh
+npx sounding stress /api/health --duration=10 --concurrency=25
+npx sounding stress https://staging.example.com/api/health --duration=10 --concurrency=25
+npx sounding stress /api/billing/summary --world=subscribed-creator --as=owner --duration=10 --concurrency=20
+```
+
+- Use `test.stress()` when load behavior is the trial:
+
+```js
+test.stress(
+  'billing summary stays fast under creator load',
+  { world: 'subscribed-creator' },
+  async ({ stress, expect }) => {
+    const result = await stress
+      .get('/api/billing/summary')
+      .as('owner')
+      .concurrently(20)
+      .for(10)
+      .seconds()
+
+    expect(result.requests.failed().count()).toBe(0)
+    expect(result.requests.duration().p95()).toBeLessThan(250)
+  }
+)
+```
+
+- Stress result metrics are assertion-first: `result.requests.failed().count()`, `result.requests.rate()`, `result.requests.duration().p95()`, and `result.testRun.concurrency()`. `result.raw` is available for engine-specific debugging.
+- For remote targets, use headers or tokens for auth. Worlds and actor aliases are for local lifted Sails app runs where Sounding can create a real Sails session cookie.
 
 ## Factory Guardrails
 
@@ -120,6 +162,10 @@ Read only the page that matches the work:
   `/Users/koo/Gringotts/687/docs.sailscasts.com/docs/sounding/testing-json-apis.md`
 - Browser-capable trials:
   `/Users/koo/Gringotts/687/docs.sailscasts.com/docs/sounding/browser-testing.md`
+- Plugins and plugin authoring:
+  `/Users/koo/Gringotts/687/docs.sailscasts.com/docs/sounding/plugins.md`
+- Stress testing:
+  `/Users/koo/Gringotts/687/docs.sailscasts.com/docs/sounding/stress-testing.md`
 - Runtime and configuration:
   `/Users/koo/Gringotts/687/docs.sailscasts.com/docs/sounding/how-it-works.md`
   `/Users/koo/Gringotts/687/docs.sailscasts.com/docs/sounding/configuration.md`


### PR DESCRIPTION
Closes #97

## Summary
- teach the bundled Sounding skill about test.it() and the coherent test.* declaration family
- document plugin auto-discovery from package.json and avoid config/sounding.js registration guidance
- add guidance for sounding-plugin-stress, sounding stress, autocannon ownership, stress metrics, and local world/actor usage

## Verification
- git diff --check